### PR TITLE
Add observability dashboard and trace tooling

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2,10 +2,15 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import Layout from './components/Layout'
 import AgentProfilePage from './pages/AgentProfilePage'
 import AgentsPage from './pages/AgentsPage'
+import AlertsPage from './pages/AlertsPage'
+import AuditPage from './pages/AuditPage'
+import ErrorsPage from './pages/ErrorsPage'
+import FederationPage from './pages/FederationPage'
 import IntentsPage from './pages/IntentsPage'
 import OverviewPage from './pages/OverviewPage'
 import RegisterPage from './pages/RegisterPage'
 import SettingsPage from './pages/SettingsPage'
+import TraceDetailPage from './pages/TraceDetailPage'
 
 export default function App() {
   return (
@@ -13,10 +18,15 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<OverviewPage />} />
+          <Route path="intents" element={<IntentsPage />} />
+          <Route path="intents/:nonce" element={<TraceDetailPage />} />
+          <Route path="audit" element={<AuditPage />} />
           <Route path="agents" element={<AgentsPage />} />
           <Route path="agents/:beamId" element={<AgentProfilePage />} />
+          <Route path="federation" element={<FederationPage />} />
+          <Route path="errors" element={<ErrorsPage />} />
+          <Route path="alerts" element={<AlertsPage />} />
           <Route path="register" element={<RegisterPage />} />
-          <Route path="intents" element={<IntentsPage />} />
           <Route path="settings" element={<SettingsPage />} />
         </Route>
       </Routes>

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,14 +1,18 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { Activity, Bot, Menu, Moon, Radio, Settings, Sun, UserPlus, X, Zap } from 'lucide-react'
+import { Activity, Bot, Globe2, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
 
 const NAV_ITEMS = [
   { path: '/', label: 'Overview', icon: Activity, exact: true },
-  { path: '/agents', label: 'Agents', icon: Bot },
-  { path: '/register', label: 'Register', icon: UserPlus },
   { path: '/intents', label: 'Intents', icon: Zap },
+  { path: '/audit', label: 'Audit', icon: ScrollText },
+  { path: '/agents', label: 'Agents', icon: Bot },
+  { path: '/federation', label: 'Federation', icon: Globe2 },
+  { path: '/errors', label: 'Errors', icon: TriangleAlert },
+  { path: '/alerts', label: 'Alerts', icon: Shield },
+  { path: '/register', label: 'Register', icon: UserPlus },
   { path: '/settings', label: 'Settings', icon: Settings },
 ]
 

--- a/packages/dashboard/src/components/Observability.tsx
+++ b/packages/dashboard/src/components/Observability.tsx
@@ -1,0 +1,179 @@
+import type { ReactNode } from 'react'
+import { ResponsiveContainer, AreaChart, Area, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts'
+import { cn, formatChartTime } from '../lib/utils'
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string
+  description: string
+  actions?: ReactNode
+}) {
+  return (
+    <section className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">{description}</p>
+      </div>
+      {actions}
+    </section>
+  )
+}
+
+export function MetricCard({
+  label,
+  value,
+  hint,
+  tone = 'default',
+}: {
+  label: string
+  value: string
+  hint?: string
+  tone?: 'default' | 'warning' | 'critical' | 'success'
+}) {
+  return (
+    <div className={cn(
+      'panel',
+      tone === 'warning' && 'border-amber-200 dark:border-amber-500/30',
+      tone === 'critical' && 'border-red-200 dark:border-red-500/30',
+      tone === 'success' && 'border-emerald-200 dark:border-emerald-500/30',
+    )}>
+      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-2 text-3xl font-semibold tracking-tight">{value}</div>
+      {hint ? <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{hint}</div> : null}
+    </div>
+  )
+}
+
+export function StatusPill({
+  label,
+  tone = 'default',
+}: {
+  label: string
+  tone?: 'default' | 'success' | 'warning' | 'critical'
+}) {
+  return (
+    <span className={cn(
+      'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium capitalize',
+      tone === 'success' && 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300',
+      tone === 'warning' && 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300',
+      tone === 'critical' && 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300',
+      tone === 'default' && 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+    )}>
+      {label}
+    </span>
+  )
+}
+
+export function EmptyPanel({ label }: { label: string }) {
+  return (
+    <div className="rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500 dark:border-slate-800 dark:text-slate-400">
+      {label}
+    </div>
+  )
+}
+
+export function TimeSeriesChart<T extends object>({
+  data,
+  series,
+  height = 260,
+}: {
+  data: Array<T & { bucketStart: string }>
+  series: Array<{
+    key: string
+    label: string
+    color: string
+  }>
+  height?: number
+}) {
+  if (data.length === 0) {
+    return <EmptyPanel label="No timeseries data in the selected window." />
+  }
+
+  return (
+    <div style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ left: -16, right: 12, top: 8, bottom: 0 }}>
+          <defs>
+            {series.map((entry) => (
+              <linearGradient key={entry.key} id={`gradient-${entry.key}`} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={entry.color} stopOpacity={0.35} />
+                <stop offset="95%" stopColor={entry.color} stopOpacity={0.02} />
+              </linearGradient>
+            ))}
+          </defs>
+          <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.18)" />
+          <XAxis
+            dataKey="bucketStart"
+            tickFormatter={(value) => formatChartTime(String(value))}
+            minTickGap={24}
+            tickLine={false}
+            axisLine={false}
+            fontSize={12}
+          />
+          <YAxis tickLine={false} axisLine={false} fontSize={12} width={36} />
+          <Tooltip
+            contentStyle={{
+              background: 'rgba(15, 23, 42, 0.96)',
+              borderRadius: 16,
+              border: '1px solid rgba(148, 163, 184, 0.15)',
+              color: '#f8fafc',
+            }}
+            formatter={(value: number, name: string) => [value ?? 0, name]}
+            labelFormatter={(label) => formatChartTime(String(label))}
+          />
+          {series.map((entry) => (
+            <Area
+              key={entry.key}
+              type="monotone"
+              dataKey={entry.key}
+              name={entry.label}
+              stroke={entry.color}
+              fill={`url(#gradient-${entry.key})`}
+              strokeWidth={2}
+              connectNulls
+            />
+          ))}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export function BarList({
+  items,
+  valueKey = 'value',
+  labelKey = 'label',
+}: {
+  items: Array<Record<string, string | number>>
+  valueKey?: string
+  labelKey?: string
+}) {
+  if (items.length === 0) {
+    return <EmptyPanel label="Nothing to visualize yet." />
+  }
+
+  const maxValue = items.reduce((max, item) => Math.max(max, Number(item[valueKey] ?? 0)), 0)
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => {
+        const value = Number(item[valueKey] ?? 0)
+        const width = maxValue > 0 ? (value / maxValue) * 100 : 0
+        return (
+          <div key={`${item[labelKey]}-${value}`} className="space-y-1">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <div className="truncate text-slate-700 dark:text-slate-200">{String(item[labelKey] ?? '')}</div>
+              <div className="text-slate-500 dark:text-slate-400">{value}</div>
+            </div>
+            <div className="h-2 rounded-full bg-slate-100 dark:bg-slate-800">
+              <div className="h-2 rounded-full bg-orange-500" style={{ width: `${width}%` }} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -1,4 +1,7 @@
 export type VerificationTier = 'basic' | 'verified' | 'business' | 'enterprise'
+export type AlertSeverity = 'info' | 'warning' | 'critical'
+export type ExportDataset = 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
+export type ExportFormat = 'json' | 'csv' | 'ndjson'
 
 export interface DirectoryAgent {
   beamId: string
@@ -61,6 +64,253 @@ export interface RecentIntent {
 export interface RecentIntentsResponse {
   intents: RecentIntent[]
   total: number
+}
+
+export interface IntentTraceStage {
+  id: number
+  nonce: string
+  from: string
+  to: string
+  intentType: string
+  stage: string
+  status: string
+  timestamp: string
+  details: Record<string, unknown> | null
+}
+
+export interface AuditEntry {
+  id: number
+  action: string
+  actor: string
+  target: string
+  timestamp: string
+  details: Record<string, unknown> | null
+}
+
+export interface ShieldAuditEntry {
+  id: number
+  nonce: string | null
+  timestamp: string | null
+  senderBeamId: string | null
+  senderTrust: number | null
+  intentType: string | null
+  payloadHash: string | null
+  decision: string | null
+  riskScore: number | null
+  responseSize: number | null
+  anomalyFlags: string[]
+  createdAt: string
+}
+
+export interface AlertItem {
+  id: string
+  severity: AlertSeverity
+  title: string
+  scope: 'network' | 'agent' | 'federation' | 'shield'
+  message: string
+  metric: string
+  value: number
+  threshold: number
+  startedAt: string
+}
+
+export interface OverviewTimelinePoint {
+  bucketStart: string
+  total: number
+  success: number
+  error: number
+  pending: number
+  p95LatencyMs: number | null
+}
+
+export interface ObservabilityOverview {
+  windowHours: number
+  summary: {
+    totalAgents: number
+    liveAgents: number
+    staleAgents: number
+    federatedAgents: number
+    federationPeers: number
+    totalIntents: number
+    successCount: number
+    errorCount: number
+    pendingCount: number
+    avgLatencyMs: number | null
+    p95LatencyMs: number | null
+    successRate: number
+    pendingOlderThan15m: number
+  }
+  timeline: OverviewTimelinePoint[]
+  topIntents: Array<{
+    intentType: string
+    total: number
+    errors: number
+    avgLatencyMs: number | null
+  }>
+  topErrors: Array<{
+    errorCode: string
+    count: number
+    lastSeenAt: string
+  }>
+  alerts: AlertItem[]
+}
+
+export interface IntentTraceResponse {
+  intent: RecentIntent
+  stages: IntentTraceStage[]
+  audit: AuditEntry[]
+  shield: ShieldAuditEntry[]
+}
+
+export interface AuditResponse {
+  entries: AuditEntry[]
+  total: number
+}
+
+export interface AgentHealthResponse {
+  beamId: string
+  windowHours: number
+  summary: {
+    beamId: string
+    displayName: string
+    trustScore: number
+    verificationTier: VerificationTier
+    lastSeen: string
+    sentCount: number
+    receivedCount: number
+    completedCount: number
+    successRate: number
+    errorRate: number
+    avgLatencyMs: number | null
+    p95LatencyMs: number | null
+    uniqueCounterparties: number
+  }
+  timeline: Array<{
+    bucketStart: string
+    sent: number
+    received: number
+    success: number
+    error: number
+    p95LatencyMs: number | null
+  }>
+  counterparties: Array<{
+    beamId: string
+    outbound: number
+    inbound: number
+    errors: number
+  }>
+  intents: Array<{
+    intentType: string
+    total: number
+    errors: number
+    avgLatencyMs: number | null
+  }>
+  errors: Array<{
+    errorCode: string
+    count: number
+    lastSeenAt: string
+  }>
+  usage: {
+    period: string
+    intentCount: number
+    encryptedCount: number
+    directCount: number
+    relayedCount: number
+  }
+  shield: {
+    total: number
+    passed: number
+    held: number
+    rejected: number
+    highRiskCount: number
+  }
+}
+
+export interface FederationHealthResponse {
+  summary: {
+    peerCount: number
+    activePeers: number
+    stalePeers: number
+    cachedAgents: number
+    trustAssertions: number
+    avgPeerTrust: number
+  }
+  peers: Array<{
+    id: number
+    directoryUrl: string
+    trustLevel: number
+    status: string
+    createdAt: string
+    lastSeen: string | null
+    syncedAt: string | null
+    cachedAgents: number
+    lastCachedAt: string | null
+    trustAssertions: number
+    avgEffectiveTrust: number | null
+    lastAssertedAt: string | null
+    stale: boolean
+  }>
+  agents: Array<{
+    beamId: string
+    directoryUrl: string
+    cachedAt: string
+    ttl: number
+    effectiveTrust: number | null
+  }>
+}
+
+export interface ErrorAnalyticsResponse {
+  windowHours: number
+  summary: {
+    totalErrors: number
+    distinctErrorCodes: number
+    timeoutCount: number
+    offlineCount: number
+    deliveryFailedCount: number
+  }
+  timeline: Array<{
+    bucketStart: string
+    total: number
+  }>
+  codes: Array<{
+    errorCode: string
+    count: number
+    lastSeenAt: string
+    avgLatencyMs: number | null
+    affectedSenders: number
+    affectedRecipients: number
+  }>
+  routes: Array<{
+    route: string
+    count: number
+  }>
+}
+
+export interface AlertsResponse {
+  windowHours: number
+  generatedAt: string
+  alerts: AlertItem[]
+  retention: {
+    defaultDays: number
+    datasets: string[]
+  }
+  exports: Array<{
+    dataset: string
+    formats: string[]
+  }>
+}
+
+export interface RetentionResponse {
+  defaultDays: number
+  datasets: string[]
+}
+
+export interface PruneResponse {
+  dataset: string
+  olderThanDays: number
+  deleted: number
+  intents?: number
+  traces?: number
 }
 
 export interface RegisterAgentInput {
@@ -188,12 +438,18 @@ export interface IntentFeedMessage {
   entry?: RecentIntent
 }
 
+export interface ExportDownload {
+  blob: Blob
+  filename: string
+}
+
 const DEFAULT_DIRECTORY_URL = 'https://api.beam.directory'
+const ADMIN_KEY_STORAGE = 'beam-dashboard-admin-key'
 
 export const DIRECTORY_URL = (import.meta.env.VITE_API_URL || DEFAULT_DIRECTORY_URL).replace(/\/$/, '')
 export const DIRECTORY_WS_URL = DIRECTORY_URL.replace(/^http/, 'ws')
 
-class ApiError extends Error {
+export class ApiError extends Error {
   status: number
   errorCode?: string
 
@@ -204,19 +460,66 @@ class ApiError extends Error {
   }
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+export function getStoredAdminKey(): string {
+  if (typeof window === 'undefined') {
+    return ''
+  }
+
+  return window.localStorage.getItem(ADMIN_KEY_STORAGE) ?? ''
+}
+
+export function setStoredAdminKey(value: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const trimmed = value.trim()
+  if (trimmed) {
+    window.localStorage.setItem(ADMIN_KEY_STORAGE, trimmed)
+  } else {
+    window.localStorage.removeItem(ADMIN_KEY_STORAGE)
+  }
+}
+
+export function clearStoredAdminKey(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.localStorage.removeItem(ADMIN_KEY_STORAGE)
+}
+
+export function hasStoredAdminKey(): boolean {
+  return getStoredAdminKey().length > 0
+}
+
+function buildHeaders(initHeaders?: HeadersInit, options?: { admin?: boolean }): Headers {
+  const headers = new Headers(initHeaders ?? {})
+  if (!headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
+
+  if (options?.admin) {
+    const adminKey = getStoredAdminKey()
+    if (adminKey) {
+      headers.set('X-Admin-Key', adminKey)
+    }
+  }
+
+  return headers
+}
+
+async function requestRaw(path: string, init?: RequestInit, options?: { admin?: boolean }): Promise<Response> {
   const response = await fetch(`${DIRECTORY_URL}${path}`, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...(init?.headers ?? {}),
-    },
+    credentials: 'include',
     ...init,
+    headers: buildHeaders(init?.headers, options),
   })
 
   if (!response.ok) {
     let payload: { error?: string; errorCode?: string } | null = null
     try {
-      payload = await response.json()
+      payload = await response.clone().json()
     } catch {
       payload = null
     }
@@ -224,11 +527,36 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     throw new ApiError(payload?.error ?? `Request failed with ${response.status}`, response.status, payload?.errorCode)
   }
 
+  return response
+}
+
+async function request<T>(path: string, init?: RequestInit, options?: { admin?: boolean }): Promise<T> {
+  const response = await requestRaw(path, init, options)
   return response.json() as Promise<T>
 }
 
 function withApiKey(apiKey?: string): HeadersInit | undefined {
   return apiKey ? { Authorization: `Bearer ${apiKey}` } : undefined
+}
+
+function buildQuery(params: Record<string, string | number | undefined | null>): string {
+  const query = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      continue
+    }
+    query.set(key, String(value))
+  }
+
+  const serialized = query.toString()
+  return serialized ? `?${serialized}` : ''
+}
+
+function getFilenameFromResponse(response: Response, dataset: string, format: ExportFormat): string {
+  const disposition = response.headers.get('content-disposition') ?? ''
+  const match = disposition.match(/filename="([^"]+)"/i)
+  return match?.[1] ?? `beam-${dataset}.${format}`
 }
 
 export const directoryApi = {
@@ -281,6 +609,67 @@ export const directoryApi = {
     headers: withApiKey(apiKey),
     body: JSON.stringify(input),
   }),
+  getObservabilityOverview: (hours = 24) => request<ObservabilityOverview>(`/observability/overview?hours=${hours}`, undefined, { admin: true }),
+  searchObservabilityIntents: (params?: {
+    q?: string
+    from?: string
+    to?: string
+    intentType?: string
+    status?: string
+    errorCode?: string
+    limit?: number
+    hours?: number
+  }) => request<RecentIntentsResponse>(`/observability/intents${buildQuery({
+    q: params?.q,
+    from: params?.from,
+    to: params?.to,
+    intentType: params?.intentType,
+    status: params?.status,
+    errorCode: params?.errorCode,
+    limit: params?.limit,
+    hours: params?.hours,
+  })}`, undefined, { admin: true }),
+  getIntentTrace: (nonce: string) => request<IntentTraceResponse>(`/observability/intents/${encodeURIComponent(nonce)}`, undefined, { admin: true }),
+  getAuditLog: (params?: {
+    q?: string
+    action?: string
+    actor?: string
+    target?: string
+    limit?: number
+    hours?: number
+  }) => request<AuditResponse>(`/observability/audit${buildQuery({
+    q: params?.q,
+    action: params?.action,
+    actor: params?.actor,
+    target: params?.target,
+    limit: params?.limit,
+    hours: params?.hours,
+  })}`, undefined, { admin: true }),
+  getAgentHealth: (beamId: string, hours = 24 * 7) => request<AgentHealthResponse>(`/observability/agents/${encodeURIComponent(beamId)}/health?hours=${hours}`, undefined, { admin: true }),
+  getFederationHealth: () => request<FederationHealthResponse>('/observability/federation', undefined, { admin: true }),
+  getErrorAnalytics: (hours = 24 * 7) => request<ErrorAnalyticsResponse>(`/observability/errors?hours=${hours}`, undefined, { admin: true }),
+  getAlerts: (hours = 24) => request<AlertsResponse>(`/observability/alerts?hours=${hours}`, undefined, { admin: true }),
+  getRetention: () => request<RetentionResponse>('/observability/retention', undefined, { admin: true }),
+  pruneObservability: (dataset: string, olderThanDays: number) => request<PruneResponse>('/observability/prune', {
+    method: 'POST',
+    body: JSON.stringify({ dataset, olderThanDays }),
+  }, { admin: true }),
+  downloadObservabilityExport: async (dataset: ExportDataset, format: ExportFormat, params?: {
+    hours?: number
+    limit?: number
+    q?: string
+  }): Promise<ExportDownload> => {
+    const response = await requestRaw(`/observability/export/${dataset}${buildQuery({
+      format,
+      hours: params?.hours,
+      limit: params?.limit,
+      q: params?.q,
+    })}`, undefined, { admin: true })
+    return {
+      blob: await response.blob(),
+      filename: getFilenameFromResponse(response, dataset, format),
+    }
+  },
 }
 
 export function connectIntentFeed(options: {
@@ -305,5 +694,3 @@ export function connectIntentFeed(options: {
 
   return socket
 }
-
-export { ApiError }

--- a/packages/dashboard/src/lib/utils.ts
+++ b/packages/dashboard/src/lib/utils.ts
@@ -36,6 +36,11 @@ export function formatNumber(value: number): string {
   return new Intl.NumberFormat().format(value)
 }
 
+export function formatPercent(value?: number | null, digits = 1): string {
+  if (value == null || Number.isNaN(value)) return '—'
+  return `${(value * 100).toFixed(digits)}%`
+}
+
 export function formatDateTime(value?: string | null): string {
   if (!value) return '—'
   const date = new Date(value)
@@ -43,6 +48,17 @@ export function formatDateTime(value?: string | null): string {
   return new Intl.DateTimeFormat(undefined, {
     dateStyle: 'medium',
     timeStyle: 'short',
+  }).format(date)
+}
+
+export function formatChartTime(value?: string | null): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
   }).format(date)
 }
 
@@ -73,6 +89,39 @@ export function verificationTierColor(tier: string): string {
     default:
       return 'bg-slate-200 text-slate-700 dark:bg-slate-800 dark:text-slate-300'
   }
+}
+
+export function intentStatusColor(status: string): string {
+  switch (status) {
+    case 'success':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
+    case 'pending':
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+    default:
+      return 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
+  }
+}
+
+export function alertSeverityColor(severity: string): string {
+  switch (severity) {
+    case 'critical':
+      return 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
+    case 'warning':
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+    default:
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300'
+  }
+}
+
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  window.setTimeout(() => URL.revokeObjectURL(url), 500)
 }
 
 export function toBase64(buffer: ArrayBuffer): string {

--- a/packages/dashboard/src/pages/AgentProfilePage.tsx
+++ b/packages/dashboard/src/pages/AgentProfilePage.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { ApiError, directoryApi, type DirectoryAgentDetail } from '../lib/api'
-import { cn, formatDateTime, formatLatency, trustScoreColor, trustScoreText, verificationTierColor } from '../lib/utils'
+import { ApiError, directoryApi, type AgentHealthResponse, type DirectoryAgentDetail } from '../lib/api'
+import { BarList, EmptyPanel, MetricCard, PageHeader, TimeSeriesChart } from '../components/Observability'
+import { cn, formatDateTime, formatLatency, formatPercent, trustScoreColor, trustScoreText, verificationTierColor } from '../lib/utils'
 
 export default function AgentProfilePage() {
   const { beamId } = useParams<{ beamId: string }>()
   const resolvedBeamId = beamId ? decodeURIComponent(beamId) : null
   const [agent, setAgent] = useState<DirectoryAgentDetail | null>(null)
+  const [health, setHealth] = useState<AgentHealthResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -18,9 +20,14 @@ export default function AgentProfilePage() {
     async function load() {
       try {
         setLoading(true)
-        const response = await directoryApi.getAgent(beamIdToLoad)
+        const [agentResponse, healthResponse] = await Promise.all([
+          directoryApi.getAgent(beamIdToLoad),
+          directoryApi.getAgentHealth(beamIdToLoad),
+        ])
+
         if (cancelled) return
-        setAgent(response)
+        setAgent(agentResponse)
+        setHealth(healthResponse)
         setError(null)
       } catch (err) {
         if (cancelled) return
@@ -40,83 +47,164 @@ export default function AgentProfilePage() {
     return <div className="panel">Loading agent profile…</div>
   }
 
-  if (error || !agent) {
+  if (error || !agent || !health) {
     return <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">{error ?? 'Agent not found'}</div>
   }
 
   return (
     <div className="space-y-6">
-      <section className="panel">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex items-start gap-4">
-            {agent.logoUrl ? (
-              <img src={agent.logoUrl} alt={agent.displayName} className="h-20 w-20 rounded-2xl object-cover" />
-            ) : (
-              <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-orange-500/10 text-2xl font-semibold text-orange-600 dark:text-orange-300">
-                {agent.displayName.slice(0, 2).toUpperCase()}
+      <PageHeader title={agent.displayName} description={agent.beamId} />
+
+      <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-4">
+              {agent.logoUrl ? (
+                <img src={agent.logoUrl} alt={agent.displayName} className="h-20 w-20 rounded-2xl object-cover" />
+              ) : (
+                <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-orange-500/10 text-2xl font-semibold text-orange-600 dark:text-orange-300">
+                  {agent.displayName.slice(0, 2).toUpperCase()}
+                </div>
+              )}
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium capitalize', verificationTierColor(agent.verificationTier))}>
+                    {agent.verificationTier}
+                  </span>
+                  <span className="rounded-full bg-slate-200 px-2.5 py-1 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                    {agent.emailVerified ? 'email verified' : 'email pending'}
+                  </span>
+                </div>
+                {agent.description ? <p className="max-w-2xl text-sm text-slate-600 dark:text-slate-300">{agent.description}</p> : null}
               </div>
-            )}
-            <div className="space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <h1 className="text-3xl font-semibold tracking-tight">{agent.displayName}</h1>
-                <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium capitalize', verificationTierColor(agent.verificationTier))}>
-                  {agent.verificationTier}
-                </span>
-              </div>
-              <div className="text-sm text-slate-500 dark:text-slate-400">{agent.beamId}</div>
-              {agent.description && <p className="max-w-2xl text-sm text-slate-600 dark:text-slate-300">{agent.description}</p>}
+            </div>
+            <div className="space-y-2 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-950">
+              <div><span className="text-slate-500 dark:text-slate-400">Created:</span> {formatDateTime(agent.createdAt)}</div>
+              <div><span className="text-slate-500 dark:text-slate-400">Last seen:</span> {formatDateTime(agent.lastSeen)}</div>
+              <div><span className="text-slate-500 dark:text-slate-400">Email:</span> {agent.email ?? '—'}</div>
             </div>
           </div>
-          <div className="space-y-2 rounded-2xl bg-slate-50 p-4 text-sm dark:bg-slate-950">
-            <div><span className="text-slate-500 dark:text-slate-400">Created:</span> {formatDateTime(agent.createdAt)}</div>
-            <div><span className="text-slate-500 dark:text-slate-400">Last seen:</span> {formatDateTime(agent.lastSeen)}</div>
-            <div><span className="text-slate-500 dark:text-slate-400">Email:</span> {agent.email ?? '—'}</div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {agent.capabilities.map((capability) => (
+              <div key={capability} className="rounded-xl bg-slate-50 px-4 py-3 text-sm dark:bg-slate-950">{capability}</div>
+            ))}
           </div>
         </div>
 
-        <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          {agent.capabilities.map((capability) => (
-            <div key={capability} className="rounded-xl bg-slate-50 px-4 py-3 text-sm dark:bg-slate-950">{capability}</div>
-          ))}
-        </div>
-      </section>
-
-      <section className="grid gap-6 xl:grid-cols-[1.2fr,0.8fr]">
         <div className="panel">
           <div className="panel-title">Trust score</div>
           <div className="mt-4 flex items-end justify-between">
             <div className="text-4xl font-semibold tracking-tight">{trustScoreText(agent.trustScore)}</div>
-            <div className="text-sm text-slate-500 dark:text-slate-400">Visualized in real time</div>
+            <div className="text-sm text-slate-500 dark:text-slate-400">Pairwise directory confidence</div>
           </div>
           <div className="mt-4 h-4 rounded-full bg-slate-200 dark:bg-slate-800">
             <div className={cn('h-4 rounded-full', trustScoreColor(agent.trustScore))} style={{ width: `${Math.round(agent.trustScore * 100)}%` }} />
           </div>
-        </div>
-
-        <div className="panel">
-          <div className="panel-title">Verification</div>
-          <div className="mt-4 space-y-3 text-sm">
-            <div className={cn('inline-flex rounded-full px-2.5 py-1 font-medium capitalize', verificationTierColor(agent.verificationTier))}>{agent.verificationTier}</div>
-            <div><span className="text-slate-500 dark:text-slate-400">Email status:</span> {agent.emailVerified ? 'Verified' : 'Pending'}</div>
-            <div><span className="text-slate-500 dark:text-slate-400">Legacy verified flag:</span> {agent.verified ? 'Yes' : 'No'}</div>
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            <MetricCard label="Success rate" value={formatPercent(health.summary.successRate)} />
+            <MetricCard label="p95 latency" value={formatLatency(health.summary.p95LatencyMs)} />
           </div>
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
-        <StatCard label="Received intents" value={String(agent.intentStats.received)} />
-        <StatCard label="Responded intents" value={String(agent.intentStats.responded)} />
-        <StatCard label="Avg response time" value={formatLatency(agent.intentStats.avg_response_time_ms)} />
+      <section className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+        <MetricCard label="Sent" value={String(health.summary.sentCount)} />
+        <MetricCard label="Received" value={String(health.summary.receivedCount)} />
+        <MetricCard label="Counterparties" value={String(health.summary.uniqueCounterparties)} />
+        <MetricCard label="Direct" value={String(health.usage.directCount)} />
+        <MetricCard label="Relayed" value={String(health.usage.relayedCount)} />
+        <MetricCard label="Shield holds" value={String(health.shield.held)} tone={health.shield.held > 0 ? 'warning' : 'default'} />
       </section>
-    </div>
-  )
-}
 
-function StatCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="panel">
-      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
-      <div className="mt-2 text-3xl font-semibold tracking-tight">{value}</div>
+      <section className="panel">
+        <div className="panel-title">Traffic timeline</div>
+        <div className="mt-5">
+          <TimeSeriesChart
+            data={health.timeline}
+            series={[
+              { key: 'sent', label: 'Sent', color: '#f97316' },
+              { key: 'received', label: 'Received', color: '#3b82f6' },
+              { key: 'error', label: 'Errors', color: '#ef4444' },
+            ]}
+          />
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[0.9fr,1.1fr]">
+        <div className="panel">
+          <div className="panel-title">Counterparties</div>
+          <div className="mt-5">
+            <BarList items={health.counterparties.map((entry) => ({ label: entry.beamId, value: entry.outbound + entry.inbound }))} />
+          </div>
+        </div>
+
+        <div className="panel overflow-hidden p-0">
+          <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <div className="panel-title">Error codes</div>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-950">
+                <tr>
+                  <th className="table-head">Code</th>
+                  <th className="table-head">Count</th>
+                  <th className="table-head">Last seen</th>
+                </tr>
+              </thead>
+              <tbody>
+                {health.errors.length === 0 ? (
+                  <tr><td className="table-cell" colSpan={3}>No errors recorded for this agent.</td></tr>
+                ) : (
+                  health.errors.map((entry) => (
+                    <tr key={entry.errorCode} className="border-t border-slate-200 dark:border-slate-800">
+                      <td className="table-cell font-medium">{entry.errorCode}</td>
+                      <td className="table-cell">{entry.count}</td>
+                      <td className="table-cell">{formatDateTime(entry.lastSeenAt)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1fr,1fr]">
+        <div className="panel">
+          <div className="panel-title">Intent mix</div>
+          <div className="mt-4 space-y-3">
+            {health.intents.length === 0 ? (
+              <EmptyPanel label="No intent history recorded for this agent." />
+            ) : (
+              health.intents.map((intent) => (
+                <div key={intent.intentType} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <div className="font-medium">{intent.intentType}</div>
+                      <div className="text-sm text-slate-500 dark:text-slate-400">{intent.errors} errors</div>
+                    </div>
+                    <div className="text-right text-sm">
+                      <div>{intent.total} total</div>
+                      <div className="text-slate-500 dark:text-slate-400">{formatLatency(intent.avgLatencyMs)}</div>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Usage & Shield</div>
+          <div className="mt-4 grid gap-4 sm:grid-cols-2">
+            <MetricCard label="Intent count" value={String(health.usage.intentCount)} hint={health.usage.period} />
+            <MetricCard label="Encrypted" value={String(health.usage.encryptedCount)} />
+            <MetricCard label="Shield passed" value={String(health.shield.passed)} />
+            <MetricCard label="High risk" value={String(health.shield.highRiskCount)} tone={health.shield.highRiskCount > 0 ? 'warning' : 'default'} />
+          </div>
+        </div>
+      </section>
     </div>
   )
 }

--- a/packages/dashboard/src/pages/AlertsPage.tsx
+++ b/packages/dashboard/src/pages/AlertsPage.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react'
+import { ApiError, directoryApi, type AlertsResponse, type ExportDataset, type ExportFormat } from '../lib/api'
+import { EmptyPanel, PageHeader } from '../components/Observability'
+import { alertSeverityColor, cn, downloadBlob, formatDateTime } from '../lib/utils'
+
+const EXPORT_FORMATS: ExportFormat[] = ['json', 'csv', 'ndjson']
+
+export default function AlertsPage() {
+  const [hours, setHours] = useState(24)
+  const [data, setData] = useState<AlertsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [pruneDataset, setPruneDataset] = useState('intents')
+  const [pruneDays, setPruneDays] = useState(30)
+  const [actionState, setActionState] = useState<string | null>(null)
+
+  async function load(currentHours: number) {
+    try {
+      setLoading(true)
+      const response = await directoryApi.getAlerts(currentHours)
+      setData(response)
+      setPruneDays(response.retention.defaultDays)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load alerts')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load(hours)
+  }, [hours])
+
+  async function handleExport(dataset: ExportDataset, format: ExportFormat) {
+    try {
+      setActionState(`Exporting ${dataset}.${format}…`)
+      const result = await directoryApi.downloadObservabilityExport(dataset, format, { hours, limit: 1000 })
+      downloadBlob(result.blob, result.filename)
+      setActionState(`Exported ${result.filename}`)
+    } catch (err) {
+      setActionState(err instanceof ApiError ? err.message : 'Export failed')
+    }
+  }
+
+  async function handlePrune() {
+    try {
+      setActionState(`Pruning ${pruneDataset} older than ${pruneDays} days…`)
+      const result = await directoryApi.pruneObservability(pruneDataset, pruneDays)
+      setActionState(`Deleted ${result.deleted} records from ${result.dataset}`)
+      await load(hours)
+    } catch (err) {
+      setActionState(err instanceof ApiError ? err.message : 'Prune failed')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Alerts"
+        description="Heuristic alerting, export controls, and log retention actions."
+        actions={(
+          <select className="input-field w-auto min-w-28" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            <option value={24}>24h</option>
+            <option value={24 * 7}>7d</option>
+            <option value={24 * 30}>30d</option>
+          </select>
+        )}
+      />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+      {actionState ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+          {actionState}
+        </div>
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel">
+          <div className="panel-title">Active Alerts</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading alerts…" />
+            ) : !data || data.alerts.length === 0 ? (
+              <EmptyPanel label="No active alerts for the selected window." />
+            ) : (
+              data.alerts.map((alert) => (
+                <div key={alert.id} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
+                      {alert.severity}
+                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(alert.startedAt)}</span>
+                  </div>
+                  <div className="mt-2 text-sm font-medium">{alert.title}</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{alert.message}</div>
+                  <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                    {alert.metric}: {alert.value} (threshold {alert.threshold})
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="panel">
+            <div className="panel-title">Exports</div>
+            <div className="mt-4 space-y-4">
+              {loading ? (
+                <EmptyPanel label="Loading export catalog…" />
+              ) : !data ? (
+                <EmptyPanel label="Export catalog unavailable." />
+              ) : (
+                data.exports.map((entry) => (
+                  <div key={entry.dataset} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="text-sm font-medium capitalize">{entry.dataset}</div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {EXPORT_FORMATS.filter((format) => entry.formats.includes(format)).map((format) => (
+                        <button
+                          key={`${entry.dataset}-${format}`}
+                          className="btn-secondary"
+                          onClick={() => void handleExport(entry.dataset as ExportDataset, format)}
+                          type="button"
+                        >
+                          {format.toUpperCase()}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="panel">
+            <div className="panel-title">Retention</div>
+            <div className="mt-4 space-y-4">
+              <div className="text-sm text-slate-500 dark:text-slate-400">
+                Default retention: {data?.retention.defaultDays ?? pruneDays} days.
+              </div>
+              <select className="input-field" value={pruneDataset} onChange={(event) => setPruneDataset(event.target.value)}>
+                {data?.retention.datasets.map((dataset) => (
+                  <option key={dataset} value={dataset}>{dataset}</option>
+                )) ?? (
+                  <>
+                    <option value="intents">intents</option>
+                    <option value="traces">traces</option>
+                    <option value="audit">audit</option>
+                    <option value="shield">shield</option>
+                  </>
+                )}
+              </select>
+              <input
+                className="input-field"
+                min={1}
+                step={1}
+                type="number"
+                value={pruneDays}
+                onChange={(event) => setPruneDays(Number(event.target.value))}
+              />
+              <button className="btn-primary w-full" onClick={() => void handlePrune()} type="button">
+                Prune Dataset
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/AuditPage.tsx
+++ b/packages/dashboard/src/pages/AuditPage.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { Search } from 'lucide-react'
+import { ApiError, directoryApi, type AuditEntry } from '../lib/api'
+import { EmptyPanel, PageHeader, StatusPill } from '../components/Observability'
+import { formatDateTime } from '../lib/utils'
+
+export default function AuditPage() {
+  const [entries, setEntries] = useState<AuditEntry[]>([])
+  const [query, setQuery] = useState('')
+  const [hours, setHours] = useState(24 * 7)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        setLoading(true)
+        const response = await directoryApi.getAuditLog({
+          q: query || undefined,
+          hours,
+          limit: 120,
+        })
+        if (cancelled) return
+        setEntries(response.entries)
+        setError(null)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof ApiError ? err.message : 'Failed to load audit log')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [hours, query])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Audit" description="Administrative and federation control-plane events across the directory." />
+
+      <section className="panel">
+        <div className="grid gap-3 lg:grid-cols-[1.5fr,0.5fr]">
+          <label className="relative block">
+            <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              className="input-field pl-10"
+              placeholder="Search action, actor, target, details"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <select className="input-field" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            <option value={24}>24h</option>
+            <option value={24 * 7}>7d</option>
+            <option value={24 * 30}>30d</option>
+          </select>
+        </div>
+      </section>
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="panel overflow-hidden p-0">
+        {loading ? (
+          <div className="p-5 text-sm text-slate-500 dark:text-slate-400">Loading audit trail…</div>
+        ) : entries.length === 0 ? (
+          <div className="p-5">
+            <EmptyPanel label="No audit events matched the current filters." />
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-200 dark:divide-slate-800">
+            {entries.map((entry) => (
+              <div key={entry.id} className="p-5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill label={entry.action} />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(entry.timestamp)}</span>
+                </div>
+                <div className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                  {entry.actor} → {entry.target}
+                </div>
+                {entry.details ? (
+                  <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                    {JSON.stringify(entry.details, null, 2)}
+                  </pre>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/ErrorsPage.tsx
+++ b/packages/dashboard/src/pages/ErrorsPage.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import { ApiError, directoryApi, type ErrorAnalyticsResponse } from '../lib/api'
+import { BarList, EmptyPanel, MetricCard, PageHeader, TimeSeriesChart } from '../components/Observability'
+import { formatDateTime, formatLatency, formatNumber } from '../lib/utils'
+
+export default function ErrorsPage() {
+  const [hours, setHours] = useState(24 * 7)
+  const [data, setData] = useState<ErrorAnalyticsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        setLoading(true)
+        const response = await directoryApi.getErrorAnalytics(hours)
+        if (cancelled) return
+        setData(response)
+        setError(null)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof ApiError ? err.message : 'Failed to load error analytics')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [hours])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Errors"
+        description="Failure-code distribution, noisy routes, and latency tied to error conditions."
+        actions={(
+          <select className="input-field w-auto min-w-28" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            <option value={24}>24h</option>
+            <option value={24 * 7}>7d</option>
+            <option value={24 * 30}>30d</option>
+          </select>
+        )}
+      />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard label="Errors" value={loading || !data ? '—' : formatNumber(data.summary.totalErrors)} tone={data && data.summary.totalErrors > 0 ? 'warning' : 'default'} />
+        <MetricCard label="Distinct codes" value={loading || !data ? '—' : formatNumber(data.summary.distinctErrorCodes)} />
+        <MetricCard label="Timeouts" value={loading || !data ? '—' : formatNumber(data.summary.timeoutCount)} />
+        <MetricCard label="Offline" value={loading || !data ? '—' : formatNumber(data.summary.offlineCount)} />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1.15fr,0.85fr]">
+        <div className="panel">
+          <div className="panel-title">Error Timeline</div>
+          <div className="mt-5">
+            {loading || !data ? (
+              <EmptyPanel label="Loading error trend…" />
+            ) : (
+              <TimeSeriesChart
+                data={data.timeline}
+                series={[
+                  { key: 'total', label: 'Errors', color: '#ef4444' },
+                ]}
+              />
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Noisiest Routes</div>
+          <div className="mt-5">
+            {loading || !data ? (
+              <EmptyPanel label="Loading route hotspots…" />
+            ) : (
+              <BarList items={data.routes.map((route) => ({ label: route.route, value: route.count }))} />
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="panel overflow-hidden p-0">
+        <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+          <div className="panel-title">Error Codes</div>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-950">
+              <tr>
+                <th className="table-head">Code</th>
+                <th className="table-head">Count</th>
+                <th className="table-head">Avg latency</th>
+                <th className="table-head">Senders</th>
+                <th className="table-head">Recipients</th>
+                <th className="table-head">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td className="table-cell" colSpan={6}>Loading error codes…</td></tr>
+              ) : !data || data.codes.length === 0 ? (
+                <tr><td className="table-cell" colSpan={6}>No error codes in the selected window.</td></tr>
+              ) : (
+                data.codes.map((entry) => (
+                  <tr key={entry.errorCode} className="border-t border-slate-200 dark:border-slate-800">
+                    <td className="table-cell font-medium">{entry.errorCode}</td>
+                    <td className="table-cell">{formatNumber(entry.count)}</td>
+                    <td className="table-cell">{formatLatency(entry.avgLatencyMs)}</td>
+                    <td className="table-cell">{formatNumber(entry.affectedSenders)}</td>
+                    <td className="table-cell">{formatNumber(entry.affectedRecipients)}</td>
+                    <td className="table-cell">{formatDateTime(entry.lastSeenAt)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/FederationPage.tsx
+++ b/packages/dashboard/src/pages/FederationPage.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+import { ApiError, directoryApi, type FederationHealthResponse } from '../lib/api'
+import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import { formatDateTime, formatNumber } from '../lib/utils'
+
+export default function FederationPage() {
+  const [data, setData] = useState<FederationHealthResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        setLoading(true)
+        const response = await directoryApi.getFederationHealth()
+        if (cancelled) return
+        setData(response)
+        setError(null)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof ApiError ? err.message : 'Failed to load federation health')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Federation" description="Peer directories, cache freshness, and propagated trust state." />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <MetricCard label="Peers" value={loading || !data ? '—' : formatNumber(data.summary.peerCount)} />
+        <MetricCard label="Active peers" value={loading || !data ? '—' : formatNumber(data.summary.activePeers)} />
+        <MetricCard label="Stale peers" value={loading || !data ? '—' : formatNumber(data.summary.stalePeers)} tone={data && data.summary.stalePeers > 0 ? 'warning' : 'default'} />
+        <MetricCard label="Cached agents" value={loading || !data ? '—' : formatNumber(data.summary.cachedAgents)} />
+        <MetricCard label="Trust assertions" value={loading || !data ? '—' : formatNumber(data.summary.trustAssertions)} />
+      </section>
+
+      <section className="panel overflow-hidden p-0">
+        <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+          <div className="panel-title">Peer Directory Health</div>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 dark:bg-slate-950">
+              <tr>
+                <th className="table-head">Directory</th>
+                <th className="table-head">Status</th>
+                <th className="table-head">Trust</th>
+                <th className="table-head">Cached</th>
+                <th className="table-head">Assertions</th>
+                <th className="table-head">Last seen</th>
+                <th className="table-head">Synced</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr><td className="table-cell" colSpan={7}>Loading peers…</td></tr>
+              ) : !data || data.peers.length === 0 ? (
+                <tr><td className="table-cell" colSpan={7}>No federation peers have been registered yet.</td></tr>
+              ) : (
+                data.peers.map((peer) => (
+                  <tr key={peer.id} className="border-t border-slate-200 dark:border-slate-800">
+                    <td className="table-cell font-mono">{peer.directoryUrl}</td>
+                    <td className="table-cell">
+                      <StatusPill label={peer.stale ? 'stale' : peer.status} tone={peer.stale ? 'warning' : peer.status === 'active' ? 'success' : 'default'} />
+                    </td>
+                    <td className="table-cell">{peer.trustLevel.toFixed(2)}</td>
+                    <td className="table-cell">{formatNumber(peer.cachedAgents)}</td>
+                    <td className="table-cell">{formatNumber(peer.trustAssertions)}</td>
+                    <td className="table-cell">{formatDateTime(peer.lastSeen)}</td>
+                    <td className="table-cell">{formatDateTime(peer.syncedAt)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-title">Federated Agent Cache</div>
+        <div className="mt-4 space-y-3">
+          {loading ? (
+            <EmptyPanel label="Loading cached agents…" />
+          ) : !data || data.agents.length === 0 ? (
+            <EmptyPanel label="No cached agents are present." />
+          ) : (
+            data.agents.map((agent) => (
+              <div key={agent.beamId} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{agent.beamId}</div>
+                    <div className="truncate text-sm text-slate-500 dark:text-slate-400">{agent.directoryUrl}</div>
+                  </div>
+                  <div className="text-right text-sm">
+                    <div>Trust {agent.effectiveTrust?.toFixed(2) ?? '—'}</div>
+                    <div className="text-slate-500 dark:text-slate-400">TTL {agent.ttl}s</div>
+                  </div>
+                </div>
+                <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">Cached {formatDateTime(agent.cachedAt)}</div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/IntentsPage.tsx
+++ b/packages/dashboard/src/pages/IntentsPage.tsx
@@ -1,35 +1,80 @@
 import { useEffect, useRef, useState } from 'react'
-import { Radio } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { Radio, Search } from 'lucide-react'
 import { ApiError, connectIntentFeed, directoryApi, type RecentIntent } from '../lib/api'
-import { cn, formatDateTime, formatLatency, truncateBeamId } from '../lib/utils'
+import { PageHeader, StatusPill } from '../components/Observability'
+import { cn, formatDateTime, formatLatency, intentStatusColor, truncateBeamId } from '../lib/utils'
+
+const WINDOW_OPTIONS = [
+  { value: 24, label: '24h' },
+  { value: 24 * 7, label: '7d' },
+]
+
+function matchesFilters(intent: RecentIntent, filters: {
+  query: string
+  status: string
+  hours: number
+}) {
+  const matchesStatus = filters.status === 'all' || intent.status === filters.status
+  const matchesQuery = !filters.query || [
+    intent.nonce,
+    intent.from,
+    intent.to,
+    intent.intentType,
+    intent.errorCode ?? '',
+  ].join(' ').toLowerCase().includes(filters.query.toLowerCase())
+
+  if (!matchesStatus || !matchesQuery) {
+    return false
+  }
+
+  const threshold = Date.now() - filters.hours * 60 * 60 * 1000
+  return new Date(intent.timestamp).getTime() >= threshold
+}
 
 export default function IntentsPage() {
   const [intents, setIntents] = useState<RecentIntent[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [socketState, setSocketState] = useState<'connecting' | 'live' | 'offline'>('connecting')
+  const [query, setQuery] = useState('')
+  const [status, setStatus] = useState('all')
+  const [hours, setHours] = useState(24)
   const socketRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
     let cancelled = false
-    let reconnectTimer: number | null = null
 
-    async function loadInitial() {
+    async function load() {
       try {
         setLoading(true)
-        const response = await directoryApi.getRecentIntents(50)
-        if (!cancelled) {
-          setIntents(response.intents)
-          setError(null)
-        }
+        const response = await directoryApi.searchObservabilityIntents({
+          limit: 150,
+          q: query || undefined,
+          status: status === 'all' ? undefined : status,
+          hours,
+        })
+
+        if (cancelled) return
+        setIntents(response.intents)
+        setError(null)
       } catch (err) {
-        if (!cancelled) {
-          setError(err instanceof ApiError ? err.message : 'Failed to load intents')
-        }
+        if (cancelled) return
+        setError(err instanceof ApiError ? err.message : 'Failed to load intents')
       } finally {
         if (!cancelled) setLoading(false)
       }
     }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [hours, query, status])
+
+  useEffect(() => {
+    let cancelled = false
+    let reconnectTimer: number | null = null
 
     function connect() {
       setSocketState('connecting')
@@ -45,44 +90,74 @@ export default function IntentsPage() {
         onError: () => setSocketState('offline'),
         onMessage: (message) => {
           if (message.type !== 'intent_feed' || !message.entry) return
-          const entry = message.entry
+          if (!matchesFilters(message.entry, { query, status, hours })) {
+            return
+          }
+
           setIntents((current) => {
-            const index = current.findIndex((currentEntry) => currentEntry.nonce === entry.nonce)
-            if (index >= 0) {
-              const updated = [...current]
-              updated[index] = entry
-              return updated.sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime())
-            }
-            return [entry, ...current].slice(0, 75)
+            const next = current.filter((entry) => entry.nonce !== message.entry?.nonce)
+            return [message.entry as RecentIntent, ...next]
+              .sort((left, right) => new Date(right.timestamp).getTime() - new Date(left.timestamp).getTime())
+              .slice(0, 150)
           })
         },
       })
     }
 
-    void loadInitial()
     connect()
 
     return () => {
       cancelled = true
-      if (reconnectTimer) window.clearTimeout(reconnectTimer)
+      if (reconnectTimer) {
+        window.clearTimeout(reconnectTimer)
+      }
       socketRef.current?.close()
     }
-  }, [])
+  }, [hours, query, status])
 
   return (
     <div className="space-y-6">
-      <section className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Intents</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">Live intent feed over the real `/ws` endpoint.</p>
-        </div>
-        <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm dark:border-slate-800">
-          <Radio size={14} className={cn(socketState === 'live' ? 'text-emerald-500' : socketState === 'connecting' ? 'text-amber-500' : 'text-red-500')} />
-          <span className="capitalize">{socketState}</span>
+      <PageHeader
+        title="Intents"
+        description="Search the live intent stream and drill into per-nonce traces."
+        actions={(
+          <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-sm dark:border-slate-800">
+            <Radio size={14} className={cn(socketState === 'live' ? 'text-emerald-500' : socketState === 'connecting' ? 'text-amber-500' : 'text-red-500')} />
+            <span className="capitalize">{socketState}</span>
+          </div>
+        )}
+      />
+
+      <section className="panel">
+        <div className="grid gap-3 lg:grid-cols-[1.6fr,0.8fr,0.8fr]">
+          <label className="relative block">
+            <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              className="input-field pl-10"
+              placeholder="Search nonce, Beam ID, intent type, error code"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+          </label>
+          <select className="input-field" value={status} onChange={(event) => setStatus(event.target.value)}>
+            <option value="all">All statuses</option>
+            <option value="success">Success</option>
+            <option value="pending">Pending</option>
+            <option value="error">Error</option>
+          </select>
+          <select className="input-field" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            {WINDOW_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
         </div>
       </section>
 
-      {error && <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">{error}</div>}
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
 
       <section className="panel overflow-hidden p-0">
         <div className="overflow-x-auto">
@@ -90,6 +165,7 @@ export default function IntentsPage() {
             <thead className="bg-slate-50 dark:bg-slate-950">
               <tr>
                 <th className="table-head">Intent</th>
+                <th className="table-head">Nonce</th>
                 <th className="table-head">From</th>
                 <th className="table-head">To</th>
                 <th className="table-head">Status</th>
@@ -99,26 +175,27 @@ export default function IntentsPage() {
             </thead>
             <tbody>
               {loading ? (
-                <tr><td className="table-cell" colSpan={6}>Loading intent history…</td></tr>
+                <tr><td className="table-cell" colSpan={7}>Loading intent history…</td></tr>
               ) : intents.length === 0 ? (
-                <tr><td className="table-cell" colSpan={6}>No intent activity yet.</td></tr>
+                <tr><td className="table-cell" colSpan={7}>No intent activity matched the current filters.</td></tr>
               ) : (
                 intents.map((intent) => (
                   <tr key={intent.nonce} className="border-t border-slate-200 dark:border-slate-800">
                     <td className="table-cell font-medium">{intent.intentType}</td>
+                    <td className="table-cell">
+                      <Link className="font-mono text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/intents/${encodeURIComponent(intent.nonce)}`}>
+                        {truncateBeamId(intent.nonce, 18)}
+                      </Link>
+                    </td>
                     <td className="table-cell">{truncateBeamId(intent.from, 28)}</td>
                     <td className="table-cell">{truncateBeamId(intent.to, 28)}</td>
                     <td className="table-cell">
-                      <span className={cn(
-                        'rounded-full px-2 py-1 text-xs font-medium capitalize',
-                        intent.status === 'success'
-                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
-                          : intent.status === 'pending'
-                            ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
-                            : 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300',
-                      )}>
-                        {intent.status}
-                      </span>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className={cn('rounded-full px-2 py-1 text-xs font-medium capitalize', intentStatusColor(intent.status))}>
+                          {intent.status}
+                        </span>
+                        {intent.errorCode ? <StatusPill label={intent.errorCode} tone="critical" /> : null}
+                      </div>
                     </td>
                     <td className="table-cell">{formatLatency(intent.roundTripLatencyMs)}</td>
                     <td className="table-cell">{formatDateTime(intent.timestamp)}</td>

--- a/packages/dashboard/src/pages/OverviewPage.tsx
+++ b/packages/dashboard/src/pages/OverviewPage.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from 'react'
-import { Activity, Bot, Clock3, ShieldCheck } from 'lucide-react'
-import { ApiError, directoryApi, type DirectoryStats, type RecentIntent } from '../lib/api'
-import { formatDateTime, formatLatency, formatNumber, truncateBeamId } from '../lib/utils'
+import { Link } from 'react-router-dom'
+import { ApiError, directoryApi, type ObservabilityOverview } from '../lib/api'
+import { alertSeverityColor, cn, formatLatency, formatNumber, formatPercent } from '../lib/utils'
+import { BarList, EmptyPanel, MetricCard, PageHeader, StatusPill, TimeSeriesChart } from '../components/Observability'
+
+const WINDOW_OPTIONS = [
+  { value: 24, label: '24h' },
+  { value: 24 * 7, label: '7d' },
+]
 
 export default function OverviewPage() {
-  const [stats, setStats] = useState<DirectoryStats | null>(null)
-  const [recentIntents, setRecentIntents] = useState<RecentIntent[]>([])
-  const [error, setError] = useState<string | null>(null)
+  const [hours, setHours] = useState(24)
+  const [overview, setOverview] = useState<ObservabilityOverview | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -15,18 +21,13 @@ export default function OverviewPage() {
     async function load() {
       try {
         setLoading(true)
-        const [statsResponse, intentsResponse] = await Promise.all([
-          directoryApi.getAgentStats(),
-          directoryApi.getRecentIntents(6),
-        ])
-
+        const response = await directoryApi.getObservabilityOverview(hours)
         if (cancelled) return
-        setStats(statsResponse)
-        setRecentIntents(intentsResponse.intents)
+        setOverview(response)
         setError(null)
       } catch (err) {
         if (cancelled) return
-        setError(err instanceof ApiError ? err.message : 'Failed to load dashboard overview')
+        setError(err instanceof ApiError ? err.message : 'Failed to load observability overview')
       } finally {
         if (!cancelled) setLoading(false)
       }
@@ -36,66 +37,142 @@ export default function OverviewPage() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [hours])
 
   return (
     <div className="space-y-6">
-      <section className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Overview</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400">Live network stats from the Beam Directory API.</p>
+      <PageHeader
+        title="Overview"
+        description="Network health, throughput, latency, and alert pressure across the Beam directory."
+        actions={(
+          <select className="input-field w-auto min-w-28" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+            {WINDOW_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        )}
+      />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
         </div>
-        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <MetricCard label="Total intents" value={loading || !overview ? '—' : formatNumber(overview.summary.totalIntents)} hint={`${hours}h window`} />
+        <MetricCard label="Success rate" value={loading || !overview ? '—' : formatPercent(overview.summary.successRate)} tone={overview && overview.summary.successRate < 0.9 ? 'warning' : 'success'} />
+        <MetricCard label="p95 latency" value={loading || !overview ? '—' : formatLatency(overview.summary.p95LatencyMs)} tone={overview && (overview.summary.p95LatencyMs ?? 0) >= 2000 ? 'warning' : 'default'} />
+        <MetricCard label="Live agents" value={loading || !overview ? '—' : formatNumber(overview.summary.liveAgents)} hint={`${overview ? formatNumber(overview.summary.totalAgents) : '—'} total`} />
+        <MetricCard label="Open alerts" value={loading || !overview ? '—' : formatNumber(overview.alerts.length)} tone={overview && overview.alerts.length > 0 ? 'critical' : 'default'} />
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-        <StatCard icon={Bot} label="Total agents" value={loading || !stats ? '—' : formatNumber(stats.total_agents)} />
-        <StatCard icon={ShieldCheck} label="Verified agents" value={loading || !stats ? '—' : formatNumber(stats.verified_agents)} />
-        <StatCard icon={Activity} label="Processed intents" value={loading || !stats ? '—' : formatNumber(stats.intents_processed)} />
-        <StatCard icon={Clock3} label="Avg response" value={loading || !stats ? '—' : formatLatency(stats.avg_response_time_ms)} />
-      </section>
-
-      <section className="grid gap-4 xl:grid-cols-[1.1fr,0.9fr]">
+      <section className="grid gap-6 xl:grid-cols-[1.4fr,0.8fr]">
         <div className="panel">
-          <div className="panel-title">Verification coverage</div>
-          <div className="mt-5 space-y-4">
+          <div className="flex items-center justify-between gap-3">
             <div>
-              <div className="mb-2 flex items-center justify-between text-sm">
-                <span className="text-slate-600 dark:text-slate-300">Verified share</span>
-                <span className="font-medium">{stats && stats.total_agents > 0 ? `${Math.round((stats.verified_agents / stats.total_agents) * 100)}%` : '0%'}</span>
-              </div>
-              <div className="h-3 rounded-full bg-slate-200 dark:bg-slate-800">
-                <div
-                  className="h-3 rounded-full bg-blue-500 transition-all"
-                  style={{ width: `${stats && stats.total_agents > 0 ? (stats.verified_agents / stats.total_agents) * 100 : 0}%` }}
-                />
-              </div>
+              <div className="panel-title">Intent Timeline</div>
+              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Throughput, failures, and pending pressure over time.</div>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2">
-              <MiniStat label="Verified" value={stats ? formatNumber(stats.verified_agents) : '—'} />
-              <MiniStat label="Unverified" value={stats ? formatNumber(Math.max(stats.total_agents - stats.verified_agents, 0)) : '—'} />
-            </div>
+            <StatusPill
+              label={overview && overview.summary.pendingOlderThan15m > 0 ? `${overview.summary.pendingOlderThan15m} stuck` : 'healthy'}
+              tone={overview && overview.summary.pendingOlderThan15m > 0 ? 'warning' : 'success'}
+            />
+          </div>
+          <div className="mt-5">
+            {loading || !overview ? (
+              <EmptyPanel label="Loading timeseries…" />
+            ) : (
+              <TimeSeriesChart
+                data={overview.timeline}
+                series={[
+                  { key: 'total', label: 'Total', color: '#f97316' },
+                  { key: 'error', label: 'Errors', color: '#ef4444' },
+                  { key: 'pending', label: 'Pending', color: '#f59e0b' },
+                ]}
+              />
+            )}
           </div>
         </div>
 
         <div className="panel">
-          <div className="panel-title">Latest intents</div>
-          <div className="mt-4 space-y-3">
-            {recentIntents.length === 0 ? (
-              <EmptyState label={loading ? 'Loading recent intents…' : 'No intents have been processed yet.'} />
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="panel-title">Top Intents</div>
+              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Most active intent types in the selected window.</div>
+            </div>
+            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/intents">
+              Open feed
+            </Link>
+          </div>
+          <div className="mt-5">
+            {loading || !overview ? (
+              <EmptyPanel label="Loading intent mix…" />
             ) : (
-              recentIntents.map((intent) => (
-                <div key={intent.nonce} className="rounded-xl border border-slate-200 p-3 dark:border-slate-800">
-                  <div className="flex flex-wrap items-center gap-2 text-sm">
-                    <span className="rounded-full bg-orange-500/10 px-2 py-1 text-xs font-medium text-orange-600 dark:text-orange-300">
-                      {intent.intentType}
+              <BarList items={overview.topIntents.map((entry) => ({ label: entry.intentType, value: entry.total }))} />
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[0.95fr,1.05fr]">
+        <div className="panel">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="panel-title">Error Pressure</div>
+              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Most frequent failure codes right now.</div>
+            </div>
+            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/errors">
+              Error dashboard
+            </Link>
+          </div>
+          <div className="mt-4 space-y-3">
+            {loading || !overview ? (
+              <EmptyPanel label="Loading error data…" />
+            ) : overview.topErrors.length === 0 ? (
+              <EmptyPanel label="No error codes in the selected window." />
+            ) : (
+              overview.topErrors.map((entry) => (
+                <div key={entry.errorCode} className="rounded-xl border border-slate-200 p-3 dark:border-slate-800">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{entry.errorCode}</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">{entry.lastSeenAt}</div>
+                    </div>
+                    <div className="text-lg font-semibold">{formatNumber(entry.count)}</div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <div className="panel-title">Alert Feed</div>
+              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Computed network warnings from errors, latency, backlog, and federation drift.</div>
+            </div>
+            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/alerts">
+              View all alerts
+            </Link>
+          </div>
+          <div className="mt-4 space-y-3">
+            {loading || !overview ? (
+              <EmptyPanel label="Loading alerts…" />
+            ) : overview.alerts.length === 0 ? (
+              <EmptyPanel label="No active alerts in the selected window." />
+            ) : (
+              overview.alerts.map((alert) => (
+                <div key={alert.id} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
+                      {alert.severity}
                     </span>
-                    <span className="text-slate-500 dark:text-slate-400">{formatDateTime(intent.timestamp)}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
                   </div>
-                  <div className="mt-2 grid gap-1 text-sm text-slate-600 dark:text-slate-300">
-                    <div>From {truncateBeamId(intent.from)}</div>
-                    <div>To {truncateBeamId(intent.to)}</div>
-                  </div>
+                  <div className="mt-2 text-sm font-medium">{alert.title}</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{alert.message}</div>
                 </div>
               ))
             )}
@@ -104,41 +181,4 @@ export default function OverviewPage() {
       </section>
     </div>
   )
-}
-
-function StatCard({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon: typeof Bot
-  label: string
-  value: string
-}) {
-  return (
-    <div className="panel">
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
-          <div className="mt-2 text-3xl font-semibold tracking-tight">{value}</div>
-        </div>
-        <div className="rounded-xl bg-orange-500/10 p-3 text-orange-500">
-          <Icon size={18} />
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function MiniStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-xl bg-slate-50 p-4 dark:bg-slate-950">
-      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
-      <div className="mt-1 text-xl font-semibold">{value}</div>
-    </div>
-  )
-}
-
-function EmptyState({ label }: { label: string }) {
-  return <div className="rounded-xl border border-dashed border-slate-200 p-6 text-sm text-slate-500 dark:border-slate-800 dark:text-slate-400">{label}</div>
 }

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -1,21 +1,36 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ApiError, DIRECTORY_URL, directoryApi, type DirectoryHealth } from '../lib/api'
+import { ApiError, DIRECTORY_URL, clearStoredAdminKey, directoryApi, getStoredAdminKey, hasStoredAdminKey, setStoredAdminKey, type DirectoryHealth, type RetentionResponse } from '../lib/api'
 
 const PRIVATE_KEY_PREFIX = 'beam-dashboard-private-key:'
 
 export default function SettingsPage() {
   const [health, setHealth] = useState<DirectoryHealth | null>(null)
+  const [retention, setRetention] = useState<RetentionResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [adminKey, setAdminKey] = useState(() => getStoredAdminKey())
+  const [adminStatus, setAdminStatus] = useState<string | null>(hasStoredAdminKey() ? 'Admin key stored locally.' : null)
 
   useEffect(() => {
     let cancelled = false
 
     async function load() {
       try {
-        const response = await directoryApi.getHealth()
-        if (!cancelled) {
-          setHealth(response)
+        const [healthResponse, retentionResponse] = await Promise.allSettled([
+          directoryApi.getHealth(),
+          directoryApi.getRetention(),
+        ])
+
+        if (cancelled) return
+
+        if (healthResponse.status === 'fulfilled') {
+          setHealth(healthResponse.value)
           setError(null)
+        } else if (healthResponse.reason instanceof ApiError) {
+          setError(healthResponse.reason.message)
+        }
+
+        if (retentionResponse.status === 'fulfilled') {
+          setRetention(retentionResponse.value)
         }
       } catch (err) {
         if (!cancelled) {
@@ -34,14 +49,34 @@ export default function SettingsPage() {
     return Object.keys(localStorage).filter((key) => key.startsWith(PRIVATE_KEY_PREFIX))
   }, [])
 
+  async function validateAdminKey() {
+    try {
+      setStoredAdminKey(adminKey)
+      await directoryApi.getObservabilityOverview(24)
+      setAdminStatus('Admin key validated against observability endpoints.')
+    } catch (err) {
+      setAdminStatus(err instanceof ApiError ? err.message : 'Admin validation failed')
+    }
+  }
+
+  function clearAdminKey() {
+    clearStoredAdminKey()
+    setAdminKey('')
+    setAdminStatus('Admin key removed from local storage.')
+  }
+
   return (
     <div className="space-y-6">
       <section>
         <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Operational status for the real API connection and browser-stored credentials.</p>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Connection health, admin auth, and browser-stored credentials for observability access.</p>
       </section>
 
-      {error && <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">{error}</div>}
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
 
       <section className="grid gap-4 lg:grid-cols-2">
         <div className="panel space-y-3">
@@ -54,8 +89,41 @@ export default function SettingsPage() {
         </div>
 
         <div className="panel space-y-3">
+          <div className="panel-title">Observability retention</div>
+          <InfoRow label="Default days" value={retention ? String(retention.defaultDays) : '—'} />
+          <InfoRow label="Datasets" value={retention?.datasets.join(', ') ?? '—'} />
+          <p className="text-sm text-slate-500 dark:text-slate-400">Retention controls in the Alerts page call the prune endpoint directly and do not rely on local cache.</p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="panel space-y-4">
+          <div className="panel-title">Admin access</div>
+          <input
+            className="input-field"
+            placeholder="Paste BEAM_ADMIN_KEY"
+            type="password"
+            value={adminKey}
+            onChange={(event) => setAdminKey(event.target.value)}
+          />
+          <div className="flex flex-wrap gap-3">
+            <button className="btn-primary" onClick={() => void validateAdminKey()} type="button">
+              Save & Validate
+            </button>
+            <button className="btn-secondary" onClick={clearAdminKey} type="button">
+              Clear
+            </button>
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            The admin key is stored in `localStorage` and attached to `/observability/*` requests as `X-Admin-Key`.
+          </p>
+          {adminStatus ? <p className="text-sm text-slate-600 dark:text-slate-300">{adminStatus}</p> : null}
+        </div>
+
+        <div className="panel space-y-3">
           <div className="panel-title">Browser storage</div>
           <InfoRow label="Stored private keys" value={String(storedKeys.length)} />
+          <InfoRow label="Admin key" value={hasStoredAdminKey() ? 'Stored' : 'Not stored'} />
           <p className="text-sm text-slate-500 dark:text-slate-400">Private keys generated on the Register page stay in `localStorage` for this browser profile only.</p>
         </div>
       </section>

--- a/packages/dashboard/src/pages/TraceDetailPage.tsx
+++ b/packages/dashboard/src/pages/TraceDetailPage.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { ApiError, directoryApi, type IntentTraceResponse } from '../lib/api'
+import { EmptyPanel, PageHeader, StatusPill } from '../components/Observability'
+import { alertSeverityColor, cn, formatDateTime, formatLatency, intentStatusColor, truncateBeamId } from '../lib/utils'
+
+export default function TraceDetailPage() {
+  const { nonce } = useParams<{ nonce: string }>()
+  const resolvedNonce = nonce ? decodeURIComponent(nonce) : null
+  const [trace, setTrace] = useState<IntentTraceResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!resolvedNonce) return
+    const nonceToLoad = resolvedNonce
+    let cancelled = false
+
+    async function load() {
+      try {
+        setLoading(true)
+        const response = await directoryApi.getIntentTrace(nonceToLoad)
+        if (cancelled) return
+        setTrace(response)
+        setError(null)
+      } catch (err) {
+        if (cancelled) return
+        setError(err instanceof ApiError ? err.message : 'Failed to load intent trace')
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [resolvedNonce])
+
+  if (loading) {
+    return <div className="panel">Loading trace…</div>
+  }
+
+  if (error || !trace) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+        {error ?? 'Trace not found'}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Trace"
+        description={`Nonce ${trace.intent.nonce}`}
+        actions={<Link className="btn-secondary" to="/intents">Back to intents</Link>}
+      />
+
+      <section className="grid gap-4 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel space-y-3">
+          <div className="panel-title">Intent Summary</div>
+          <InfoRow label="Intent type" value={trace.intent.intentType} />
+          <InfoRow label="From" value={trace.intent.from} mono />
+          <InfoRow label="To" value={trace.intent.to} mono />
+          <InfoRow label="Requested" value={formatDateTime(trace.intent.timestamp)} />
+          <InfoRow label="Completed" value={formatDateTime(trace.intent.completedAt)} />
+          <InfoRow label="Latency" value={formatLatency(trace.intent.roundTripLatencyMs)} />
+          <div className="pt-1">
+            <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium capitalize', intentStatusColor(trace.intent.status))}>
+              {trace.intent.status}
+            </span>
+            {trace.intent.errorCode ? <span className="ml-2 text-sm text-red-600 dark:text-red-400">{trace.intent.errorCode}</span> : null}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Linked Entities</div>
+          <div className="mt-4 space-y-4 text-sm">
+            <div>
+              <div className="text-slate-500 dark:text-slate-400">Source agent</div>
+              <Link className="font-medium text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/agents/${encodeURIComponent(trace.intent.from)}`}>
+                {truncateBeamId(trace.intent.from, 44)}
+              </Link>
+            </div>
+            <div>
+              <div className="text-slate-500 dark:text-slate-400">Target agent</div>
+              <Link className="font-medium text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/agents/${encodeURIComponent(trace.intent.to)}`}>
+                {truncateBeamId(trace.intent.to, 44)}
+              </Link>
+            </div>
+            <div>
+              <div className="text-slate-500 dark:text-slate-400">Trace stages</div>
+              <div className="mt-1 text-lg font-semibold">{trace.stages.length}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="panel-title">Lifecycle</div>
+        <div className="mt-5 space-y-4">
+          {trace.stages.length === 0 ? (
+            <EmptyPanel label="No structured trace events were recorded for this nonce." />
+          ) : (
+            trace.stages.map((stage, index) => (
+              <div key={`${stage.id}-${stage.stage}-${index}`} className="flex gap-4">
+                <div className="flex flex-col items-center">
+                  <div className={cn(
+                    'h-3 w-3 rounded-full',
+                    stage.status === 'success' ? 'bg-emerald-500' : stage.status === 'error' ? 'bg-red-500' : 'bg-orange-500',
+                  )} />
+                  {index < trace.stages.length - 1 ? <div className="mt-2 h-full w-px bg-slate-200 dark:bg-slate-800" /> : null}
+                </div>
+                <div className="min-w-0 flex-1 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <div className="font-medium capitalize">{stage.stage.split('.').join(' ')}</div>
+                    <StatusPill label={stage.status} tone={stage.status === 'success' ? 'success' : stage.status === 'error' ? 'critical' : 'warning'} />
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(stage.timestamp)}</span>
+                  </div>
+                  {stage.details ? (
+                    <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                      {JSON.stringify(stage.details, null, 2)}
+                    </pre>
+                  ) : null}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1fr,1fr]">
+        <div className="panel">
+          <div className="panel-title">Audit Context</div>
+          <div className="mt-4 space-y-3">
+            {trace.audit.length === 0 ? (
+              <EmptyPanel label="No related audit entries were matched to this nonce." />
+            ) : (
+              trace.audit.map((entry) => (
+                <div key={entry.id} className="rounded-xl border border-slate-200 p-3 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill label={entry.action} />
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(entry.timestamp)}</span>
+                  </div>
+                  <div className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                    {entry.actor} → {entry.target}
+                  </div>
+                  {entry.details ? (
+                    <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                      {JSON.stringify(entry.details, null, 2)}
+                    </pre>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Shield Context</div>
+          <div className="mt-4 space-y-3">
+            {trace.shield.length === 0 ? (
+              <EmptyPanel label="No shield audit entries were recorded for this nonce." />
+            ) : (
+              trace.shield.map((entry) => (
+                <div key={entry.id} className="rounded-xl border border-slate-200 p-3 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor((entry.riskScore ?? 0) >= 0.8 ? 'critical' : (entry.riskScore ?? 0) >= 0.65 ? 'warning' : 'info'))}>
+                      {entry.decision ?? 'unknown'}
+                    </span>
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(entry.createdAt)}</span>
+                  </div>
+                  <div className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                    Risk {entry.riskScore?.toFixed(2) ?? '—'} · {entry.intentType ?? 'unknown'} · {entry.payloadHash ?? 'no-hash'}
+                  </div>
+                  {entry.anomalyFlags.length > 0 ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {entry.anomalyFlags.map((flag) => (
+                        <StatusPill key={flag} label={flag} tone="warning" />
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function InfoRow({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
+      <div className={cn('mt-1 break-all text-sm font-medium', mono && 'font-mono')}>{value}</div>
+    </div>
+  )
+}

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -15,10 +15,12 @@ import type {
   FederatedTrustRow,
   IntentFrame,
   IntentLogRow,
+  IntentTraceEventRow,
   OrgAgentRow,
   OrgRow,
   ReportRow,
   RegisterRequest,
+  ShieldAuditLogRow,
   TrustScoreRow,
   VerificationTier,
 } from './types.js'
@@ -165,6 +167,24 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_intent_log_from_to
       ON intent_log(from_beam_id, to_beam_id);
+
+    CREATE TABLE IF NOT EXISTS intent_trace_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nonce TEXT NOT NULL,
+      from_beam_id TEXT NOT NULL,
+      to_beam_id TEXT NOT NULL,
+      intent_type TEXT NOT NULL,
+      stage TEXT NOT NULL,
+      status TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      details TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_intent_trace_nonce
+      ON intent_trace_events(nonce, timestamp ASC, id ASC);
+
+    CREATE INDEX IF NOT EXISTS idx_intent_trace_timestamp
+      ON intent_trace_events(timestamp DESC);
 
     CREATE TABLE IF NOT EXISTS trust_scores (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -333,6 +353,7 @@ function initSchema(db: DB): void {
 
     CREATE TABLE IF NOT EXISTS shield_audit_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
+      nonce TEXT,
       timestamp TEXT,
       sender_beam_id TEXT,
       sender_trust REAL,
@@ -347,6 +368,7 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_shield_audit_sender ON shield_audit_log(sender_beam_id);
     CREATE INDEX IF NOT EXISTS idx_shield_audit_created ON shield_audit_log(created_at);
+    CREATE INDEX IF NOT EXISTS idx_shield_audit_nonce ON shield_audit_log(nonce);
 
     CREATE TABLE IF NOT EXISTS pinned_keys (
       beam_id TEXT NOT NULL,
@@ -396,6 +418,8 @@ function initSchema(db: DB): void {
   // Create indexes that depend on ensureColumn'd columns
   db.exec(`CREATE INDEX IF NOT EXISTS idx_agents_verification_tier ON agents(verification_tier, trust_score DESC)`)
   ensureColumn(db, 'agents', 'personal', 'INTEGER NOT NULL DEFAULT 0')
+  ensureColumn(db, 'shield_audit_log', 'nonce', 'TEXT')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_shield_audit_nonce ON shield_audit_log(nonce)')
 
   db.prepare(`
     UPDATE agents
@@ -1438,6 +1462,56 @@ export function listRecentIntentLogs(db: DB, limit = 50): IntentLogRow[] {
   `).all(safeLimit) as IntentLogRow[]
 }
 
+export function appendIntentTraceEvent(
+  db: DB,
+  input: {
+    nonce: string
+    fromBeamId: string
+    toBeamId: string
+    intentType: string
+    stage: string
+    status: string
+    timestamp?: string
+    details?: unknown
+  },
+): IntentTraceEventRow {
+  const timestamp = input.timestamp ?? nowIso()
+  const details = input.details === undefined ? null : JSON.stringify(input.details)
+
+  const result = db.prepare(`
+    INSERT INTO intent_trace_events (
+      nonce,
+      from_beam_id,
+      to_beam_id,
+      intent_type,
+      stage,
+      status,
+      timestamp,
+      details
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.nonce,
+    input.fromBeamId,
+    input.toBeamId,
+    input.intentType,
+    input.stage,
+    input.status,
+    timestamp,
+    details,
+  )
+
+  return db.prepare('SELECT * FROM intent_trace_events WHERE id = ?').get(Number(result.lastInsertRowid)) as IntentTraceEventRow
+}
+
+export function listIntentTraceEvents(db: DB, nonce: string): IntentTraceEventRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM intent_trace_events
+    WHERE nonce = ?
+    ORDER BY timestamp ASC, id ASC
+  `).all(nonce) as IntentTraceEventRow[]
+}
+
 export function getAgentIntentStats(db: DB, beamId: string): AgentIntentStats {
   const row = db.prepare(`
     SELECT
@@ -1615,6 +1689,35 @@ export function listAuditLog(
     ORDER BY timestamp DESC, id DESC
     LIMIT ${limit}
   `).all(...params) as AuditLogRow[]
+}
+
+export function listShieldAuditLog(
+  db: DB,
+  query: { limit?: number; nonce?: string; senderBeamId?: string } = {}
+): ShieldAuditLogRow[] {
+  const limit = Math.max(1, Math.min(500, Math.trunc(query.limit ?? 100)))
+  const conditions: string[] = []
+  const params: string[] = []
+
+  if (query.nonce) {
+    conditions.push('nonce = ?')
+    params.push(query.nonce)
+  }
+
+  if (query.senderBeamId) {
+    conditions.push('sender_beam_id = ?')
+    params.push(query.senderBeamId)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  return db.prepare(`
+    SELECT *
+    FROM shield_audit_log
+    ${where}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `).all(...params) as ShieldAuditLogRow[]
 }
 
 export function getDnsCache(db: DB, cacheKey: string, recordType: string): DnsCacheRow | null {

--- a/packages/directory/src/observability-hooks.ts
+++ b/packages/directory/src/observability-hooks.ts
@@ -1,0 +1,117 @@
+import type { Database } from 'better-sqlite3'
+import { appendIntentTraceEvent, getAgent } from './db.js'
+import { hashPayload, logShieldEvent } from './shield/audit.js'
+import { sanitizeExternalMessage } from './shield/content-sandbox.js'
+import { AnomalyDetector } from './shield/anomaly.js'
+
+type TraceFrame = {
+  nonce: string
+  from: string
+  to: string
+  intent: string
+}
+
+type ShieldDecision = 'pass' | 'hold' | 'reject'
+
+type AnomalyDb = ConstructorParameters<typeof AnomalyDetector>[0]
+
+function severityToRiskScore(severity: 'low' | 'medium' | 'high' | 'critical'): number {
+  switch (severity) {
+    case 'critical':
+      return 1
+    case 'high':
+      return 0.8
+    case 'medium':
+      return 0.55
+    case 'low':
+      return 0.35
+    default:
+      return 0
+  }
+}
+
+function stringifyPayload(payload: unknown): string {
+  try {
+    return typeof payload === 'string' ? payload : JSON.stringify(payload ?? {})
+  } catch {
+    return String(payload)
+  }
+}
+
+export function recordIntentStage(
+  db: Database,
+  frame: TraceFrame,
+  stage: string,
+  status: string,
+  details?: unknown,
+  timestamp?: string,
+): void {
+  appendIntentTraceEvent(db, {
+    nonce: frame.nonce,
+    fromBeamId: frame.from,
+    toBeamId: frame.to,
+    intentType: frame.intent,
+    stage,
+    status,
+    details,
+    timestamp,
+  })
+}
+
+export function recordShieldDecision(
+  db: Database,
+  frame: TraceFrame & { payload: Record<string, unknown> },
+  options: {
+    decision?: ShieldDecision
+    extraFlags?: string[]
+    riskScore?: number
+    timestamp?: string
+  } = {},
+): ShieldDecision {
+  const payloadText = stringifyPayload(frame.payload)
+  const senderTrust = getAgent(db, frame.from)?.trust_score ?? 0.5
+  const sandboxResult = sanitizeExternalMessage(payloadText)
+  const anomalies = new AnomalyDetector(db as unknown as AnomalyDb).detectAll({
+    senderBeamId: frame.from,
+    intentType: frame.intent,
+    currentTrust: senderTrust,
+    responseSize: payloadText.length,
+  })
+
+  const anomalyRisk = anomalies.reduce((maxRisk, anomaly) => {
+    return Math.max(maxRisk, severityToRiskScore(anomaly.severity))
+  }, 0)
+
+  const riskScore = Math.max(
+    options.riskScore ?? 0,
+    sandboxResult.riskScore,
+    anomalyRisk,
+  )
+
+  const flags = [
+    ...sandboxResult.matchedPatterns,
+    ...anomalies.map((anomaly) => anomaly.type),
+    ...(options.extraFlags ?? []),
+  ]
+
+  const decision = options.decision ?? (
+    riskScore >= 0.65 || anomalies.some((anomaly) => anomaly.shouldAlert)
+      ? 'hold'
+      : 'pass'
+  )
+
+  logShieldEvent(db, {
+    nonce: frame.nonce,
+    timestamp: options.timestamp ?? new Date().toISOString(),
+    senderBeamId: frame.from,
+    senderTrust,
+    intentType: frame.intent,
+    payloadHash: hashPayload(frame.payload),
+    decision,
+    riskScore,
+    responseSize: payloadText.length,
+    anomalyFlags: flags,
+  })
+
+  return decision
+}

--- a/packages/directory/src/observability.test.ts
+++ b/packages/directory/src/observability.test.ts
@@ -1,0 +1,218 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { generateKeyPairSync } from 'node:crypto'
+import { createApp } from './server.js'
+import {
+  appendIntentTraceEvent,
+  createDatabase,
+  finalizeIntentLog,
+  logAuditEvent,
+  logIntentStart,
+  registerAgent,
+} from './db.js'
+import { logShieldEvent } from './shield/audit.js'
+import type { IntentFrame } from './types.js'
+
+function registerFixtureAgents(db: ReturnType<typeof createDatabase>) {
+  const senderKeys = generateKeyPairSync('ed25519')
+  const receiverKeys = generateKeyPairSync('ed25519')
+
+  registerAgent(db, {
+    beamId: 'sender@local.beam.directory',
+    displayName: 'Sender',
+    capabilities: ['demo.intent'],
+    publicKey: (senderKeys.publicKey.export({ type: 'spki', format: 'der' }) as Buffer).toString('base64'),
+    org: 'local',
+  })
+
+  registerAgent(db, {
+    beamId: 'receiver@local.beam.directory',
+    displayName: 'Receiver',
+    capabilities: ['demo.intent'],
+    publicKey: (receiverKeys.publicKey.export({ type: 'spki', format: 'der' }) as Buffer).toString('base64'),
+    org: 'local',
+  })
+}
+
+function createFrame(nonce: string, timestamp = new Date().toISOString()): IntentFrame {
+  return {
+    v: '1',
+    from: 'sender@local.beam.directory',
+    to: 'receiver@local.beam.directory',
+    intent: 'demo.intent',
+    payload: { ok: true },
+    nonce,
+    timestamp,
+    signature: 'signature',
+  }
+}
+
+test('observability trace endpoint returns lifecycle, audit, and shield context', async () => {
+  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
+  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
+
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const frame = createFrame('trace-nonce')
+
+    logIntentStart(db, frame)
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'received',
+      status: 'pending',
+      timestamp: frame.timestamp,
+    })
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'validated',
+      status: 'success',
+    })
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'completed',
+      status: 'success',
+    })
+    finalizeIntentLog(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      success: true,
+      latencyMs: 42,
+    })
+
+    logAuditEvent(db, {
+      action: 'federation.relay',
+      actor: 'https://peer.example',
+      target: frame.nonce,
+      details: { nonce: frame.nonce, intent: frame.intent },
+    })
+
+    logShieldEvent(db, {
+      nonce: frame.nonce,
+      timestamp: frame.timestamp,
+      senderBeamId: frame.from,
+      senderTrust: 0.5,
+      intentType: frame.intent,
+      payloadHash: 'abc123',
+      decision: 'hold',
+      riskScore: 0.75,
+      responseSize: 128,
+      anomalyFlags: ['rapid_sender_rate'],
+    })
+
+    const app = createApp(db)
+    const response = await app.request(new Request(`http://localhost/observability/intents/${encodeURIComponent(frame.nonce)}`, {
+      headers: { 'x-admin-key': 'test-admin' },
+    }))
+
+    assert.equal(response.status, 200)
+    const payload = await response.json() as {
+      intent: { nonce: string }
+      stages: Array<{ stage: string }>
+      audit: Array<{ action: string }>
+      shield: Array<{ decision: string }>
+    }
+
+    assert.equal(payload.intent.nonce, frame.nonce)
+    assert.deepEqual(payload.stages.map((stage) => stage.stage), ['received', 'validated', 'completed'])
+    assert.equal(payload.audit[0]?.action, 'federation.relay')
+    assert.equal(payload.shield[0]?.decision, 'hold')
+  } finally {
+    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
+    db.close()
+  }
+})
+
+test('alerts endpoint surfaces elevated error rate and error hotspots', async () => {
+  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
+  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
+
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+
+    for (let index = 0; index < 10; index += 1) {
+      const frame = createFrame(`error-${index}`)
+      logIntentStart(db, frame)
+      finalizeIntentLog(db, {
+        nonce: frame.nonce,
+        fromBeamId: frame.from,
+        toBeamId: frame.to,
+        success: false,
+        latencyMs: 3200,
+        errorCode: 'TIMEOUT',
+      })
+    }
+
+    const app = createApp(db)
+    const response = await app.request(new Request('http://localhost/observability/alerts?hours=24', {
+      headers: { 'x-admin-key': 'test-admin' },
+    }))
+
+    assert.equal(response.status, 200)
+    const payload = await response.json() as { alerts: Array<{ id: string }> }
+
+    assert.ok(payload.alerts.some((alert) => alert.id === 'network-error-rate'))
+    assert.ok(payload.alerts.some((alert) => alert.id === 'error-hotspot-timeout'))
+  } finally {
+    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
+    db.close()
+  }
+})
+
+test('prune endpoint removes aged intents and trace records', async () => {
+  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
+  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
+
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const oldTimestamp = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
+    const frame = createFrame('old-intent', oldTimestamp)
+
+    logIntentStart(db, frame)
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'received',
+      status: 'pending',
+      timestamp: oldTimestamp,
+    })
+
+    const app = createApp(db)
+    const response = await app.request(new Request('http://localhost/observability/prune', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-admin-key': 'test-admin',
+      },
+      body: JSON.stringify({ dataset: 'intents', olderThanDays: 30 }),
+    }))
+
+    assert.equal(response.status, 200)
+    const payload = await response.json() as { deleted: number; intents: number; traces: number }
+    assert.equal(payload.intents, 1)
+    assert.equal(payload.traces, 1)
+    assert.equal(payload.deleted, 2)
+
+    const remainingIntents = db.prepare('SELECT COUNT(*) AS count FROM intent_log').get() as { count: number }
+    const remainingTraces = db.prepare('SELECT COUNT(*) AS count FROM intent_trace_events').get() as { count: number }
+    assert.equal(remainingIntents.count, 0)
+    assert.equal(remainingTraces.count, 0)
+  } finally {
+    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
+    db.close()
+  }
+})

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -1,0 +1,1327 @@
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+import type { Database } from 'better-sqlite3'
+import { getAgent, listAuditLog, listIntentTraceEvents, listShieldAuditLog } from '../db.js'
+import type {
+  AuditLogRow,
+  FederationPeerRow,
+  IntentLogRow,
+  IntentTraceEventRow,
+  ShieldAuditLogRow,
+} from '../types.js'
+
+type BindValue = string | number | null
+type AlertSeverity = 'info' | 'warning' | 'critical'
+
+type AlertItem = {
+  id: string
+  severity: AlertSeverity
+  title: string
+  scope: 'network' | 'agent' | 'federation' | 'shield'
+  message: string
+  metric: string
+  value: number
+  threshold: number
+  startedAt: string
+}
+
+type IntentQuery = {
+  q?: string
+  fromBeamId?: string
+  toBeamId?: string
+  intentType?: string
+  status?: string
+  errorCode?: string
+  limit: number
+  sinceHours?: number
+}
+
+const DEFAULT_RETENTION_DAYS = Math.max(1, Number.parseInt(process.env['BEAM_OBSERVABILITY_RETENTION_DAYS'] ?? '30', 10) || 30)
+
+function getSuppliedAdminKey(c: Context): string {
+  const header = c.req.header('x-admin-key') ?? ''
+  if (header) {
+    return header
+  }
+
+  const authorization = c.req.header('authorization') ?? ''
+  if (authorization.toLowerCase().startsWith('bearer ')) {
+    return authorization.slice(7).trim()
+  }
+
+  return c.req.query('key') ?? ''
+}
+
+function requireAdmin(c: Context): Response | null {
+  const configuredKey = process.env['BEAM_ADMIN_KEY'] ?? ''
+  if (!configuredKey) {
+    return c.json({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }, 503)
+  }
+
+  const suppliedKey = getSuppliedAdminKey(c)
+  if (!suppliedKey || suppliedKey !== configuredKey) {
+    return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
+  }
+
+  return null
+}
+
+function parseLimit(value: string | undefined, fallback: number, max = 500): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isFinite(parsed)) {
+    return fallback
+  }
+
+  return Math.max(1, Math.min(max, parsed))
+}
+
+function parseHours(value: string | undefined, fallback: number, max = 24 * 90): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isFinite(parsed)) {
+    return fallback
+  }
+
+  return Math.max(1, Math.min(max, parsed))
+}
+
+function parseDays(value: string | undefined, fallback: number, max = 3650): number {
+  const parsed = Number.parseInt(value ?? '', 10)
+  if (!Number.isFinite(parsed)) {
+    return fallback
+  }
+
+  return Math.max(1, Math.min(max, parsed))
+}
+
+function round(value: number, digits = 2): number {
+  const factor = 10 ** digits
+  return Math.round(value * factor) / factor
+}
+
+function nowMinusHours(hours: number): string {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString()
+}
+
+function nowMinusDays(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function parseJson<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) {
+    return fallback
+  }
+
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return fallback
+  }
+}
+
+function percentile(values: number[], pct: number): number | null {
+  if (values.length === 0) {
+    return null
+  }
+
+  const sorted = [...values].sort((left, right) => left - right)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * pct) - 1))
+  return sorted[index] ?? null
+}
+
+function bucketSizeHours(windowHours: number): number {
+  if (windowHours <= 24) {
+    return 1
+  }
+
+  if (windowHours <= 24 * 7) {
+    return 6
+  }
+
+  return 24
+}
+
+function toBucketStart(isoTimestamp: string, bucketHours: number): string {
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    return isoTimestamp
+  }
+
+  const utcHours = date.getUTCHours()
+  const snappedHours = Math.floor(utcHours / bucketHours) * bucketHours
+  date.setUTCMinutes(0, 0, 0)
+  date.setUTCHours(snappedHours)
+  return date.toISOString()
+}
+
+function serializeIntentRow(row: IntentLogRow) {
+  return {
+    nonce: row.nonce,
+    from: row.from_beam_id,
+    to: row.to_beam_id,
+    intentType: row.intent_type,
+    timestamp: row.requested_at,
+    completedAt: row.completed_at,
+    roundTripLatencyMs: row.round_trip_latency_ms,
+    status: row.status,
+    errorCode: row.error_code,
+  }
+}
+
+function serializeTraceEvent(row: IntentTraceEventRow) {
+  return {
+    id: row.id,
+    nonce: row.nonce,
+    from: row.from_beam_id,
+    to: row.to_beam_id,
+    intentType: row.intent_type,
+    stage: row.stage,
+    status: row.status,
+    timestamp: row.timestamp,
+    details: parseJson<Record<string, unknown> | null>(row.details, null),
+  }
+}
+
+function serializeAuditRow(row: AuditLogRow) {
+  return {
+    id: row.id,
+    action: row.action,
+    actor: row.actor,
+    target: row.target,
+    timestamp: row.timestamp,
+    details: parseJson<Record<string, unknown> | null>(row.details, null),
+  }
+}
+
+function serializeShieldRow(row: ShieldAuditLogRow) {
+  return {
+    id: row.id,
+    nonce: row.nonce,
+    timestamp: row.timestamp,
+    senderBeamId: row.sender_beam_id,
+    senderTrust: row.sender_trust,
+    intentType: row.intent_type,
+    payloadHash: row.payload_hash,
+    decision: row.decision,
+    riskScore: row.risk_score,
+    responseSize: row.response_size,
+    anomalyFlags: parseJson<string[]>(row.anomaly_flags, []),
+    createdAt: row.created_at,
+  }
+}
+
+function buildIntentWhereClause(query: IntentQuery): { whereClause: string; params: BindValue[] } {
+  const conditions: string[] = []
+  const params: BindValue[] = []
+
+  if (query.fromBeamId) {
+    conditions.push('from_beam_id = ?')
+    params.push(query.fromBeamId)
+  }
+
+  if (query.toBeamId) {
+    conditions.push('to_beam_id = ?')
+    params.push(query.toBeamId)
+  }
+
+  if (query.intentType) {
+    conditions.push('intent_type = ?')
+    params.push(query.intentType)
+  }
+
+  if (query.status && query.status !== 'all') {
+    conditions.push('status = ?')
+    params.push(query.status)
+  }
+
+  if (query.errorCode) {
+    conditions.push('error_code = ?')
+    params.push(query.errorCode)
+  }
+
+  if (query.q) {
+    const like = `%${query.q}%`
+    conditions.push('(nonce LIKE ? OR from_beam_id LIKE ? OR to_beam_id LIKE ? OR intent_type LIKE ? OR COALESCE(error_code, \'\') LIKE ?)')
+    params.push(like, like, like, like, like)
+  }
+
+  if (query.sinceHours) {
+    conditions.push('requested_at >= ?')
+    params.push(nowMinusHours(query.sinceHours))
+  }
+
+  return {
+    whereClause: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  }
+}
+
+function searchIntentRows(db: Database, query: IntentQuery): { intents: IntentLogRow[]; total: number } {
+  const { whereClause, params } = buildIntentWhereClause(query)
+  const totalRow = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM intent_log
+    ${whereClause}
+  `).get(...params) as { count: number } | undefined
+
+  const intents = db.prepare(`
+    SELECT *
+    FROM intent_log
+    ${whereClause}
+    ORDER BY requested_at DESC, id DESC
+    LIMIT ${query.limit}
+  `).all(...params) as IntentLogRow[]
+
+  return { intents, total: totalRow?.count ?? intents.length }
+}
+
+function searchAuditRows(
+  db: Database,
+  query: { limit: number; action?: string; actor?: string; target?: string; q?: string; sinceHours?: number },
+): { entries: AuditLogRow[]; total: number } {
+  const conditions: string[] = []
+  const params: BindValue[] = []
+
+  if (query.action) {
+    conditions.push('action = ?')
+    params.push(query.action)
+  }
+
+  if (query.actor) {
+    conditions.push('actor = ?')
+    params.push(query.actor)
+  }
+
+  if (query.target) {
+    conditions.push('target = ?')
+    params.push(query.target)
+  }
+
+  if (query.q) {
+    const like = `%${query.q}%`
+    conditions.push('(action LIKE ? OR actor LIKE ? OR target LIKE ? OR COALESCE(details, \'\') LIKE ?)')
+    params.push(like, like, like, like)
+  }
+
+  if (query.sinceHours) {
+    conditions.push('timestamp >= ?')
+    params.push(nowMinusHours(query.sinceHours))
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  const totalRow = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM audit_log
+    ${whereClause}
+  `).get(...params) as { count: number } | undefined
+
+  const entries = db.prepare(`
+    SELECT *
+    FROM audit_log
+    ${whereClause}
+    ORDER BY timestamp DESC, id DESC
+    LIMIT ${query.limit}
+  `).all(...params) as AuditLogRow[]
+
+  return { entries, total: totalRow?.count ?? entries.length }
+}
+
+function buildOverviewPayload(db: Database, windowHours: number) {
+  const since = nowMinusHours(windowHours)
+  const rows = db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE requested_at >= ?
+    ORDER BY requested_at ASC, id ASC
+  `).all(since) as IntentLogRow[]
+
+  const bucketHours = bucketSizeHours(windowHours)
+  const bucketMap = new Map<string, {
+    bucketStart: string
+    total: number
+    success: number
+    error: number
+    pending: number
+    latencies: number[]
+  }>()
+
+  const intentTypeMap = new Map<string, {
+    intentType: string
+    total: number
+    errors: number
+    latencies: number[]
+  }>()
+
+  const errorCodeMap = new Map<string, {
+    errorCode: string
+    count: number
+    lastSeenAt: string
+  }>()
+
+  const latencies = rows
+    .map((row) => row.round_trip_latency_ms)
+    .filter((value): value is number => typeof value === 'number')
+
+  for (const row of rows) {
+    const bucketStart = toBucketStart(row.requested_at, bucketHours)
+    const bucket = bucketMap.get(bucketStart) ?? {
+      bucketStart,
+      total: 0,
+      success: 0,
+      error: 0,
+      pending: 0,
+      latencies: [],
+    }
+    bucket.total += 1
+    if (row.status === 'success') {
+      bucket.success += 1
+    } else if (row.status === 'error') {
+      bucket.error += 1
+    } else {
+      bucket.pending += 1
+    }
+    if (typeof row.round_trip_latency_ms === 'number') {
+      bucket.latencies.push(row.round_trip_latency_ms)
+    }
+    bucketMap.set(bucketStart, bucket)
+
+    const intentEntry = intentTypeMap.get(row.intent_type) ?? {
+      intentType: row.intent_type,
+      total: 0,
+      errors: 0,
+      latencies: [],
+    }
+    intentEntry.total += 1
+    if (row.status === 'error') {
+      intentEntry.errors += 1
+    }
+    if (typeof row.round_trip_latency_ms === 'number') {
+      intentEntry.latencies.push(row.round_trip_latency_ms)
+    }
+    intentTypeMap.set(row.intent_type, intentEntry)
+
+    if (row.error_code) {
+      const errorEntry = errorCodeMap.get(row.error_code) ?? {
+        errorCode: row.error_code,
+        count: 0,
+        lastSeenAt: row.requested_at,
+      }
+      errorEntry.count += 1
+      if (row.requested_at > errorEntry.lastSeenAt) {
+        errorEntry.lastSeenAt = row.requested_at
+      }
+      errorCodeMap.set(row.error_code, errorEntry)
+    }
+  }
+
+  const totalAgents = (db.prepare('SELECT COUNT(*) AS count FROM agents').get() as { count: number } | undefined)?.count ?? 0
+  const liveAgents = (db.prepare('SELECT COUNT(*) AS count FROM agents WHERE last_seen >= ?').get(nowMinusHours(1)) as { count: number } | undefined)?.count ?? 0
+  const staleAgents = (db.prepare('SELECT COUNT(*) AS count FROM agents WHERE last_seen < ?').get(nowMinusHours(24)) as { count: number } | undefined)?.count ?? 0
+  const federatedAgents = (db.prepare('SELECT COUNT(*) AS count FROM federated_agents').get() as { count: number } | undefined)?.count ?? 0
+  const federationPeers = (db.prepare('SELECT COUNT(*) AS count FROM federation_peers').get() as { count: number } | undefined)?.count ?? 0
+
+  const pendingOlderThan15m = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM intent_log
+    WHERE status = 'pending' AND requested_at < ?
+  `).get(new Date(Date.now() - 15 * 60 * 1000).toISOString()) as { count: number } | undefined)?.count ?? 0
+
+  const timeline = Array.from(bucketMap.values())
+    .sort((left, right) => left.bucketStart.localeCompare(right.bucketStart))
+    .map((bucket) => ({
+      bucketStart: bucket.bucketStart,
+      total: bucket.total,
+      success: bucket.success,
+      error: bucket.error,
+      pending: bucket.pending,
+      p95LatencyMs: percentile(bucket.latencies, 0.95),
+    }))
+
+  const summary = {
+    totalAgents,
+    liveAgents,
+    staleAgents,
+    federatedAgents,
+    federationPeers,
+    totalIntents: rows.length,
+    successCount: rows.filter((row) => row.status === 'success').length,
+    errorCount: rows.filter((row) => row.status === 'error').length,
+    pendingCount: rows.filter((row) => row.status === 'pending').length,
+    avgLatencyMs: latencies.length > 0 ? round(latencies.reduce((sum, value) => sum + value, 0) / latencies.length) : null,
+    p95LatencyMs: percentile(latencies, 0.95),
+    successRate: rows.length > 0 ? round(rows.filter((row) => row.status === 'success').length / rows.length, 4) : 0,
+    pendingOlderThan15m,
+  }
+
+  return {
+    windowHours,
+    summary,
+    timeline,
+    topIntents: Array.from(intentTypeMap.values())
+      .sort((left, right) => right.total - left.total)
+      .slice(0, 8)
+      .map((entry) => ({
+        intentType: entry.intentType,
+        total: entry.total,
+        errors: entry.errors,
+        avgLatencyMs: entry.latencies.length > 0 ? round(entry.latencies.reduce((sum, value) => sum + value, 0) / entry.latencies.length) : null,
+      })),
+    topErrors: Array.from(errorCodeMap.values())
+      .sort((left, right) => right.count - left.count)
+      .slice(0, 8),
+  }
+}
+
+function buildAgentHealthPayload(db: Database, beamId: string, windowHours: number) {
+  const agent = getAgent(db, beamId)
+  if (!agent) {
+    return null
+  }
+
+  const since = nowMinusHours(windowHours)
+  const rows = db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE requested_at >= ? AND (from_beam_id = ? OR to_beam_id = ?)
+    ORDER BY requested_at ASC, id ASC
+  `).all(since, beamId, beamId) as IntentLogRow[]
+
+  const outbound = rows.filter((row) => row.from_beam_id === beamId)
+  const inbound = rows.filter((row) => row.to_beam_id === beamId)
+  const completed = rows.filter((row) => row.status !== 'pending')
+  const latencies = completed
+    .map((row) => row.round_trip_latency_ms)
+    .filter((value): value is number => typeof value === 'number')
+
+  const bucketHours = bucketSizeHours(windowHours)
+  const timelineMap = new Map<string, {
+    bucketStart: string
+    sent: number
+    received: number
+    success: number
+    error: number
+    latencies: number[]
+  }>()
+
+  const counterpartyMap = new Map<string, {
+    beamId: string
+    outbound: number
+    inbound: number
+    errors: number
+  }>()
+
+  const intentTypeMap = new Map<string, {
+    intentType: string
+    total: number
+    errors: number
+    latencies: number[]
+  }>()
+
+  const errorMap = new Map<string, {
+    errorCode: string
+    count: number
+    lastSeenAt: string
+  }>()
+
+  for (const row of rows) {
+    const bucketStart = toBucketStart(row.requested_at, bucketHours)
+    const bucket = timelineMap.get(bucketStart) ?? {
+      bucketStart,
+      sent: 0,
+      received: 0,
+      success: 0,
+      error: 0,
+      latencies: [],
+    }
+    if (row.from_beam_id === beamId) {
+      bucket.sent += 1
+    }
+    if (row.to_beam_id === beamId) {
+      bucket.received += 1
+    }
+    if (row.status === 'success') {
+      bucket.success += 1
+    }
+    if (row.status === 'error') {
+      bucket.error += 1
+    }
+    if (typeof row.round_trip_latency_ms === 'number') {
+      bucket.latencies.push(row.round_trip_latency_ms)
+    }
+    timelineMap.set(bucketStart, bucket)
+
+    const counterpartyBeamId = row.from_beam_id === beamId ? row.to_beam_id : row.from_beam_id
+    const counterparty = counterpartyMap.get(counterpartyBeamId) ?? {
+      beamId: counterpartyBeamId,
+      outbound: 0,
+      inbound: 0,
+      errors: 0,
+    }
+    if (row.from_beam_id === beamId) {
+      counterparty.outbound += 1
+    } else {
+      counterparty.inbound += 1
+    }
+    if (row.status === 'error') {
+      counterparty.errors += 1
+    }
+    counterpartyMap.set(counterpartyBeamId, counterparty)
+
+    const intentEntry = intentTypeMap.get(row.intent_type) ?? {
+      intentType: row.intent_type,
+      total: 0,
+      errors: 0,
+      latencies: [],
+    }
+    intentEntry.total += 1
+    if (row.status === 'error') {
+      intentEntry.errors += 1
+    }
+    if (typeof row.round_trip_latency_ms === 'number') {
+      intentEntry.latencies.push(row.round_trip_latency_ms)
+    }
+    intentTypeMap.set(row.intent_type, intentEntry)
+
+    if (row.error_code) {
+      const errorEntry = errorMap.get(row.error_code) ?? {
+        errorCode: row.error_code,
+        count: 0,
+        lastSeenAt: row.requested_at,
+      }
+      errorEntry.count += 1
+      if (row.requested_at > errorEntry.lastSeenAt) {
+        errorEntry.lastSeenAt = row.requested_at
+      }
+      errorMap.set(row.error_code, errorEntry)
+    }
+  }
+
+  const currentPeriod = new Date().toISOString().slice(0, 7)
+  const usage = db.prepare(`
+    SELECT intent_count, encrypted_count, direct_count, relayed_count
+    FROM usage_metering
+    WHERE beam_id = ? AND period = ?
+  `).get(beamId, currentPeriod) as {
+    intent_count: number
+    encrypted_count: number
+    direct_count: number
+    relayed_count: number
+  } | undefined
+
+  const shieldRows = listShieldAuditLog(db, { senderBeamId: beamId, limit: 500 })
+    .filter((row) => row.created_at >= since)
+
+  return {
+    beamId,
+    windowHours,
+    summary: {
+      beamId,
+      displayName: agent.display_name,
+      trustScore: agent.trust_score,
+      verificationTier: agent.verification_tier,
+      lastSeen: agent.last_seen,
+      sentCount: outbound.length,
+      receivedCount: inbound.length,
+      completedCount: completed.length,
+      successRate: completed.length > 0 ? round(completed.filter((row) => row.status === 'success').length / completed.length, 4) : 0,
+      errorRate: completed.length > 0 ? round(completed.filter((row) => row.status === 'error').length / completed.length, 4) : 0,
+      avgLatencyMs: latencies.length > 0 ? round(latencies.reduce((sum, value) => sum + value, 0) / latencies.length) : null,
+      p95LatencyMs: percentile(latencies, 0.95),
+      uniqueCounterparties: counterpartyMap.size,
+    },
+    timeline: Array.from(timelineMap.values())
+      .sort((left, right) => left.bucketStart.localeCompare(right.bucketStart))
+      .map((bucket) => ({
+        bucketStart: bucket.bucketStart,
+        sent: bucket.sent,
+        received: bucket.received,
+        success: bucket.success,
+        error: bucket.error,
+        p95LatencyMs: percentile(bucket.latencies, 0.95),
+      })),
+    counterparties: Array.from(counterpartyMap.values())
+      .sort((left, right) => (right.inbound + right.outbound) - (left.inbound + left.outbound))
+      .slice(0, 10),
+    intents: Array.from(intentTypeMap.values())
+      .sort((left, right) => right.total - left.total)
+      .slice(0, 10)
+      .map((entry) => ({
+        intentType: entry.intentType,
+        total: entry.total,
+        errors: entry.errors,
+        avgLatencyMs: entry.latencies.length > 0 ? round(entry.latencies.reduce((sum, value) => sum + value, 0) / entry.latencies.length) : null,
+      })),
+    errors: Array.from(errorMap.values())
+      .sort((left, right) => right.count - left.count)
+      .slice(0, 10),
+    usage: {
+      period: currentPeriod,
+      intentCount: usage?.intent_count ?? 0,
+      encryptedCount: usage?.encrypted_count ?? 0,
+      directCount: usage?.direct_count ?? 0,
+      relayedCount: usage?.relayed_count ?? 0,
+    },
+    shield: {
+      total: shieldRows.length,
+      passed: shieldRows.filter((row) => row.decision === 'pass').length,
+      held: shieldRows.filter((row) => row.decision === 'hold').length,
+      rejected: shieldRows.filter((row) => row.decision === 'reject').length,
+      highRiskCount: shieldRows.filter((row) => (row.risk_score ?? 0) >= 0.65).length,
+    },
+  }
+}
+
+function buildFederationPayload(db: Database) {
+  const peerRows = db.prepare(`
+    SELECT *
+    FROM federation_peers
+    ORDER BY trust_level DESC, directory_url ASC
+  `).all() as FederationPeerRow[]
+
+  const cachedRows = db.prepare(`
+    SELECT home_directory_url, COUNT(*) AS cached_agents, MAX(cached_at) AS last_cached_at
+    FROM federated_agents
+    GROUP BY home_directory_url
+  `).all() as Array<{ home_directory_url: string; cached_agents: number; last_cached_at: string | null }>
+
+  const trustRows = db.prepare(`
+    SELECT
+      source_directory_url,
+      COUNT(*) AS trust_assertions,
+      AVG(effective_trust) AS avg_effective_trust,
+      MAX(asserted_at) AS last_asserted_at
+    FROM federated_trust
+    GROUP BY source_directory_url
+  `).all() as Array<{
+    source_directory_url: string
+    trust_assertions: number
+    avg_effective_trust: number | null
+    last_asserted_at: string | null
+  }>
+
+  const trustByPeer = new Map(trustRows.map((row) => [row.source_directory_url, row]))
+  const cacheByPeer = new Map(cachedRows.map((row) => [row.home_directory_url, row]))
+  const staleCutoff = nowMinusHours(24)
+
+  const peers = peerRows.map((peer) => {
+    const cache = cacheByPeer.get(peer.directory_url)
+    const trust = trustByPeer.get(peer.directory_url)
+    const stale = !peer.last_seen || peer.last_seen < staleCutoff || peer.status !== 'active'
+
+    return {
+      id: peer.id,
+      directoryUrl: peer.directory_url,
+      trustLevel: peer.trust_level,
+      status: peer.status,
+      createdAt: peer.created_at,
+      lastSeen: peer.last_seen,
+      syncedAt: peer.synced_at,
+      cachedAgents: cache?.cached_agents ?? 0,
+      lastCachedAt: cache?.last_cached_at ?? null,
+      trustAssertions: trust?.trust_assertions ?? 0,
+      avgEffectiveTrust: trust?.avg_effective_trust == null ? null : round(trust.avg_effective_trust, 4),
+      lastAssertedAt: trust?.last_asserted_at ?? null,
+      stale,
+    }
+  })
+
+  const federatedAgents = db.prepare(`
+    SELECT
+      fa.beam_id,
+      fa.home_directory_url,
+      fa.cached_at,
+      fa.ttl,
+      MAX(ft.effective_trust) AS effective_trust
+    FROM federated_agents fa
+    LEFT JOIN federated_trust ft ON ft.beam_id = fa.beam_id
+    GROUP BY fa.beam_id, fa.home_directory_url, fa.cached_at, fa.ttl
+    ORDER BY fa.cached_at DESC
+    LIMIT 20
+  `).all() as Array<{
+    beam_id: string
+    home_directory_url: string
+    cached_at: string
+    ttl: number
+    effective_trust: number | null
+  }>
+
+  const totalCachedAgents = cachedRows.reduce((sum, row) => sum + row.cached_agents, 0)
+
+  return {
+    summary: {
+      peerCount: peers.length,
+      activePeers: peers.filter((peer) => peer.status === 'active' && !peer.stale).length,
+      stalePeers: peers.filter((peer) => peer.stale).length,
+      cachedAgents: totalCachedAgents,
+      trustAssertions: trustRows.reduce((sum, row) => sum + row.trust_assertions, 0),
+      avgPeerTrust: peers.length > 0 ? round(peers.reduce((sum, peer) => sum + peer.trustLevel, 0) / peers.length, 4) : 0,
+    },
+    peers,
+    agents: federatedAgents.map((agent) => ({
+      beamId: agent.beam_id,
+      directoryUrl: agent.home_directory_url,
+      cachedAt: agent.cached_at,
+      ttl: agent.ttl,
+      effectiveTrust: agent.effective_trust == null ? null : round(agent.effective_trust, 4),
+    })),
+  }
+}
+
+function buildErrorsPayload(db: Database, windowHours: number) {
+  const since = nowMinusHours(windowHours)
+  const rows = db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE status = 'error' AND requested_at >= ?
+    ORDER BY requested_at ASC, id ASC
+  `).all(since) as IntentLogRow[]
+
+  const bucketHours = bucketSizeHours(windowHours)
+  const timelineMap = new Map<string, { bucketStart: string; total: number }>()
+  const codeMap = new Map<string, {
+    errorCode: string
+    count: number
+    lastSeenAt: string
+    latencies: number[]
+    senders: Set<string>
+    recipients: Set<string>
+  }>()
+  const routeMap = new Map<string, { route: string; count: number }>()
+
+  for (const row of rows) {
+    const bucketStart = toBucketStart(row.requested_at, bucketHours)
+    const bucket = timelineMap.get(bucketStart) ?? { bucketStart, total: 0 }
+    bucket.total += 1
+    timelineMap.set(bucketStart, bucket)
+
+    const errorCode = row.error_code ?? 'UNKNOWN'
+    const codeEntry = codeMap.get(errorCode) ?? {
+      errorCode,
+      count: 0,
+      lastSeenAt: row.requested_at,
+      latencies: [],
+      senders: new Set<string>(),
+      recipients: new Set<string>(),
+    }
+    codeEntry.count += 1
+    if (row.requested_at > codeEntry.lastSeenAt) {
+      codeEntry.lastSeenAt = row.requested_at
+    }
+    if (typeof row.round_trip_latency_ms === 'number') {
+      codeEntry.latencies.push(row.round_trip_latency_ms)
+    }
+    codeEntry.senders.add(row.from_beam_id)
+    codeEntry.recipients.add(row.to_beam_id)
+    codeMap.set(errorCode, codeEntry)
+
+    const routeKey = `${row.from_beam_id} → ${row.to_beam_id}`
+    const route = routeMap.get(routeKey) ?? { route: routeKey, count: 0 }
+    route.count += 1
+    routeMap.set(routeKey, route)
+  }
+
+  return {
+    windowHours,
+    summary: {
+      totalErrors: rows.length,
+      distinctErrorCodes: codeMap.size,
+      timeoutCount: rows.filter((row) => row.error_code === 'TIMEOUT').length,
+      offlineCount: rows.filter((row) => row.error_code === 'OFFLINE').length,
+      deliveryFailedCount: rows.filter((row) => row.error_code === 'DELIVERY_FAILED').length,
+    },
+    timeline: Array.from(timelineMap.values()).sort((left, right) => left.bucketStart.localeCompare(right.bucketStart)),
+    codes: Array.from(codeMap.values())
+      .sort((left, right) => right.count - left.count)
+      .map((entry) => ({
+        errorCode: entry.errorCode,
+        count: entry.count,
+        lastSeenAt: entry.lastSeenAt,
+        avgLatencyMs: entry.latencies.length > 0 ? round(entry.latencies.reduce((sum, value) => sum + value, 0) / entry.latencies.length) : null,
+        affectedSenders: entry.senders.size,
+        affectedRecipients: entry.recipients.size,
+      })),
+    routes: Array.from(routeMap.values())
+      .sort((left, right) => right.count - left.count)
+      .slice(0, 10),
+  }
+}
+
+function buildAlerts(db: Database, windowHours: number): AlertItem[] {
+  const overview = buildOverviewPayload(db, windowHours)
+  const errors = buildErrorsPayload(db, windowHours)
+  const federation = buildFederationPayload(db)
+  const alerts: AlertItem[] = []
+
+  const completedCount = overview.summary.successCount + overview.summary.errorCount
+  const errorRate = completedCount > 0 ? overview.summary.errorCount / completedCount : 0
+  if (completedCount >= 10 && errorRate >= 0.1) {
+    alerts.push({
+      id: 'network-error-rate',
+      severity: errorRate >= 0.25 ? 'critical' : 'warning',
+      title: 'Error rate exceeded threshold',
+      scope: 'network',
+      message: `${Math.round(errorRate * 100)}% of completed intents failed in the selected window.`,
+      metric: 'error_rate',
+      value: round(errorRate, 4),
+      threshold: 0.1,
+      startedAt: new Date().toISOString(),
+    })
+  }
+
+  if ((overview.summary.p95LatencyMs ?? 0) >= 2000) {
+    alerts.push({
+      id: 'network-latency-p95',
+      severity: (overview.summary.p95LatencyMs ?? 0) >= 5000 ? 'critical' : 'warning',
+      title: 'p95 latency is elevated',
+      scope: 'network',
+      message: `p95 intent latency is ${overview.summary.p95LatencyMs}ms.`,
+      metric: 'p95_latency_ms',
+      value: overview.summary.p95LatencyMs ?? 0,
+      threshold: 2000,
+      startedAt: new Date().toISOString(),
+    })
+  }
+
+  if (overview.summary.pendingOlderThan15m > 0) {
+    alerts.push({
+      id: 'network-pending-backlog',
+      severity: overview.summary.pendingOlderThan15m >= 5 ? 'critical' : 'warning',
+      title: 'Pending intent backlog detected',
+      scope: 'network',
+      message: `${overview.summary.pendingOlderThan15m} intents have been pending for more than 15 minutes.`,
+      metric: 'pending_older_than_15m',
+      value: overview.summary.pendingOlderThan15m,
+      threshold: 1,
+      startedAt: new Date().toISOString(),
+    })
+  }
+
+  if (federation.summary.stalePeers > 0) {
+    alerts.push({
+      id: 'federation-stale-peers',
+      severity: federation.summary.stalePeers >= 2 ? 'critical' : 'warning',
+      title: 'Federation peers are stale',
+      scope: 'federation',
+      message: `${federation.summary.stalePeers} peer directories have stale sync or heartbeat data.`,
+      metric: 'stale_peers',
+      value: federation.summary.stalePeers,
+      threshold: 1,
+      startedAt: new Date().toISOString(),
+    })
+  }
+
+  const shieldRow = db.prepare(`
+    SELECT
+      SUM(CASE WHEN decision = 'reject' THEN 1 ELSE 0 END) AS rejected,
+      SUM(CASE WHEN decision = 'hold' THEN 1 ELSE 0 END) AS held
+    FROM shield_audit_log
+    WHERE created_at >= ?
+  `).get(nowMinusHours(windowHours)) as { rejected: number | null; held: number | null } | undefined
+
+  const rejected = shieldRow?.rejected ?? 0
+  const held = shieldRow?.held ?? 0
+  if (rejected >= 3 || held >= 5) {
+    alerts.push({
+      id: 'shield-review-load',
+      severity: rejected >= 5 ? 'critical' : 'warning',
+      title: 'Shield is flagging elevated traffic',
+      scope: 'shield',
+      message: `${rejected} rejects and ${held} holds were recorded in the selected window.`,
+      metric: 'shield_flagged_events',
+      value: rejected + held,
+      threshold: 5,
+      startedAt: new Date().toISOString(),
+    })
+  }
+
+  const topError = errors.codes[0]
+  if (topError && topError.count >= 5) {
+    alerts.push({
+      id: `error-hotspot-${topError.errorCode.toLowerCase()}`,
+      severity: topError.count >= 10 ? 'critical' : 'warning',
+      title: `Error hotspot: ${topError.errorCode}`,
+      scope: 'agent',
+      message: `${topError.count} intents failed with ${topError.errorCode}.`,
+      metric: 'error_code_count',
+      value: topError.count,
+      threshold: 5,
+      startedAt: topError.lastSeenAt,
+    })
+  }
+
+  return alerts.sort((left, right) => {
+    const severityOrder: Record<AlertSeverity, number> = { critical: 0, warning: 1, info: 2 }
+    return severityOrder[left.severity] - severityOrder[right.severity]
+  })
+}
+
+function createSyntheticTrace(intent: IntentLogRow): Array<ReturnType<typeof serializeTraceEvent>> {
+  const stages: Array<ReturnType<typeof serializeTraceEvent>> = [
+    {
+      id: 0,
+      nonce: intent.nonce,
+      from: intent.from_beam_id,
+      to: intent.to_beam_id,
+      intentType: intent.intent_type,
+      stage: 'received',
+      status: 'pending',
+      timestamp: intent.requested_at,
+      details: null,
+    },
+  ]
+
+  if (intent.completed_at) {
+    stages.push({
+      id: -1,
+      nonce: intent.nonce,
+      from: intent.from_beam_id,
+      to: intent.to_beam_id,
+      intentType: intent.intent_type,
+      stage: 'completed',
+      status: intent.status,
+      timestamp: intent.completed_at,
+      details: {
+        latencyMs: intent.round_trip_latency_ms,
+        errorCode: intent.error_code,
+      },
+    })
+  }
+
+  return stages
+}
+
+function flattenCsvValue(value: unknown): string {
+  if (value == null) {
+    return ''
+  }
+
+  if (Array.isArray(value) || typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+
+  return String(value)
+}
+
+function toCsv(rows: Array<Record<string, unknown>>): string {
+  if (rows.length === 0) {
+    return ''
+  }
+
+  const keys = Array.from(rows.reduce((acc, row) => {
+    for (const key of Object.keys(row)) {
+      acc.add(key)
+    }
+    return acc
+  }, new Set<string>()))
+
+  const escape = (value: string) => `"${value.replaceAll('"', '""')}"`
+  const lines = [keys.map(escape).join(',')]
+
+  for (const row of rows) {
+    lines.push(keys.map((key) => escape(flattenCsvValue(row[key]))).join(','))
+  }
+
+  return lines.join('\n')
+}
+
+function pruneDataset(db: Database, dataset: string, olderThanDays: number): { deleted: number; extra?: Record<string, number> } {
+  const cutoff = nowMinusDays(olderThanDays)
+
+  switch (dataset) {
+    case 'intents': {
+      const intents = db.prepare('DELETE FROM intent_log WHERE requested_at < ?').run(cutoff)
+      const traces = db.prepare('DELETE FROM intent_trace_events WHERE timestamp < ?').run(cutoff)
+      return { deleted: intents.changes + traces.changes, extra: { intents: intents.changes, traces: traces.changes } }
+    }
+    case 'traces': {
+      const result = db.prepare('DELETE FROM intent_trace_events WHERE timestamp < ?').run(cutoff)
+      return { deleted: result.changes }
+    }
+    case 'audit': {
+      const result = db.prepare('DELETE FROM audit_log WHERE timestamp < ?').run(cutoff)
+      return { deleted: result.changes }
+    }
+    case 'shield': {
+      const result = db.prepare('DELETE FROM shield_audit_log WHERE created_at < ?').run(cutoff)
+      return { deleted: result.changes }
+    }
+    default:
+      throw new Error(`Unsupported dataset: ${dataset}`)
+  }
+}
+
+export function observabilityRouter(db: Database): Hono {
+  const router = new Hono()
+
+  router.get('/overview', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const windowHours = parseHours(c.req.query('hours'), 24)
+    const overview = buildOverviewPayload(db, windowHours)
+    const alerts = buildAlerts(db, windowHours)
+    return c.json({
+      ...overview,
+      alerts: alerts.slice(0, 5),
+    })
+  })
+
+  router.get('/intents', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const result = searchIntentRows(db, {
+      q: c.req.query('q') ?? undefined,
+      fromBeamId: c.req.query('from') ?? undefined,
+      toBeamId: c.req.query('to') ?? undefined,
+      intentType: c.req.query('intentType') ?? undefined,
+      status: c.req.query('status') ?? undefined,
+      errorCode: c.req.query('errorCode') ?? undefined,
+      limit: parseLimit(c.req.query('limit'), 100),
+      sinceHours: c.req.query('hours') ? parseHours(c.req.query('hours'), 24 * 7) : undefined,
+    })
+
+    return c.json({
+      intents: result.intents.map(serializeIntentRow),
+      total: result.total,
+    })
+  })
+
+  router.get('/intents/:nonce', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const nonce = c.req.param('nonce')
+    const intent = db.prepare('SELECT * FROM intent_log WHERE nonce = ?').get(nonce) as IntentLogRow | undefined
+    if (!intent) {
+      return c.json({ error: 'Intent not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const trace = listIntentTraceEvents(db, nonce)
+    const shield = listShieldAuditLog(db, { nonce, limit: 50 })
+    const audit = listAuditLog(db, { limit: 100 })
+      .filter((entry) => entry.target === nonce || entry.details?.includes?.(nonce))
+      .slice(0, 25)
+    const stages = trace.length > 0
+      ? trace.map(serializeTraceEvent)
+      : createSyntheticTrace(intent)
+
+    return c.json({
+      intent: serializeIntentRow(intent),
+      stages,
+      audit: audit.map(serializeAuditRow),
+      shield: shield.map(serializeShieldRow),
+    })
+  })
+
+  router.get('/audit', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const result = searchAuditRows(db, {
+      limit: parseLimit(c.req.query('limit'), 100),
+      action: c.req.query('action') ?? undefined,
+      actor: c.req.query('actor') ?? undefined,
+      target: c.req.query('target') ?? undefined,
+      q: c.req.query('q') ?? undefined,
+      sinceHours: c.req.query('hours') ? parseHours(c.req.query('hours'), 24 * 30) : undefined,
+    })
+
+    return c.json({
+      entries: result.entries.map(serializeAuditRow),
+      total: result.total,
+    })
+  })
+
+  router.get('/agents/:beamId/health', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
+    const payload = buildAgentHealthPayload(db, beamId, parseHours(c.req.query('hours'), 24 * 7))
+    if (!payload) {
+      return c.json({ error: 'Agent not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    return c.json(payload)
+  })
+
+  router.get('/federation', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    return c.json(buildFederationPayload(db))
+  })
+
+  router.get('/errors', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    return c.json(buildErrorsPayload(db, parseHours(c.req.query('hours'), 24 * 7)))
+  })
+
+  router.get('/alerts', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const windowHours = parseHours(c.req.query('hours'), 24)
+    return c.json({
+      windowHours,
+      generatedAt: new Date().toISOString(),
+      alerts: buildAlerts(db, windowHours),
+      retention: {
+        defaultDays: DEFAULT_RETENTION_DAYS,
+        datasets: ['intents', 'traces', 'audit', 'shield'],
+      },
+      exports: [
+        { dataset: 'intents', formats: ['json', 'csv', 'ndjson'] },
+        { dataset: 'audit', formats: ['json', 'csv', 'ndjson'] },
+        { dataset: 'errors', formats: ['json', 'csv', 'ndjson'] },
+        { dataset: 'federation', formats: ['json', 'csv', 'ndjson'] },
+        { dataset: 'alerts', formats: ['json', 'csv', 'ndjson'] },
+      ],
+    })
+  })
+
+  router.get('/retention', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    return c.json({
+      defaultDays: DEFAULT_RETENTION_DAYS,
+      datasets: ['intents', 'traces', 'audit', 'shield'],
+    })
+  })
+
+  router.get('/export/:dataset', (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    const dataset = c.req.param('dataset')
+    const format = (c.req.query('format') ?? 'json').toLowerCase()
+    const windowHours = parseHours(c.req.query('hours'), 24 * 7)
+
+    let rows: Array<Record<string, unknown>>
+    switch (dataset) {
+      case 'intents':
+        rows = searchIntentRows(db, {
+          limit: parseLimit(c.req.query('limit'), 500, 5000),
+          sinceHours: windowHours,
+          q: c.req.query('q') ?? undefined,
+          fromBeamId: c.req.query('from') ?? undefined,
+          toBeamId: c.req.query('to') ?? undefined,
+          intentType: c.req.query('intentType') ?? undefined,
+          status: c.req.query('status') ?? undefined,
+          errorCode: c.req.query('errorCode') ?? undefined,
+        }).intents.map(serializeIntentRow)
+        break
+      case 'audit':
+        rows = searchAuditRows(db, {
+          limit: parseLimit(c.req.query('limit'), 500, 5000),
+          sinceHours: windowHours,
+          action: c.req.query('action') ?? undefined,
+          actor: c.req.query('actor') ?? undefined,
+          target: c.req.query('target') ?? undefined,
+          q: c.req.query('q') ?? undefined,
+        }).entries.map(serializeAuditRow)
+        break
+      case 'errors':
+        rows = buildErrorsPayload(db, windowHours).codes
+        break
+      case 'federation':
+        rows = buildFederationPayload(db).peers
+        break
+      case 'alerts':
+        rows = buildAlerts(db, windowHours)
+        break
+      default:
+        return c.json({ error: 'Unsupported export dataset', errorCode: 'INVALID_EXPORT' }, 400)
+    }
+
+    if (format === 'csv') {
+      c.header('Content-Type', 'text/csv; charset=utf-8')
+      c.header('Content-Disposition', `attachment; filename="beam-${dataset}.csv"`)
+      return c.body(toCsv(rows))
+    }
+
+    if (format === 'ndjson') {
+      c.header('Content-Type', 'application/x-ndjson; charset=utf-8')
+      c.header('Content-Disposition', `attachment; filename="beam-${dataset}.ndjson"`)
+      return c.body(rows.map((row) => JSON.stringify(row)).join('\n'))
+    }
+
+    c.header('Content-Disposition', `attachment; filename="beam-${dataset}.json"`)
+    return c.json({
+      dataset,
+      exportedAt: new Date().toISOString(),
+      rows,
+      total: rows.length,
+    })
+  })
+
+  router.post('/prune', async (c) => {
+    const auth = requireAdmin(c)
+    if (auth) {
+      return auth
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const dataset = String(raw.dataset ?? '').trim()
+    const olderThanDays = parseDays(
+      raw.olderThanDays == null ? undefined : String(raw.olderThanDays),
+      DEFAULT_RETENTION_DAYS,
+    )
+
+    if (!dataset) {
+      return c.json({ error: 'dataset is required', errorCode: 'INVALID_PRUNE' }, 400)
+    }
+
+    try {
+      const result = pruneDataset(db, dataset, olderThanDays)
+      return c.json({
+        dataset,
+        olderThanDays,
+        deleted: result.deleted,
+        ...result.extra,
+      })
+    } catch (err) {
+      return c.json({
+        error: err instanceof Error ? err.message : 'Failed to prune dataset',
+        errorCode: 'PRUNE_ERROR',
+      }, 400)
+    }
+  })
+
+  return router
+}

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -17,16 +17,18 @@ import { didRouter } from './routes/did.js'
 import { federationRouter } from './routes/federation.js'
 import { agentKeysRouter, revokedKeysRouter } from './routes/keys.js'
 import { orgsRouter } from './routes/orgs.js'
+import { observabilityRouter } from './routes/observability.js'
 import { reportsRouter } from './routes/reports.js'
 import { shieldRouter } from './routes/shield.js'
 import { verificationRouter } from './routes/verify.js'
 import { createTrustGateMiddleware } from './middleware/trust-gate.js'
 import { createWebSocketServer, getConnectedCount, getConnectedBeamIds, relayIntentFromHttp, RelayError } from './websocket.js'
 import { createAcl, deleteAcl, listAclsForBeam, seedAclsFromCatalog } from './acl.js'
-import { getDirectoryRole, listAuditLog, listRecentIntentLogs, listTrustScores, getDIDDocument, getAgent, upsertDIDDocument } from './db.js'
+import { finalizeIntentLog, getDirectoryRole, listAuditLog, listRecentIntentLogs, listTrustScores, getDIDDocument, getAgent, logIntentStart, upsertDIDDocument } from './db.js'
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import type { AgentRow, IntentFrame } from './types.js'
+import { recordIntentStage, recordShieldDecision } from './observability-hooks.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
@@ -925,6 +927,7 @@ export function createApp(db: Database): Hono {
   app.route('/federation', federationRouter(db))
   app.route('/billing', billingRouter(db))
   app.route('/shield', shieldRouter(db))
+  app.route('/observability', observabilityRouter(db))
   app.route('/keys', revokedKeysRouter(db))
 
   app.post('/acl', async (c) => {
@@ -1128,7 +1131,23 @@ export function createApp(db: Database): Hono {
       // S4: Check if recipient has HTTP endpoint for direct delivery
       const recipientAgent = db.prepare('SELECT http_endpoint, dh_public_key FROM agents WHERE beam_id = ?').get(frame.to) as { http_endpoint: string | null; dh_public_key: string | null } | undefined
       if (recipientAgent?.http_endpoint) {
+        logIntentStart(db, frame)
+        recordIntentStage(db, frame, 'received', 'pending', {
+          transport: 'http',
+          deliveryTarget: 'direct-http',
+        }, frame.timestamp)
+        recordShieldDecision(db, frame, { timestamp: frame.timestamp })
+        recordIntentStage(db, frame, 'validated', 'success', {
+          transport: 'http',
+          deliveryTarget: 'direct-http',
+        })
+        recordIntentStage(db, frame, 'delivery', 'pending', {
+          transport: 'direct-http',
+          endpoint: recipientAgent.http_endpoint,
+        })
+
         try {
+          const startedAt = Date.now()
           const directResponse = await fetch(recipientAgent.http_endpoint, {
             method: 'POST',
             headers: {
@@ -1149,6 +1168,24 @@ export function createApp(db: Database): Hono {
           })
           if (directResponse.ok) {
             const directResult = await directResponse.json() as Record<string, unknown>
+            const latencyMs = Date.now() - startedAt
+            finalizeIntentLog(db, {
+              nonce: frame.nonce,
+              fromBeamId: frame.from,
+              toBeamId: frame.to,
+              success: true,
+              latencyMs,
+            })
+            recordIntentStage(db, frame, 'delivery', 'success', {
+              transport: 'direct-http',
+              endpoint: recipientAgent.http_endpoint,
+              status: directResponse.status,
+              latencyMs,
+            })
+            recordIntentStage(db, frame, 'completed', 'success', {
+              transport: 'direct-http',
+              latencyMs,
+            })
             // Log as direct delivery
             db.prepare(
               `INSERT OR REPLACE INTO usage_metering (beam_id, period, intent_count, direct_count)
@@ -1157,8 +1194,20 @@ export function createApp(db: Database): Hono {
             ).run(frame.from, new Date().toISOString().slice(0, 7), frame.from, new Date().toISOString().slice(0, 7), frame.from, new Date().toISOString().slice(0, 7))
             return c.json({ ...directResult, delivery: 'direct' })
           }
+          recordIntentStage(db, frame, 'delivery', 'error', {
+            transport: 'direct-http',
+            endpoint: recipientAgent.http_endpoint,
+            status: directResponse.status,
+            errorCode: 'DIRECT_HTTP_FAILED',
+          })
           // Direct delivery failed — fall through to WebSocket relay
-        } catch {
+        } catch (err) {
+          recordIntentStage(db, frame, 'delivery', 'error', {
+            transport: 'direct-http',
+            endpoint: recipientAgent.http_endpoint,
+            errorCode: 'DIRECT_HTTP_FAILED',
+            message: err instanceof Error ? err.message : 'Direct delivery failed',
+          })
           // Direct delivery error — fall through to WebSocket relay
         }
       }

--- a/packages/directory/src/shield/audit.ts
+++ b/packages/directory/src/shield/audit.ts
@@ -7,6 +7,7 @@ import { createHash } from 'node:crypto'
 import type { Database } from 'better-sqlite3'
 
 export interface AuditEvent {
+  nonce?: string | null
   timestamp: string
   senderBeamId: string
   senderTrust: number
@@ -24,11 +25,16 @@ export function hashPayload(payload: unknown): string {
 }
 
 export function logShieldEvent(db: Database, event: AuditEvent): void {
+  if (event.nonce) {
+    db.prepare('DELETE FROM shield_audit_log WHERE nonce = ?').run(event.nonce)
+  }
+
   db.prepare(`
     INSERT INTO shield_audit_log
-    (timestamp, sender_beam_id, sender_trust, intent_type, payload_hash, decision, risk_score, response_size, anomaly_flags, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    (nonce, timestamp, sender_beam_id, sender_trust, intent_type, payload_hash, decision, risk_score, response_size, anomaly_flags, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
+    event.nonce ?? null,
     event.timestamp,
     event.senderBeamId,
     event.senderTrust,
@@ -43,6 +49,7 @@ export function logShieldEvent(db: Database, event: AuditEvent): void {
 }
 
 interface AuditRow {
+  nonce: string | null
   timestamp: string
   sender_beam_id: string
   sender_trust: number
@@ -66,6 +73,7 @@ export function getRecentEvents(
   ).all(beamId, cutoff) as AuditRow[]
 
   return rows.map((r) => ({
+    nonce: r.nonce,
     timestamp: r.timestamp,
     senderBeamId: r.sender_beam_id,
     senderTrust: r.sender_trust,

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -50,6 +50,18 @@ export interface IntentLogRow {
   error_code: string | null
 }
 
+export interface IntentTraceEventRow {
+  id: number
+  nonce: string
+  from_beam_id: string
+  to_beam_id: string
+  intent_type: string
+  stage: string
+  status: string
+  timestamp: string
+  details: string | null
+}
+
 export interface TrustScoreRow {
   id: number
   source_beam_id: string
@@ -98,6 +110,21 @@ export interface AuditLogRow {
   target: string
   timestamp: string
   details: string
+}
+
+export interface ShieldAuditLogRow {
+  id: number
+  nonce: string | null
+  timestamp: string | null
+  sender_beam_id: string | null
+  sender_trust: number | null
+  intent_type: string | null
+  payload_hash: string | null
+  decision: string | null
+  risk_score: number | null
+  response_size: number | null
+  anomaly_flags: string | null
+  created_at: string
 }
 
 export interface DnsCacheRow {

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -17,6 +17,7 @@ import { validateIntentPayload } from './validation.js'
 import { checkAgentRateLimit, getRateLimitPerMinute, pruneRateLimitState } from './rate-limit.js'
 import { verifyPayload } from './crypto.js'
 import { agentApiKeyMatches, getSuppliedApiKey } from './api-key.js'
+import { recordIntentStage, recordShieldDecision } from './observability-hooks.js'
 
 const REPLAY_WINDOW_MS = 5 * 60 * 1000
 
@@ -153,16 +154,52 @@ export async function relayIntentFromHttp(
     throw new RelayError('BAD_REQUEST', `Federation hop limit exceeded (${MAX_FEDERATION_HOPS})`)
   }
 
+  recordIntentStage(db, prepared, 'received', 'pending', {
+    transport: 'http',
+    sourceDirectory,
+    hopCount,
+  }, prepared.timestamp)
+
   const sender = getAgent(db, prepared.from)
   const senderPublicKey = sender?.public_key ?? await resolveSenderPublicKey(db, prepared.from, sourceDirectory)
 
   if (!senderPublicKey) {
+    recordIntentStage(db, prepared, 'sender_lookup', 'error', {
+      sourceDirectory,
+      errorCode: 'UNKNOWN_SENDER',
+    })
     throw new RelayError('BAD_REQUEST', `Sender ${prepared.from} is not registered`)
   }
 
-  enforceSecurityChecks(db, prepared, senderPublicKey)
+  recordIntentStage(db, prepared, 'sender_lookup', 'success', {
+    sourceDirectory,
+    source: sender ? 'local' : 'federated',
+  })
+
+  try {
+    enforceSecurityChecks(db, prepared, senderPublicKey)
+    recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
+    recordIntentStage(db, prepared, 'validated', 'success', {
+      transport: 'http',
+    })
+  } catch (err) {
+    recordShieldDecision(db, prepared, {
+      decision: 'reject',
+      timestamp: prepared.timestamp,
+      extraFlags: [err instanceof RelayError ? err.code : 'INVALID_INTENT'],
+    })
+    recordIntentStage(db, prepared, 'validated', 'error', {
+      transport: 'http',
+      errorCode: err instanceof RelayError ? err.code : 'INVALID_INTENT',
+      message: err instanceof Error ? err.message : 'Rejected by security checks',
+    })
+    throw err
+  }
 
   logIntentStart(db, prepared)
+  recordIntentStage(db, prepared, 'dispatch', 'pending', {
+    deliveryTarget: 'local-or-federated',
+  })
   broadcastIntentFeed({
     nonce: prepared.nonce,
     from: prepared.from,
@@ -177,6 +214,9 @@ export async function relayIntentFromHttp(
 
   const localRecipient = getAgent(db, prepared.to)
   if (!localRecipient) {
+    recordIntentStage(db, prepared, 'dispatch', 'pending', {
+      deliveryTarget: 'federation',
+    })
     const federatedResult = await relayIntentToFederatedPeer(db, prepared, timeoutMs, {
       sourceDirectory,
       hopCount,
@@ -196,6 +236,10 @@ export async function relayIntentFromHttp(
       latencyMs: null,
       errorCode: 'OFFLINE',
     })
+    recordIntentStage(db, prepared, 'delivery', 'error', {
+      transport: 'ws',
+      errorCode: 'OFFLINE',
+    })
     broadcastIntentFeed({
       nonce: prepared.nonce,
       from: prepared.from,
@@ -211,6 +255,10 @@ export async function relayIntentFromHttp(
   }
 
   const resultPromise = createResultWaiter(db, prepared, timeoutMs)
+  recordIntentStage(db, prepared, 'delivery', 'pending', {
+    transport: 'ws',
+    timeoutMs,
+  })
 
   try {
     sendJson(recipientWs, {
@@ -227,6 +275,11 @@ export async function relayIntentFromHttp(
       success: false,
       latencyMs: null,
       errorCode: 'DELIVERY_FAILED',
+    })
+    recordIntentStage(db, prepared, 'delivery', 'error', {
+      transport: 'ws',
+      errorCode: 'DELIVERY_FAILED',
+      message: err instanceof Error ? err.message : 'Failed to deliver to recipient socket',
     })
     broadcastIntentFeed({
       nonce: prepared.nonce,
@@ -300,6 +353,12 @@ async function handleIntent(
   try {
     senderAgent = resolveIntentSender(db, senderBeamId, prepared)
   } catch (err) {
+    recordIntentStage(db, prepared, 'sender_lookup', 'error', {
+      transport: 'ws',
+      connectedBeamId: senderBeamId,
+      errorCode: err instanceof RelayError ? err.code : 'UNKNOWN_SENDER',
+      message: err instanceof Error ? err.message : 'Sender is not registered in the directory',
+    })
     sendJson(senderWs, {
       type: 'error',
       nonce: prepared.nonce,
@@ -309,9 +368,35 @@ async function handleIntent(
     return
   }
 
+  recordIntentStage(db, prepared, 'received', 'pending', {
+    transport: 'ws',
+    connectedBeamId: senderBeamId,
+  }, prepared.timestamp)
+  recordIntentStage(db, prepared, 'sender_lookup', 'success', {
+    transport: 'ws',
+    connectedBeamId: senderBeamId,
+    actingOnBehalf: senderBeamId !== prepared.from,
+  })
+
   try {
     enforceSecurityChecks(db, prepared, senderAgent.public_key, { skipSignatureVerification: auth.authenticatedViaApiKey })
+    recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
+    recordIntentStage(db, prepared, 'validated', 'success', {
+      transport: 'ws',
+      authenticatedViaApiKey: auth.authenticatedViaApiKey,
+    })
   } catch (err) {
+    recordShieldDecision(db, prepared, {
+      decision: 'reject',
+      timestamp: prepared.timestamp,
+      extraFlags: [err instanceof RelayError ? err.code : 'INVALID_INTENT'],
+    })
+    recordIntentStage(db, prepared, 'validated', 'error', {
+      transport: 'ws',
+      authenticatedViaApiKey: auth.authenticatedViaApiKey,
+      errorCode: err instanceof RelayError ? err.code : 'INVALID_INTENT',
+      message: err instanceof Error ? err.message : 'Rejected by relay security checks',
+    })
     if (err instanceof RelayError && err.code === 'RATE_LIMITED') {
       sendJson(senderWs, {
         type: 'error',
@@ -333,6 +418,9 @@ async function handleIntent(
   }
 
   logIntentStart(db, prepared)
+  recordIntentStage(db, prepared, 'dispatch', 'pending', {
+    deliveryTarget: 'local-or-federated',
+  })
   broadcastIntentFeed({
     nonce: prepared.nonce,
     from: prepared.from,
@@ -347,6 +435,9 @@ async function handleIntent(
 
   const localRecipient = getAgent(db, prepared.to)
   if (!localRecipient) {
+    recordIntentStage(db, prepared, 'dispatch', 'pending', {
+      deliveryTarget: 'federation',
+    })
     try {
       const result = await relayIntentToFederatedPeer(db, prepared, 30_000, {
         sourceDirectory: getLocalDirectoryUrl(),
@@ -377,6 +468,10 @@ async function handleIntent(
       latencyMs: null,
       errorCode: 'OFFLINE',
     })
+    recordIntentStage(db, prepared, 'delivery', 'error', {
+      transport: 'ws',
+      errorCode: 'OFFLINE',
+    })
     broadcastIntentFeed({
       nonce: prepared.nonce,
       from: prepared.from,
@@ -398,13 +493,42 @@ async function handleIntent(
   }
 
   const resultPromise = createResultWaiter(db, prepared, 30_000)
-
-  sendJson(recipientWs, {
-    type: 'intent',
-    frame: prepared,
-    senderPublicKey: senderAgent.public_key,
+  recordIntentStage(db, prepared, 'delivery', 'pending', {
+    transport: 'ws',
+    timeoutMs: 30_000,
     actingBeamId: senderBeamId !== prepared.from ? senderBeamId : undefined,
   })
+
+  try {
+    sendJson(recipientWs, {
+      type: 'intent',
+      frame: prepared,
+      senderPublicKey: senderAgent.public_key,
+      actingBeamId: senderBeamId !== prepared.from ? senderBeamId : undefined,
+    })
+  } catch (err) {
+    clearPendingResult(prepared.nonce)
+    finalizeIntentLog(db, {
+      nonce: prepared.nonce,
+      fromBeamId: prepared.from,
+      toBeamId: prepared.to,
+      success: false,
+      latencyMs: null,
+      errorCode: 'DELIVERY_FAILED',
+    })
+    recordIntentStage(db, prepared, 'delivery', 'error', {
+      transport: 'ws',
+      errorCode: 'DELIVERY_FAILED',
+      message: err instanceof Error ? err.message : 'Failed to deliver to recipient socket',
+    })
+    sendJson(senderWs, {
+      type: 'error',
+      nonce: prepared.nonce,
+      errorCode: 'DELIVERY_FAILED',
+      message: err instanceof Error ? err.message : 'Failed to relay intent',
+    })
+    return
+  }
 
   updateLastSeen(db, senderBeamId)
 
@@ -455,6 +579,9 @@ async function relayIntentToFederatedPeer(
   const peerUrl = resolved?.directoryUrl
 
   if (!resolved || !peerUrl || peerUrl === getLocalDirectoryUrl()) {
+    recordIntentStage(db, frame, 'federation.resolve', 'error', {
+      errorCode: 'OFFLINE',
+    })
     finalizeIntentLog(db, {
       nonce: frame.nonce,
       fromBeamId: frame.from,
@@ -466,8 +593,17 @@ async function relayIntentToFederatedPeer(
     throw new RelayError('OFFLINE', `Agent ${frame.to} is not available locally or through federation`)
   }
 
+  recordIntentStage(db, frame, 'federation.resolve', 'success', {
+    peerUrl,
+    scope: resolved.scope,
+  })
+
   const nextHopCount = options.hopCount + 1
   if (nextHopCount > MAX_FEDERATION_HOPS) {
+    recordIntentStage(db, frame, 'federation.relay', 'error', {
+      errorCode: 'BAD_REQUEST',
+      hopCount: nextHopCount,
+    })
     finalizeIntentLog(db, {
       nonce: frame.nonce,
       fromBeamId: frame.from,
@@ -480,6 +616,10 @@ async function relayIntentToFederatedPeer(
   }
 
   const startedAt = Date.now()
+  recordIntentStage(db, frame, 'federation.relay', 'pending', {
+    peerUrl,
+    hopCount: nextHopCount,
+  })
   const response = await fetch(`${peerUrl}/federation/relay`, {
     method: 'POST',
     headers: getFederationRequestHeaders({
@@ -491,6 +631,12 @@ async function relayIntentToFederatedPeer(
   })
 
   if (!response.ok) {
+    recordIntentStage(db, frame, 'federation.relay', 'error', {
+      peerUrl,
+      hopCount: nextHopCount,
+      errorCode: 'DELIVERY_FAILED',
+      status: response.status,
+    })
     finalizeIntentLog(db, {
       nonce: frame.nonce,
       fromBeamId: frame.from,
@@ -503,6 +649,11 @@ async function relayIntentToFederatedPeer(
   }
 
   const result = await response.json() as ResultFrame
+  recordIntentStage(db, frame, 'federation.relay', result.success ? 'success' : 'error', {
+    peerUrl,
+    hopCount: nextHopCount,
+    errorCode: result.success ? null : (result.errorCode ?? 'RESULT_ERROR'),
+  })
   finalizeIntentLog(db, {
     nonce: frame.nonce,
     fromBeamId: frame.from,
@@ -510,6 +661,12 @@ async function relayIntentToFederatedPeer(
     success: result.success,
     latencyMs: typeof result.latency === 'number' ? result.latency : Date.now() - startedAt,
     errorCode: result.success ? undefined : (result.errorCode ?? 'RESULT_ERROR'),
+  })
+  recordIntentStage(db, frame, 'completed', result.success ? 'success' : 'error', {
+    transport: 'federation',
+    peerUrl,
+    latencyMs: typeof result.latency === 'number' ? result.latency : Date.now() - startedAt,
+    errorCode: result.success ? null : (result.errorCode ?? 'RESULT_ERROR'),
   })
 
   return result
@@ -681,6 +838,16 @@ function handleResult(frame: ResultFrame): void {
     latencyMs,
     errorCode: frame.success ? undefined : (frame.errorCode ?? 'RESULT_ERROR'),
   })
+  recordIntentStage(pending.db, {
+    nonce: frame.nonce,
+    from: pending.fromBeamId,
+    to: pending.toBeamId,
+    intent: pending.intentType,
+  }, 'completed', frame.success ? 'success' : 'error', {
+    transport: 'ws',
+    latencyMs,
+    errorCode: frame.success ? null : (frame.errorCode ?? 'RESULT_ERROR'),
+  })
   broadcastIntentFeed({
     nonce: frame.nonce,
     from: pending.fromBeamId,
@@ -714,6 +881,12 @@ function createResultWaiter(db: Database, frame: IntentFrame, timeoutMs: number)
         success: false,
         latencyMs,
         errorCode: 'TIMEOUT',
+      })
+      recordIntentStage(db, frame, 'completed', 'error', {
+        transport: 'ws',
+        latencyMs,
+        errorCode: 'TIMEOUT',
+        timeoutMs,
       })
       broadcastIntentFeed({
         nonce: frame.nonce,


### PR DESCRIPTION
## Summary
- add structured observability routes for intents, traces, audits, federation, errors, alerts, exports, and prune controls
- record intent trace lifecycle and nonce-bound shield audit entries in the directory pipeline
- ship dashboard pages for overview, intents, trace detail, audit, federation, errors, alerts, agent health, and admin-key settings

## Verification
- npm run build
- npm test