### PR TITLE
Add cross-stack E2E compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,40 @@ jobs:
       - name: Test workspaces
         run: npm test
 
+  e2e:
+    runs-on: ubuntu-latest
+    needs: monorepo
+    strategy:
+      matrix:
+        node: [20, 22]
+        python: ['3.10', '3.12']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Build workspaces
+        run: npm run build
+
+      - name: Install Python SDK dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e packages/sdk-python
+
+      - name: Run cross-stack E2E compatibility check
+        run: npm run test:e2e
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -57,7 +91,7 @@ jobs:
 
   publish:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [monorepo, docs]
+    needs: [monorepo, e2e, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Thanks for contributing to Beam Protocol.
 npm install
 npm run build
 npm test
+python3 -m pip install -e packages/sdk-python
+npm run test:e2e
 ```
 
 For the local directory server:
@@ -65,6 +67,8 @@ npm run build --workspace=packages/message-bus
 ```
 
 If you add examples or CLI changes, verify the exact commands in the updated README files.
+
+Before cutting or approving a release branch, make sure the `e2e` GitHub Actions job is green. It is the cross-stack guard that boots the directory and message bus, then verifies registration, discovery, and `conversation.message` delivery through the TypeScript SDK, Python SDK, and CLI.
 
 ## Commit Style
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ spec/              protocol RFCs and supporting material
 npm install
 npm run build
 npm test
+python3 -m pip install -e packages/sdk-python
+npm run test:e2e
 ```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution workflow, reporting guidelines, and local development expectations.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run build:workspaces",
     "build:workspaces": "npm run build --if-present --workspace=packages/sdk-typescript --workspace=packages/cli --workspace=packages/echo-agent --workspace=packages/create-beam-agent --workspace=packages/dashboard --workspace=packages/directory --workspace=packages/message-bus",
     "test": "npm run test --workspaces --if-present",
+    "test:e2e": "node scripts/e2e/run.mjs",
     "dev:directory": "npm run dev --workspace=packages/directory",
     "typecheck": "npm run typecheck:workspaces",
     "typecheck:workspaces": "npm run typecheck --if-present --workspace=packages/sdk-typescript --workspace=packages/cli --workspace=packages/echo-agent --workspace=packages/create-beam-agent --workspace=packages/dashboard --workspace=packages/directory --workspace=packages/message-bus"

--- a/packages/sdk-python/beam_directory/frames.py
+++ b/packages/sdk-python/beam_directory/frames.py
@@ -18,6 +18,30 @@ def _canonical_json(data: dict[str, Any]) -> str:
     return json.dumps(data, sort_keys=True, separators=(",", ":"))
 
 
+def _intent_signature_payload(
+    *,
+    from_id: BeamIdString,
+    to_id: BeamIdString,
+    intent: str,
+    payload: dict[str, Any],
+    timestamp: str,
+    nonce: str,
+) -> str:
+    """Match the TypeScript SDK's on-wire signature payload exactly."""
+    return json.dumps(
+        {
+            "type": "intent",
+            "from": from_id,
+            "to": to_id,
+            "intent": intent,
+            "payload": payload,
+            "timestamp": timestamp,
+            "nonce": nonce,
+        },
+        separators=(",", ":"),
+    )
+
+
 def create_intent_frame(
     intent: str,
     from_id: BeamIdString,
@@ -42,8 +66,16 @@ def create_intent_frame(
     )
 
     if identity is not None:
-        canonical = _canonical_json(frame.to_dict())
-        frame.signature = identity.sign(canonical)
+        frame.signature = identity.sign(
+            _intent_signature_payload(
+                from_id=frame.from_id,
+                to_id=frame.to_id,
+                intent=frame.intent,
+                payload=frame.params,
+                timestamp=frame.timestamp,
+                nonce=frame.nonce,
+            )
+        )
 
     return frame
 
@@ -125,10 +157,17 @@ def validate_intent_frame(
 
     # Signature check
     if public_key_base64 and frame.signature:
-        frame_dict = frame.to_dict()
-        sig = frame_dict.pop("signature", None)
-        if sig and not BeamIdentity.verify(
-            _canonical_json(frame_dict), sig, public_key_base64
+        if not BeamIdentity.verify(
+            _intent_signature_payload(
+                from_id=frame.from_id,
+                to_id=frame.to_id,
+                intent=frame.intent,
+                payload=frame.params,
+                timestamp=frame.timestamp,
+                nonce=frame.nonce,
+            ),
+            frame.signature,
+            public_key_base64,
         ):
             errors.append("Signature verification failed")
 

--- a/packages/sdk-python/beam_directory/types.py
+++ b/packages/sdk-python/beam_directory/types.py
@@ -43,13 +43,21 @@ class IntentFrame:
     timestamp: str
     signature: Optional[str] = None
 
+    @property
+    def payload(self) -> dict[str, Any]:
+        return self.params
+
+    @payload.setter
+    def payload(self, value: dict[str, Any]) -> None:
+        self.params = value
+
     def to_dict(self) -> dict[str, Any]:
         data: dict[str, Any] = {
             "v": self.v,
             "intent": self.intent,
             "from": self.from_id,
             "to": self.to_id,
-            "params": self.params,
+            "payload": self.params,
             "nonce": self.nonce,
             "timestamp": self.timestamp,
         }
@@ -59,12 +67,14 @@ class IntentFrame:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "IntentFrame":
+        payload = data.get("payload")
+        params = payload if isinstance(payload, dict) else data.get("params", {})
         return cls(
             v=data["v"],
             intent=data["intent"],
             from_id=data["from"],
             to_id=data["to"],
-            params=data.get("params", {}),
+            params=params if isinstance(params, dict) else {},
             nonce=data["nonce"],
             timestamp=data["timestamp"],
             signature=data.get("signature"),

--- a/packages/sdk-python/tests/test_frames.py
+++ b/packages/sdk-python/tests/test_frames.py
@@ -1,5 +1,6 @@
 """Tests for IntentFrame and ResultFrame creation and validation."""
 
+import json
 import time
 
 import pytest
@@ -67,9 +68,57 @@ class TestCreateIntentFrame:
         assert "intent" in d
         assert "from" in d
         assert "to" in d
-        assert "params" in d
+        assert "payload" in d
+        assert "params" not in d
         assert "nonce" in d
         assert "timestamp" in d
+
+    def test_to_dict_uses_payload_wire_format_for_signature(self, identity, recipient_id):
+        frame = create_intent_frame(
+            intent="greet",
+            from_id=identity.beam_id,
+            to_id=recipient_id,
+            params={"message": "hello"},
+            identity=identity,
+        )
+
+        signed_payload = json.dumps(
+            {
+                "type": "intent",
+                "from": frame.from_id,
+                "to": frame.to_id,
+                "intent": frame.intent,
+                "payload": frame.params,
+                "timestamp": frame.timestamp,
+                "nonce": frame.nonce,
+            },
+            separators=(",", ":"),
+        )
+
+        assert BeamIdentity.verify(signed_payload, frame.signature, identity.public_key_base64)
+
+    def test_from_dict_accepts_payload_key(self, recipient_id):
+        identity = BeamIdentity.generate("sender", "testorg")
+        frame = create_intent_frame(
+            intent="query",
+            from_id=identity.beam_id,
+            to_id=recipient_id,
+            params={"q": "hello"},
+        )
+
+        restored = type(frame).from_dict(
+            {
+                "v": frame.v,
+                "intent": frame.intent,
+                "from": frame.from_id,
+                "to": frame.to_id,
+                "payload": {"q": "hello"},
+                "nonce": frame.nonce,
+                "timestamp": frame.timestamp,
+            }
+        )
+
+        assert restored.params == {"q": "hello"}
 
 
 class TestCreateResultFrame:

--- a/scripts/e2e/python_sender.py
+++ b/scripts/e2e/python_sender.py
@@ -1,0 +1,59 @@
+"""Cross-check the Beam Python SDK against a live local directory."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import sys
+
+from beam_directory import BeamClient, BeamIdentity
+from beam_directory.types import AgentSearchQuery
+
+
+async def main() -> int:
+    directory_url = os.environ["BEAM_DIRECTORY_URL"]
+    receiver_beam_id = os.environ["BEAM_RECEIVER_BEAM_ID"]
+    org_name = os.environ.get("BEAM_SEARCH_ORG", "e2e")
+    message = os.environ.get("BEAM_MESSAGE", "hello from python")
+    suffix = secrets.token_hex(3)
+
+    identity = BeamIdentity.generate(agent_name=f"python-sender-{suffix}", org_name=org_name)
+    client = BeamClient(identity=identity, directory_url=directory_url)
+
+    await client.register("Python Sender", capabilities=["conversation.message"])
+
+    lookup = await client.directory.lookup(receiver_beam_id)
+    if lookup is None:
+        raise RuntimeError(f"Python lookup could not find {receiver_beam_id}")
+
+    matches = await client.directory.search(
+        AgentSearchQuery(org=org_name, capabilities=["conversation.message"], limit=20)
+    )
+
+    reply = await client.talk(receiver_beam_id, message)
+
+    print(
+        json.dumps(
+            {
+                "senderBeamId": client.beam_id,
+                "lookupBeamId": lookup.beam_id,
+                "searchMatches": [agent.beam_id for agent in matches],
+                "reply": {
+                    "message": reply["message"],
+                    "structured": reply.get("structured"),
+                    "threadId": reply.get("threadId"),
+                },
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(asyncio.run(main()))
+    except Exception as exc:  # pragma: no cover - failure path is consumed by the parent harness
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/e2e/run.mjs
+++ b/scripts/e2e/run.mjs
@@ -1,0 +1,363 @@
+import assert from 'node:assert/strict'
+import { execFile, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import net from 'node:net'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { setTimeout as sleep } from 'node:timers/promises'
+import { BeamClient, BeamIdentity } from '../../packages/sdk-typescript/dist/index.js'
+
+const execFileAsync = promisify(execFile)
+const repoRoot = path.resolve(fileURLToPath(new URL('../../', import.meta.url)))
+const directoryEntry = path.join(repoRoot, 'packages/directory/dist/index.js')
+const messageBusEntry = path.join(repoRoot, 'packages/message-bus/dist/server.js')
+const cliEntry = path.join(repoRoot, 'packages/cli/dist/index.js')
+const pythonSenderEntry = path.join(repoRoot, 'scripts/e2e/python_sender.py')
+
+async function ensureBuiltArtifacts() {
+  for (const file of [directoryEntry, messageBusEntry, cliEntry, pythonSenderEntry]) {
+    await access(file)
+  }
+}
+
+async function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        reject(new Error('Could not determine an open TCP port'))
+        return
+      }
+      const { port } = address
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(port)
+      })
+    })
+  })
+}
+
+function logStep(message) {
+  console.log(`[e2e] ${message}`)
+}
+
+function spawnProcess({ name, command, args, env, cwd = repoRoot }) {
+  const child = spawn(command, args, {
+    cwd,
+    env: {
+      ...process.env,
+      ...env,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+      CI: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+
+  child.stdout.on('data', (chunk) => {
+    process.stdout.write(`[${name}] ${chunk}`)
+  })
+  child.stderr.on('data', (chunk) => {
+    process.stderr.write(`[${name}] ${chunk}`)
+  })
+
+  return child
+}
+
+async function stopProcess(child, signal = 'SIGTERM') {
+  if (!child || child.exitCode !== null) {
+    return
+  }
+
+  child.kill(signal)
+  const exitPromise = once(child, 'exit').catch(() => undefined)
+  await Promise.race([exitPromise, sleep(5_000)])
+  if (child.exitCode === null) {
+    child.kill('SIGKILL')
+    await once(child, 'exit').catch(() => undefined)
+  }
+}
+
+async function waitForHealth(url, label) {
+  const deadline = Date.now() + 20_000
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) {
+        return
+      }
+    } catch {
+      // ignore during boot
+    }
+    await sleep(250)
+  }
+
+  throw new Error(`${label} did not become healthy at ${url}`)
+}
+
+async function requestJson(url, init) {
+  const response = await fetch(url, init)
+  const text = await response.text()
+  let parsed
+  try {
+    parsed = text.length > 0 ? JSON.parse(text) : null
+  } catch {
+    parsed = text
+  }
+
+  if (!response.ok) {
+    throw new Error(`Request to ${url} failed with ${response.status}: ${text}`)
+  }
+
+  return parsed
+}
+
+async function allowIntent(directoryUrl, targetBeamId, intentType, allowedFrom) {
+  await requestJson(`${directoryUrl}/acl`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ targetBeamId, intentType, allowedFrom }),
+  })
+}
+
+async function runCli(args, cwd, env = {}) {
+  return execFileAsync(process.execPath, [cliEntry, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      ...env,
+      FORCE_COLOR: '0',
+      NO_COLOR: '1',
+      CI: '1',
+    },
+    maxBuffer: 1024 * 1024,
+  })
+}
+
+async function runPython(env) {
+  return execFileAsync('python3', [pythonSenderEntry], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      ...env,
+      PYTHONUNBUFFERED: '1',
+    },
+    maxBuffer: 1024 * 1024,
+  })
+}
+
+async function step(name, fn) {
+  logStep(name)
+  try {
+    return await fn()
+  } catch (error) {
+    throw new Error(`${name} failed: ${error instanceof Error ? error.message : String(error)}`, { cause: error })
+  }
+}
+
+async function main() {
+  await ensureBuiltArtifacts()
+
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'beam-e2e-'))
+  const cliRoot = path.join(tempRoot, 'cli-agent')
+  const directoryDb = path.join(tempRoot, 'beam-directory.sqlite')
+  const messageBusDb = path.join(tempRoot, 'beam-bus.sqlite')
+  const identityBundlePath = path.join(tempRoot, 'beam-bus-identities.json')
+  const directoryPort = await getFreePort()
+  const messageBusPort = await getFreePort()
+  const directoryUrl = `http://127.0.0.1:${directoryPort}`
+  const messageBusUrl = `http://127.0.0.1:${messageBusPort}/v1/beam`
+  const beamBusApiKey = 'beam-bus-e2e-key'
+
+  await mkdir(cliRoot, { recursive: true })
+
+  const receiverIdentity = BeamIdentity.generate({ agentName: 'ts-receiver', orgName: 'e2e' })
+  const tsSenderIdentity = BeamIdentity.generate({ agentName: 'ts-sender', orgName: 'e2e' })
+  const busSenderIdentity = BeamIdentity.generate({ agentName: 'bus-sender', orgName: 'e2e' })
+
+  await writeFile(
+    identityBundlePath,
+    JSON.stringify({ busSender: busSenderIdentity.export() }, null, 2),
+    'utf8',
+  )
+
+  let directoryProcess
+  let messageBusProcess
+  let receiver
+
+  try {
+    directoryProcess = spawnProcess({
+      name: 'directory',
+      command: process.execPath,
+      args: [directoryEntry],
+      env: {
+        PORT: String(directoryPort),
+        DB_PATH: directoryDb,
+        JWT_SECRET: 'beam-e2e-jwt-secret',
+        BEAM_ADMIN_KEY: 'beam-e2e-admin-key',
+      },
+    })
+
+    await waitForHealth(`${directoryUrl}/health`, 'directory')
+
+    messageBusProcess = spawnProcess({
+      name: 'message-bus',
+      command: process.execPath,
+      args: [
+        messageBusEntry,
+        '--port', String(messageBusPort),
+        '--directory', directoryUrl,
+        '--db', messageBusDb,
+        '--identity', identityBundlePath,
+        '--rate-limit', '50',
+      ],
+      env: {
+        BEAM_BUS_API_KEY: beamBusApiKey,
+        BEAM_BUS_STATS_PUBLIC: 'true',
+        BEAM_BUS_CLEAN_TEST_DATA: 'true',
+      },
+    })
+
+    await waitForHealth(`http://127.0.0.1:${messageBusPort}/health`, 'message bus')
+
+    receiver = new BeamClient({
+      identity: receiverIdentity.export(),
+      directoryUrl,
+    })
+
+    await step('registering the TypeScript receiver', async () => {
+      await receiver.register('TypeScript Receiver', ['conversation.message'])
+      receiver.onTalk(async (message, from, respond) => {
+        respond(`TS receiver heard: ${message}`, {
+          echoed: message,
+          from,
+          via: 'typescript',
+        })
+      })
+      await receiver.connect()
+      await allowIntent(directoryUrl, receiver.beamId, 'conversation.message', '*')
+    })
+
+    await step('validating the TypeScript SDK flow', async () => {
+      const sender = new BeamClient({
+        identity: tsSenderIdentity.export(),
+        directoryUrl,
+      })
+
+      await sender.register('TypeScript Sender', [])
+      const lookup = await sender.directory.lookup(receiver.beamId)
+      assert.equal(lookup?.beamId, receiver.beamId, 'TypeScript lookup did not resolve the receiver')
+
+      const search = await sender.directory.search({
+        org: 'e2e',
+        capabilities: ['conversation.message'],
+        limit: 10,
+      })
+      assert(search.some((agent) => agent.beamId === receiver.beamId), 'TypeScript search did not find the receiver')
+
+      const reply = await sender.talk(receiver.beamId, 'hello from typescript')
+      assert.equal(reply.message, 'TS receiver heard: hello from typescript', 'TypeScript talk returned the wrong reply')
+      assert.equal(reply.structured?.via, 'typescript', 'TypeScript structured reply did not round-trip')
+    })
+
+    await step('validating the Python SDK flow', async () => {
+      const { stdout, stderr } = await runPython({
+        BEAM_DIRECTORY_URL: directoryUrl,
+        BEAM_RECEIVER_BEAM_ID: receiver.beamId,
+        BEAM_SEARCH_ORG: 'e2e',
+        BEAM_MESSAGE: 'hello from python',
+      })
+
+      if (stderr.trim().length > 0) {
+        console.error(stderr)
+      }
+
+      const payload = JSON.parse(stdout)
+      assert.equal(payload.lookupBeamId, receiver.beamId, 'Python lookup did not resolve the receiver')
+      assert(payload.searchMatches.includes(receiver.beamId), 'Python search did not include the receiver')
+      assert.equal(payload.reply.message, 'TS receiver heard: hello from python', 'Python talk returned the wrong reply')
+    })
+
+    await step('validating the CLI flow', async () => {
+      await runCli(['init', '--agent', 'cli-sender', '--org', 'e2e', '--directory', directoryUrl, '--force'], cliRoot)
+      await runCli(['register', '--display-name', 'CLI Sender', '--capabilities', 'conversation.message', '--directory', directoryUrl], cliRoot)
+
+      const lookup = JSON.parse((await runCli(['lookup', receiver.beamId, '--directory', directoryUrl, '--json'], cliRoot)).stdout)
+      assert.equal(lookup.beamId, receiver.beamId, 'CLI lookup did not resolve the receiver')
+
+      const search = JSON.parse((await runCli(['search', '--org', 'e2e', '--capability', 'conversation.message', '--directory', directoryUrl, '--json'], cliRoot)).stdout)
+      assert(search.some((agent) => agent.beamId === receiver.beamId), 'CLI search did not include the receiver')
+
+      const reply = JSON.parse((await runCli(['talk', receiver.beamId, 'hello from cli', '--directory', directoryUrl, '--json'], cliRoot)).stdout)
+      assert.equal(reply.message, 'TS receiver heard: hello from cli', 'CLI talk returned the wrong reply')
+    })
+
+    await step('smoke testing the message bus', async () => {
+      const busSender = new BeamClient({
+        identity: busSenderIdentity.export(),
+        directoryUrl,
+      })
+      await busSender.register('Bus Sender', [])
+
+      const sendResult = await requestJson(`${messageBusUrl}/send`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${beamBusApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: busSender.beamId,
+          to: receiver.beamId,
+          intent: 'conversation.message',
+          payload: { message: 'hello from message bus' },
+        }),
+      })
+
+      assert.equal(sendResult.status, 'delivered', 'Message bus did not report a delivered send')
+
+      const history = await requestJson(
+        `${messageBusUrl}/history?sender=${encodeURIComponent(busSender.beamId)}&recipient=${encodeURIComponent(receiver.beamId)}&limit=5`,
+        {
+          headers: { 'Authorization': `Bearer ${beamBusApiKey}` },
+        },
+      )
+
+      assert(history.messages.some((message) => message.status === 'delivered' && message.intent === 'conversation.message'), 'Message bus history did not contain the delivered message')
+
+      const stats = await requestJson(`${messageBusUrl}/stats`)
+      assert(stats.total >= 1, 'Message bus stats did not record the delivered message')
+      assert(stats.by_agent?.[busSender.beamId]?.sent >= 1, 'Message bus sender stats were not updated')
+    })
+
+    logStep('all cross-stack checks passed')
+  } finally {
+    if (receiver) {
+      receiver.disconnect()
+    }
+    await stopProcess(messageBusProcess)
+    await stopProcess(directoryProcess)
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error('[e2e] failed')
+  if (error instanceof Error) {
+    console.error(error.message)
+    if (error.cause instanceof Error) {
+      console.error(error.cause.message)
+    }
+  } else {
+    console.error(String(error))
+  }
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a cross-stack E2E harness that boots the directory and message bus, then verifies Beam flows through the TypeScript SDK, Python SDK, CLI, and message bus
- wire a dedicated matrix job into GitHub Actions and document the new release gate in the contributor workflow
- fix the Python SDK intent-frame wire format so its signatures and payload parsing match the TypeScript and directory implementation

## Verification
- npm run build
- PATH="/tmp/beam-e2e-venv/bin:$PATH" python3 -m pytest packages/sdk-python/tests/test_frames.py
- PATH="/tmp/beam-e2e-venv/bin:$PATH" npm run test:e2e
- npm test

Closes #4