### PR TITLE
Replace static admin keys with session-based admin auth

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -67,13 +67,24 @@ Typical health response:
 
 If you publish a friendlier `/stats` endpoint in front of the directory, it should usually aggregate health, connection count, and relay metrics.
 
+## Admin auth
+
+Admin and operator access is session-based.
+
+- `POST /admin/auth/magic-link`
+- `POST /admin/auth/verify`
+- `GET /admin/auth/session`
+- `POST /admin/auth/logout`
+
+Successful verification returns a short-lived signed bearer token and also sets the admin session cookie for dashboard clients.
+
 ## `DELETE /admin/waitlist`
 
 Clears waitlist entries from the admin surface.
 
-- Requires the admin key.
-- Accepts `x-admin-key` or a `key` query parameter.
-- Returns `{ ok: true }` on success.
+- Requires an authenticated admin session.
+- Accepts `Authorization: Bearer <admin-session-token>` for API clients or the dashboard session cookie.
+- Returns `{ deleted: <count> }` on success.
 
 ## WebSocket ` /ws `
 

--- a/docs/guide/self-hosting.md
+++ b/docs/guide/self-hosting.md
@@ -38,7 +38,8 @@ For Fly deployments, make sure you:
 - persist `/data` for the SQLite file
 - keep `force_https = true`
 - expose port `3100`
-- configure your admin key and any proxy headers upstream
+- configure `BEAM_ADMIN_EMAILS`, `BEAM_DASHBOARD_URL`, and your proxy headers upstream
+- wire SMTP or Resend for admin magic-link delivery
 
 ## Bare metal
 
@@ -60,7 +61,8 @@ Recommended production setup:
 ## Operational checklist
 
 - Store private keys only on the agents that own them.
-- Protect admin endpoints with `BEAM_ADMIN_KEY`.
+- Bootstrap operator access with `BEAM_ADMIN_EMAILS` and short-lived admin sessions.
+- Configure `SMTP_*` or `RESEND_API_KEY` so production can deliver admin magic links.
 - Back up the directory database.
 - Rotate keys and ACLs when agent ownership changes.
 - Watch connection health, relay latency, and rate-limit events.

--- a/docs/security/beam-shield.md
+++ b/docs/security/beam-shield.md
@@ -27,10 +27,15 @@ Every agent can configure their own security posture via the Shield Config API.
 ### Configuration
 
 ```bash
+# Admin session path for operators
+# 1. POST /admin/auth/magic-link
+# 2. POST /admin/auth/verify
+# 3. reuse the returned bearer token below
+
 # Set whitelist mode (e.g., for internal agent fleet)
 curl -X PATCH https://api.beam.directory/shield/config/agent@org.beam.directory \
   -H "Content-Type: application/json" \
-  -H "X-Admin-Key: your-key" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "mode": "whitelist",
     "allowlist": ["*@org.beam.directory"],
@@ -41,7 +46,7 @@ curl -X PATCH https://api.beam.directory/shield/config/agent@org.beam.directory 
 # Set open mode (e.g., for public-facing agents)
 curl -X PATCH https://api.beam.directory/shield/config/agent@org.beam.directory \
   -H "Content-Type: application/json" \
-  -H "X-Admin-Key: your-key" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "mode": "open",
     "minTrust": 0.3,
@@ -112,7 +117,7 @@ GET /shield/config/:beamId
 
 # Update shield config
 PATCH /shield/config/:beamId
-# Auth: X-Admin-Key header or Ed25519 signature
+# Auth: admin bearer session or Ed25519 signature
 
 # Get audit events for a sender (admin only)
 GET /shield/audit/:beamId?hours=24

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -67,9 +67,9 @@ No wildcard origins. No `*`.
 | Resource | Auth Method |
 |----------|------------|
 | Intent relay | Ed25519 signature on every frame |
-| Visibility toggle | Ed25519 signature or admin key |
+| Visibility toggle | Ed25519 signature, agent API key, or admin session |
 | Delegations | Ed25519 signature (grantor) |
-| Admin endpoints | `x-admin-key` header |
+| Admin endpoints | Admin session bearer token or dashboard session cookie |
 | Billing webhook | Stripe signature verification (`whsec_*`) |
 | Federation | Mutual TLS / peer registration |
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1,37 +1,65 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import Layout from './components/Layout'
+import { AdminAuthProvider, useAdminAuth } from './lib/admin-auth'
 import AgentProfilePage from './pages/AgentProfilePage'
 import AgentsPage from './pages/AgentsPage'
 import AlertsPage from './pages/AlertsPage'
+import AuthCallbackPage from './pages/AuthCallbackPage'
 import AuditPage from './pages/AuditPage'
 import DeadLetterPage from './pages/DeadLetterPage'
 import ErrorsPage from './pages/ErrorsPage'
 import FederationPage from './pages/FederationPage'
 import IntentsPage from './pages/IntentsPage'
+import LoginPage from './pages/LoginPage'
 import OverviewPage from './pages/OverviewPage'
 import RegisterPage from './pages/RegisterPage'
 import SettingsPage from './pages/SettingsPage'
 import TraceDetailPage from './pages/TraceDetailPage'
 
+function RequireAdminSession({ children }: { children: JSX.Element }) {
+  const { session, loading } = useAdminAuth()
+
+  if (loading) {
+    return <div className="min-h-screen bg-slate-50 dark:bg-slate-950" />
+  }
+
+  if (!session) {
+    return <Navigate to="/login" replace />
+  }
+
+  return children
+}
+
 export default function App() {
   return (
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<OverviewPage />} />
-          <Route path="intents" element={<IntentsPage />} />
-          <Route path="intents/:nonce" element={<TraceDetailPage />} />
-          <Route path="audit" element={<AuditPage />} />
-          <Route path="agents" element={<AgentsPage />} />
-          <Route path="agents/:beamId" element={<AgentProfilePage />} />
-          <Route path="federation" element={<FederationPage />} />
-          <Route path="errors" element={<ErrorsPage />} />
-          <Route path="alerts" element={<AlertsPage />} />
-          <Route path="dead-letter" element={<DeadLetterPage />} />
-          <Route path="register" element={<RegisterPage />} />
-          <Route path="settings" element={<SettingsPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <AdminAuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route
+            path="/"
+            element={(
+              <RequireAdminSession>
+                <Layout />
+              </RequireAdminSession>
+            )}
+          >
+            <Route index element={<OverviewPage />} />
+            <Route path="intents" element={<IntentsPage />} />
+            <Route path="intents/:nonce" element={<TraceDetailPage />} />
+            <Route path="audit" element={<AuditPage />} />
+            <Route path="agents" element={<AgentsPage />} />
+            <Route path="agents/:beamId" element={<AgentProfilePage />} />
+            <Route path="federation" element={<FederationPage />} />
+            <Route path="errors" element={<ErrorsPage />} />
+            <Route path="alerts" element={<AlertsPage />} />
+            <Route path="dead-letter" element={<DeadLetterPage />} />
+            <Route path="register" element={<RegisterPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </AdminAuthProvider>
   )
 }

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
 import { Activity, Bot, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
+import { useAdminAuth } from '../lib/admin-auth'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
 
@@ -21,6 +22,7 @@ export default function Layout() {
   const location = useLocation()
   const [menuOpen, setMenuOpen] = useState(false)
   const { theme, toggleTheme } = useThemeMode()
+  const { session, logout } = useAdminAuth()
 
   return (
     <div className="min-h-screen bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-slate-50">
@@ -99,8 +101,17 @@ export default function Layout() {
             </button>
             <div className="min-w-0 flex-1">
               <div className="truncate text-sm font-semibold">Beam Protocol Dashboard v2</div>
-              <div className="text-xs text-slate-500 dark:text-slate-400">Connected to the real directory API</div>
+              <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                {session ? `${session.email} · ${session.role}` : 'Connected to the real directory API'}
+              </div>
             </div>
+            <button
+              className="hidden rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50 sm:inline-flex"
+              onClick={() => void logout()}
+              type="button"
+            >
+              Sign out
+            </button>
             <button
               className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-300 dark:hover:bg-slate-800"
               onClick={toggleTheme}

--- a/packages/dashboard/src/lib/admin-auth.tsx
+++ b/packages/dashboard/src/lib/admin-auth.tsx
@@ -1,0 +1,127 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import {
+  adminAuthApi,
+  ApiError,
+  clearStoredAdminSessionToken,
+  getStoredAdminSessionToken,
+  setStoredAdminSessionToken,
+  type AdminAuthConfig,
+  type AdminMagicLinkResponse,
+  type AdminSessionInfo,
+} from './api'
+
+type AdminAuthContextValue = {
+  session: AdminSessionInfo | null
+  config: AdminAuthConfig | null
+  loading: boolean
+  login: (email: string) => Promise<AdminMagicLinkResponse>
+  verify: (token: string) => Promise<boolean>
+  logout: () => Promise<void>
+  refresh: () => Promise<void>
+}
+
+const AdminAuthContext = createContext<AdminAuthContextValue | null>(null)
+
+export function AdminAuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<AdminSessionInfo | null>(null)
+  const [config, setConfig] = useState<AdminAuthConfig | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  async function loadConfig() {
+    try {
+      const nextConfig = await adminAuthApi.getConfig()
+      setConfig(nextConfig)
+    } catch {
+      setConfig(null)
+    }
+  }
+
+  async function refresh() {
+    try {
+      const nextSession = await adminAuthApi.getSession()
+      setSession(nextSession)
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        clearStoredAdminSessionToken()
+        setSession(null)
+        return
+      }
+
+      throw error
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function bootstrap() {
+      try {
+        await loadConfig()
+        if (cancelled) return
+        await refresh()
+      } catch {
+        if (!cancelled) {
+          clearStoredAdminSessionToken()
+          setSession(null)
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void bootstrap()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function login(email: string) {
+    const response = await adminAuthApi.requestMagicLink(email)
+    await loadConfig()
+    return response
+  }
+
+  async function verify(token: string) {
+    const sessionResponse = await adminAuthApi.verify(token)
+    if (sessionResponse.token) {
+      setStoredAdminSessionToken(sessionResponse.token)
+    } else if (!getStoredAdminSessionToken()) {
+      clearStoredAdminSessionToken()
+    }
+    setSession({
+      email: sessionResponse.email,
+      role: sessionResponse.role,
+      expiresAt: sessionResponse.expiresAt,
+    })
+    await loadConfig()
+    return true
+  }
+
+  async function logout() {
+    try {
+      await adminAuthApi.logout()
+    } catch {
+      // Best-effort logout; local token still needs to be cleared.
+    } finally {
+      clearStoredAdminSessionToken()
+      setSession(null)
+    }
+  }
+
+  return (
+    <AdminAuthContext.Provider value={{ session, config, loading, login, verify, logout, refresh }}>
+      {children}
+    </AdminAuthContext.Provider>
+  )
+}
+
+export function useAdminAuth() {
+  const context = useContext(AdminAuthContext)
+  if (!context) {
+    throw new Error('useAdminAuth must be used within an AdminAuthProvider')
+  }
+
+  return context
+}

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -497,8 +497,34 @@ export interface ExportDownload {
   filename: string
 }
 
+export type AdminRole = 'admin' | 'operator' | 'viewer'
+
+export interface AdminSessionInfo {
+  email: string
+  role: AdminRole
+  expiresAt: string
+  token?: string
+}
+
+export interface AdminAuthConfig {
+  configured: boolean
+  emailDelivery: boolean
+  localDevMagicLinks: boolean
+  sessionTtlSeconds: number
+}
+
+export interface AdminMagicLinkResponse {
+  ok: boolean
+  email: string
+  role: AdminRole
+  expiresAt: string
+  dev: boolean
+  url?: string
+  token?: string
+}
+
 const DEFAULT_DIRECTORY_URL = 'https://api.beam.directory'
-const ADMIN_KEY_STORAGE = 'beam-dashboard-admin-key'
+const ADMIN_SESSION_STORAGE = 'beam-dashboard-admin-session-token'
 const DEFAULT_BUS_URL = (import.meta.env.VITE_BEAM_BUS_URL || 'http://localhost:8420').replace(/\/$/, '')
 const BUS_URL_STORAGE = 'beam-dashboard-bus-url'
 const BUS_API_KEY_STORAGE = 'beam-dashboard-bus-api-key'
@@ -518,37 +544,37 @@ export class ApiError extends Error {
   }
 }
 
-export function getStoredAdminKey(): string {
+export function getStoredAdminSessionToken(): string {
   if (typeof window === 'undefined') {
     return ''
   }
 
-  return window.localStorage.getItem(ADMIN_KEY_STORAGE) ?? ''
+  return window.localStorage.getItem(ADMIN_SESSION_STORAGE) ?? ''
 }
 
-export function setStoredAdminKey(value: string): void {
+export function setStoredAdminSessionToken(value: string): void {
   if (typeof window === 'undefined') {
     return
   }
 
   const trimmed = value.trim()
   if (trimmed) {
-    window.localStorage.setItem(ADMIN_KEY_STORAGE, trimmed)
+    window.localStorage.setItem(ADMIN_SESSION_STORAGE, trimmed)
   } else {
-    window.localStorage.removeItem(ADMIN_KEY_STORAGE)
+    window.localStorage.removeItem(ADMIN_SESSION_STORAGE)
   }
 }
 
-export function clearStoredAdminKey(): void {
+export function clearStoredAdminSessionToken(): void {
   if (typeof window === 'undefined') {
     return
   }
 
-  window.localStorage.removeItem(ADMIN_KEY_STORAGE)
+  window.localStorage.removeItem(ADMIN_SESSION_STORAGE)
 }
 
-export function hasStoredAdminKey(): boolean {
-  return getStoredAdminKey().length > 0
+export function hasStoredAdminSessionToken(): boolean {
+  return getStoredAdminSessionToken().length > 0
 }
 
 export function getStoredBusUrl(): string {
@@ -616,11 +642,9 @@ function buildHeaders(initHeaders?: HeadersInit, options?: { admin?: boolean }):
     headers.set('Content-Type', 'application/json')
   }
 
-  if (options?.admin) {
-    const adminKey = getStoredAdminKey()
-    if (adminKey) {
-      headers.set('X-Admin-Key', adminKey)
-    }
+  const sessionToken = getStoredAdminSessionToken()
+  if (sessionToken && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${sessionToken}`)
   }
 
   return headers
@@ -826,6 +850,22 @@ export const directoryApi = {
       filename: getFilenameFromResponse(response, dataset, format),
     }
   },
+}
+
+export const adminAuthApi = {
+  getConfig: () => request<AdminAuthConfig>('/admin/auth/config'),
+  requestMagicLink: (email: string) => request<AdminMagicLinkResponse>('/admin/auth/magic-link', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  }),
+  verify: (token: string) => request<AdminSessionInfo>('/admin/auth/verify', {
+    method: 'POST',
+    body: JSON.stringify({ token }),
+  }),
+  getSession: () => request<AdminSessionInfo>('/admin/auth/session'),
+  logout: () => request<{ ok: boolean }>('/admin/auth/logout', {
+    method: 'POST',
+  }),
 }
 
 export const busApi = {

--- a/packages/dashboard/src/pages/AlertsPage.tsx
+++ b/packages/dashboard/src/pages/AlertsPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { ApiError, directoryApi, type AlertsResponse, type ExportDataset, type ExportFormat } from '../lib/api'
 import { EmptyPanel, PageHeader } from '../components/Observability'
+import { useAdminAuth } from '../lib/admin-auth'
 import { alertSeverityColor, cn, downloadBlob, formatDateTime } from '../lib/utils'
 
 const EXPORT_FORMATS: ExportFormat[] = ['json', 'csv', 'ndjson']
 
 export default function AlertsPage() {
+  const { session } = useAdminAuth()
   const [hours, setHours] = useState(24)
   const [data, setData] = useState<AlertsResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -44,6 +46,11 @@ export default function AlertsPage() {
   }
 
   async function handlePrune() {
+    if (session?.role !== 'admin') {
+      setActionState('Only admins can prune observability datasets.')
+      return
+    }
+
     try {
       setActionState(`Pruning ${pruneDataset} older than ${pruneDays} days…`)
       const result = await directoryApi.pruneObservability(pruneDataset, pruneDays)
@@ -164,8 +171,13 @@ export default function AlertsPage() {
                 value={pruneDays}
                 onChange={(event) => setPruneDays(Number(event.target.value))}
               />
-              <button className="btn-primary w-full" onClick={() => void handlePrune()} type="button">
-                Prune Dataset
+              <button
+                className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={session?.role !== 'admin'}
+                onClick={() => void handlePrune()}
+                type="button"
+              >
+                {session?.role === 'admin' ? 'Prune Dataset' : 'Admin role required'}
               </button>
             </div>
           </div>

--- a/packages/dashboard/src/pages/AuthCallbackPage.tsx
+++ b/packages/dashboard/src/pages/AuthCallbackPage.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { useAuth } from '../lib/auth'
+import { useAdminAuth } from '../lib/admin-auth'
 
 export default function AuthCallbackPage() {
   const [searchParams] = useSearchParams()
-  const { verify } = useAuth()
+  const { verify } = useAdminAuth()
   const navigate = useNavigate()
   const [error, setError] = useState('')
 

--- a/packages/dashboard/src/pages/LoginPage.tsx
+++ b/packages/dashboard/src/pages/LoginPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { useAuth } from '../lib/auth'
+import { useAdminAuth } from '../lib/admin-auth'
 
 export default function LoginPage() {
-  const { login } = useAuth()
+  const { login, config } = useAdminAuth()
   const [email, setEmail] = useState('')
   const [sent, setSent] = useState(false)
   const [error, setError] = useState('')
@@ -16,15 +16,11 @@ export default function LoginPage() {
     
     try {
       const result = await login(email)
-      if (result.ok) {
-        setSent(true)
-        if ((result as any).url) {
-          setDevUrl((result as any).url)
-        }
-      } else {
-        setError(result.error || 'Something went wrong')
+      setSent(true)
+      if (result.url) {
+        setDevUrl(result.url)
       }
-    } catch (err) {
+    } catch {
       setError('Network error. Please try again.')
     } finally {
       setLoading(false)
@@ -60,7 +56,7 @@ export default function LoginPage() {
               Welcome Back
             </h1>
             <p style={{ color: '#52525B', fontSize: '0.9rem', marginBottom: '24px' }}>
-              Sign in to manage your agents.
+              Sign in to access the Beam operator dashboard.
             </p>
 
             <form onSubmit={handleSubmit}>
@@ -119,8 +115,8 @@ export default function LoginPage() {
             </form>
 
             <p style={{ marginTop: '24px', fontSize: '0.82rem', color: '#A1A1AA' }}>
-              We'll send a login link to your email.<br />
-              No password needed.
+              We issue a short-lived admin session after verification.<br />
+              No shared browser key required.
             </p>
           </>
         ) : (
@@ -152,7 +148,7 @@ export default function LoginPage() {
                 borderRadius: '8px',
                 fontSize: '0.82rem',
               }}>
-                <strong>🔧 Dev Mode</strong><br />
+                <strong>🔧 Local Dev</strong><br />
                 <a href={devUrl} style={{ color: '#F75C03', wordBreak: 'break-all' }}>
                   Click to login →
                 </a>
@@ -163,10 +159,9 @@ export default function LoginPage() {
 
         <div style={{ marginTop: '32px', borderTop: '1px solid #E4E4E7', paddingTop: '16px' }}>
           <p style={{ fontSize: '0.82rem', color: '#A1A1AA' }}>
-            Don't have an agent yet?{' '}
-            <a href="https://beam.directory/register.html" style={{ color: '#F75C03' }}>
-              Register one →
-            </a>
+            {config?.emailDelivery
+              ? 'Authorized admins receive a magic link by email.'
+              : 'Without SMTP or Resend, localhost returns the dev magic link directly.'}
           </p>
         </div>
       </div>

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -4,16 +4,13 @@ import {
   BUS_DEFAULT_URL,
   DIRECTORY_URL,
   busApi,
-  clearStoredAdminKey,
   clearStoredBusConfig,
   directoryApi,
   getBusBaseUrl,
-  getStoredAdminKey,
   getStoredBusApiKey,
   getStoredBusUrl,
-  hasStoredAdminKey,
+  hasStoredAdminSessionToken,
   hasStoredBusApiKey,
-  setStoredAdminKey,
   setStoredBusApiKey,
   setStoredBusUrl,
   type BusHealth,
@@ -21,17 +18,17 @@ import {
   type DirectoryHealth,
   type RetentionResponse,
 } from '../lib/api'
+import { useAdminAuth } from '../lib/admin-auth'
 
 const PRIVATE_KEY_PREFIX = 'beam-dashboard-private-key:'
 
 export default function SettingsPage() {
+  const { session, config, logout } = useAdminAuth()
   const [health, setHealth] = useState<DirectoryHealth | null>(null)
   const [busHealth, setBusHealth] = useState<BusHealth | null>(null)
   const [busStats, setBusStats] = useState<BusStats | null>(null)
   const [retention, setRetention] = useState<RetentionResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [adminKey, setAdminKey] = useState(() => getStoredAdminKey())
-  const [adminStatus, setAdminStatus] = useState<string | null>(hasStoredAdminKey() ? 'Admin key stored locally.' : null)
   const [busUrl, setBusUrl] = useState(() => getStoredBusUrl() || BUS_DEFAULT_URL)
   const [busApiKey, setBusApiKey] = useState(() => getStoredBusApiKey())
   const [busStatus, setBusStatus] = useState<string | null>(hasStoredBusApiKey() || getStoredBusUrl() ? 'Bus configuration stored locally.' : null)
@@ -92,22 +89,6 @@ export default function SettingsPage() {
     return Object.keys(localStorage).filter((key) => key.startsWith(PRIVATE_KEY_PREFIX))
   }, [])
 
-  async function validateAdminKey() {
-    try {
-      setStoredAdminKey(adminKey)
-      await directoryApi.getObservabilityOverview(24)
-      setAdminStatus('Admin key validated against observability endpoints.')
-    } catch (err) {
-      setAdminStatus(err instanceof ApiError ? err.message : 'Admin validation failed')
-    }
-  }
-
-  function clearAdminKey() {
-    clearStoredAdminKey()
-    setAdminKey('')
-    setAdminStatus('Admin key removed from local storage.')
-  }
-
   async function validateBusConfig() {
     try {
       setStoredBusUrl(busUrl)
@@ -137,7 +118,7 @@ export default function SettingsPage() {
     <div className="space-y-6">
       <section>
         <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Connection health, admin auth, and browser-stored credentials for observability access.</p>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">Connection health, admin session state, and browser-stored credentials for observability access.</p>
       </section>
 
       {error ? (
@@ -169,25 +150,19 @@ export default function SettingsPage() {
       <section className="grid gap-4 lg:grid-cols-2">
         <div className="panel space-y-4">
           <div className="panel-title">Admin access</div>
-          <input
-            className="input-field"
-            placeholder="Paste BEAM_ADMIN_KEY"
-            type="password"
-            value={adminKey}
-            onChange={(event) => setAdminKey(event.target.value)}
-          />
+          <InfoRow label="Signed in as" value={session?.email ?? 'No active session'} />
+          <InfoRow label="Role" value={session?.role ?? '—'} />
+          <InfoRow label="Session expires" value={session?.expiresAt ?? '—'} />
+          <InfoRow label="Authorized admins configured" value={config?.configured ? 'Yes' : 'No'} />
+          <InfoRow label="Magic-link delivery" value={config?.emailDelivery ? 'Email provider configured' : 'Local dev / bootstrap only'} />
           <div className="flex flex-wrap gap-3">
-            <button className="btn-primary" onClick={() => void validateAdminKey()} type="button">
-              Save & Validate
-            </button>
-            <button className="btn-secondary" onClick={clearAdminKey} type="button">
-              Clear
+            <button className="btn-secondary" onClick={() => void logout()} type="button">
+              Sign out
             </button>
           </div>
           <p className="text-sm text-slate-500 dark:text-slate-400">
-            The admin key is stored in `localStorage` and attached to `/observability/*` requests as `X-Admin-Key`.
+            Observability requests now use an authenticated admin session instead of a pasted static browser key.
           </p>
-          {adminStatus ? <p className="text-sm text-slate-600 dark:text-slate-300">{adminStatus}</p> : null}
         </div>
 
         <div className="panel space-y-4">
@@ -232,7 +207,7 @@ export default function SettingsPage() {
         <div className="panel space-y-3">
           <div className="panel-title">Browser storage</div>
           <InfoRow label="Stored private keys" value={String(storedKeys.length)} />
-          <InfoRow label="Admin key" value={hasStoredAdminKey() ? 'Stored' : 'Not stored'} />
+          <InfoRow label="Admin session token" value={hasStoredAdminSessionToken() ? 'Stored' : 'Not stored'} />
           <InfoRow label="Bus API key" value={hasStoredBusApiKey() ? 'Stored' : 'Not stored'} />
           <InfoRow label="Bus URL" value={getStoredBusUrl() || BUS_DEFAULT_URL} />
           <p className="text-sm text-slate-500 dark:text-slate-400">Private keys generated on the Register page stay in `localStorage` for this browser profile only.</p>

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -39,7 +39,10 @@ Default local endpoints:
 
 - `PORT` - server port, default `3100`
 - `DB_PATH` - SQLite database path, default `./beam-directory.db`
-- `BEAM_ADMIN_KEY` - enables admin and dashboard endpoints
+- `BEAM_ADMIN_EMAILS` - comma-separated bootstrap admin emails
+- `BEAM_OPERATOR_EMAILS` - comma-separated read-only operator emails
+- `BEAM_VIEWER_EMAILS` - comma-separated read-only viewer emails
+- `BEAM_DASHBOARD_URL` - dashboard origin used in admin magic links
 - `BEAM_DIRECTORY_BASE_URL` - DID base URL override
 - `PUBLIC_BASE_URL` - public origin used in verification links
 - `BEAM_RATE_LIMIT_PER_MIN` - global per-agent rate limit override
@@ -71,12 +74,31 @@ npm run build
 docker build -t beam-directory .
 docker run --rm -p 3100:3100 \
   -e JWT_SECRET=local-dev-secret \
-  -e BEAM_ADMIN_KEY=admin-dev-key \
+  -e BEAM_ADMIN_EMAILS=ops@example.com \
+  -e BEAM_DASHBOARD_URL=http://localhost:5173 \
   -v "$PWD/data:/data" \
   beam-directory
 ```
 
 If `LITESTREAM_REPLICA_BUCKET` is set, the container starts with Litestream replication enabled.
+
+## Admin Auth
+
+Directory operator access now uses authenticated admin sessions instead of a pasted static browser key.
+
+Local development:
+
+1. Set `BEAM_ADMIN_EMAILS=you@example.com`
+2. Start the directory with `JWT_SECRET`
+3. Request a magic link through `POST /admin/auth/magic-link`
+4. On `localhost`, the API returns the dev callback URL directly if SMTP/Resend is not configured
+
+Production:
+
+- configure `BEAM_ADMIN_EMAILS` and optional operator/viewer email lists
+- set `BEAM_DASHBOARD_URL` to the real dashboard origin
+- configure `SMTP_*` or `RESEND_API_KEY` for magic-link delivery
+- the dashboard and admin APIs use `/admin/auth/*` plus a short-lived signed session
 
 ## Fly.io
 

--- a/packages/directory/src/admin-auth.test.ts
+++ b/packages/directory/src/admin-auth.test.ts
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createApp } from './server.js'
+import { assignDirectoryRole, createDatabase, listAuditLog } from './db.js'
+import { getLocalDirectoryUrl } from './federation.js'
+
+test('admin auth issues sessions, supports session introspection, and audits login/logout', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    assignDirectoryRole(db, {
+      userId: 'ops@example.com',
+      role: 'admin',
+      directoryUrl: getLocalDirectoryUrl(),
+    })
+
+    const app = createApp(db)
+    const challengeResponse = await app.request(new Request('http://localhost/admin/auth/magic-link', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ email: 'ops@example.com' }),
+    }))
+
+    assert.equal(challengeResponse.status, 200)
+    const challenge = await challengeResponse.json() as { token?: string; url?: string; dev: boolean }
+    assert.equal(challenge.dev, true)
+    assert.ok(challenge.token)
+    assert.ok(challenge.url?.includes('/auth/callback?token='))
+
+    const verifyResponse = await app.request(new Request('http://localhost/admin/auth/verify', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: challenge.token }),
+    }))
+
+    assert.equal(verifyResponse.status, 200)
+    assert.ok((verifyResponse.headers.get('set-cookie') ?? '').includes('beam_admin_session='))
+
+    const verified = await verifyResponse.json() as { token: string; email: string; role: string }
+    assert.equal(verified.email, 'ops@example.com')
+    assert.equal(verified.role, 'admin')
+
+    const sessionResponse = await app.request(new Request('http://localhost/admin/auth/session', {
+      headers: { Authorization: `Bearer ${verified.token}` },
+    }))
+    assert.equal(sessionResponse.status, 200)
+    const session = await sessionResponse.json() as { email: string; role: string }
+    assert.equal(session.email, 'ops@example.com')
+    assert.equal(session.role, 'admin')
+
+    const logoutResponse = await app.request(new Request('http://localhost/admin/auth/logout', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${verified.token}` },
+    }))
+    assert.equal(logoutResponse.status, 200)
+
+    const afterLogoutResponse = await app.request(new Request('http://localhost/admin/auth/session', {
+      headers: { Authorization: `Bearer ${verified.token}` },
+    }))
+    assert.equal(afterLogoutResponse.status, 401)
+
+    const auditActions = listAuditLog(db, { limit: 10 }).map((entry) => entry.action)
+    assert.ok(auditActions.includes('admin.auth.challenge.issued'))
+    assert.ok(auditActions.includes('admin.auth.login'))
+    assert.ok(auditActions.includes('admin.auth.logout'))
+  } finally {
+    db.close()
+  }
+})

--- a/packages/directory/src/admin-auth.ts
+++ b/packages/directory/src/admin-auth.ts
@@ -1,0 +1,429 @@
+import { createHmac, randomBytes, randomUUID } from 'node:crypto'
+import type { Database } from 'better-sqlite3'
+import type { Context } from 'hono'
+import { getDirectoryRole } from './db.js'
+import { getLocalDirectoryUrl } from './federation.js'
+import type { AdminMagicLinkRow, AdminSessionRow, DirectoryRoleRow } from './types.js'
+
+export type AdminRole = DirectoryRoleRow['role']
+
+type AdminSessionClaims = {
+  typ: 'beam-admin'
+  sid: string
+  email: string
+  role: AdminRole
+  exp: number
+}
+
+export type AdminSession = {
+  id: string
+  email: string
+  role: AdminRole
+  expiresAt: string
+  authType: 'cookie' | 'bearer'
+}
+
+const ADMIN_MAGIC_LINK_TTL_MS = 15 * 60 * 1000
+const ADMIN_SESSION_TTL_MS = Math.max(
+  15 * 60 * 1000,
+  (Number.parseInt(process.env['BEAM_ADMIN_SESSION_TTL_HOURS'] ?? '168', 10) || 168) * 60 * 60 * 1000,
+)
+export const ADMIN_SESSION_COOKIE = 'beam_admin_session'
+
+const ROLE_ORDER: Record<AdminRole, number> = {
+  viewer: 0,
+  operator: 1,
+  admin: 2,
+}
+
+function getJwtSecret(): string {
+  const secret = process.env['JWT_SECRET']
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is required')
+  }
+
+  return secret
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+function parseEmailList(value: string | undefined): Set<string> {
+  if (!value) {
+    return new Set()
+  }
+
+  return new Set(
+    value
+      .split(',')
+      .map((entry) => normalizeEmail(entry))
+      .filter(Boolean),
+  )
+}
+
+function createSessionJwt(claims: AdminSessionClaims): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url')
+  const signature = createHmac('sha256', getJwtSecret())
+    .update(`${header}.${payload}`)
+    .digest('base64url')
+
+  return `${header}.${payload}.${signature}`
+}
+
+function verifySessionJwt(token: string): AdminSessionClaims | null {
+  try {
+    const [header, payload, signature] = token.split('.')
+    if (!header || !payload || !signature) {
+      return null
+    }
+
+    const expectedSignature = createHmac('sha256', getJwtSecret())
+      .update(`${header}.${payload}`)
+      .digest('base64url')
+
+    if (signature !== expectedSignature) {
+      return null
+    }
+
+    const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Partial<AdminSessionClaims>
+    if (claims.typ !== 'beam-admin' || !claims.sid || !claims.email || !claims.role || !claims.exp) {
+      return null
+    }
+
+    if (claims.exp <= Date.now()) {
+      return null
+    }
+
+    if (!(claims.role in ROLE_ORDER)) {
+      return null
+    }
+
+    return claims as AdminSessionClaims
+  } catch {
+    return null
+  }
+}
+
+function parseCookieHeader(cookieHeader: string | null | undefined): Record<string, string> {
+  if (!cookieHeader) {
+    return {}
+  }
+
+  return cookieHeader
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((cookies, part) => {
+      const index = part.indexOf('=')
+      if (index <= 0) {
+        return cookies
+      }
+
+      const key = part.slice(0, index).trim()
+      const value = part.slice(index + 1).trim()
+      cookies[key] = value
+      return cookies
+    }, {})
+}
+
+function getRequestOrigin(c: Context): string {
+  return c.req.header('origin') ?? c.req.header('referer') ?? c.req.url
+}
+
+function shouldUseCrossSiteCookie(c: Context): boolean {
+  const origin = getRequestOrigin(c)
+  return origin.startsWith('https://') && !origin.includes('localhost') && !origin.includes('127.0.0.1')
+}
+
+function getDashboardUrl(): string {
+  return (process.env['BEAM_DASHBOARD_URL'] ?? process.env['APP_URL'] ?? 'https://dashboard.beam.directory').replace(/\/$/, '')
+}
+
+function getConfiguredRoleForEmail(email: string): AdminRole | null {
+  const normalizedEmail = normalizeEmail(email)
+  if (parseEmailList(process.env['BEAM_ADMIN_EMAILS']).has(normalizedEmail)) {
+    return 'admin'
+  }
+
+  if (parseEmailList(process.env['BEAM_OPERATOR_EMAILS']).has(normalizedEmail)) {
+    return 'operator'
+  }
+
+  if (parseEmailList(process.env['BEAM_VIEWER_EMAILS']).has(normalizedEmail)) {
+    return 'viewer'
+  }
+
+  return null
+}
+
+export function resolveAdminRole(db: Database, email: string): AdminRole | null {
+  const normalizedEmail = normalizeEmail(email)
+  const databaseRole = getDirectoryRole(db, normalizedEmail, getLocalDirectoryUrl())?.role
+  return databaseRole ?? getConfiguredRoleForEmail(normalizedEmail)
+}
+
+export function isAdminRoleConfigured(db: Database): boolean {
+  const configured = (
+    parseEmailList(process.env['BEAM_ADMIN_EMAILS']).size +
+    parseEmailList(process.env['BEAM_OPERATOR_EMAILS']).size +
+    parseEmailList(process.env['BEAM_VIEWER_EMAILS']).size
+  ) > 0
+
+  if (configured) {
+    return true
+  }
+
+  const row = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM directory_roles
+    WHERE directory_url = ?
+  `).get(getLocalDirectoryUrl()) as { count: number } | undefined
+
+  return (row?.count ?? 0) > 0
+}
+
+export function roleSatisfies(actual: AdminRole, required: AdminRole): boolean {
+  return ROLE_ORDER[actual] >= ROLE_ORDER[required]
+}
+
+export function issueAdminMagicLink(db: Database, email: string): {
+  email: string
+  role: AdminRole
+  token: string
+  url: string
+  expiresAt: string
+} | null {
+  const normalizedEmail = normalizeEmail(email)
+  const role = resolveAdminRole(db, normalizedEmail)
+  if (!role) {
+    return null
+  }
+
+  const token = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + ADMIN_MAGIC_LINK_TTL_MS).toISOString()
+  const createdAt = new Date().toISOString()
+
+  db.prepare(`
+    INSERT INTO admin_magic_links (token, email, role, created_at, expires_at, used)
+    VALUES (?, ?, ?, ?, ?, 0)
+  `).run(token, normalizedEmail, role, createdAt, expiresAt)
+
+  db.prepare(`
+    DELETE FROM admin_magic_links
+    WHERE expires_at <= ? OR used = 1
+  `).run(createdAt)
+
+  const url = `${getDashboardUrl()}/auth/callback?token=${token}`
+
+  return {
+    email: normalizedEmail,
+    role,
+    token,
+    url,
+    expiresAt,
+  }
+}
+
+function consumeMagicLink(db: Database, token: string): { email: string; role: AdminRole } | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM admin_magic_links
+    WHERE token = ? AND used = 0 AND expires_at > ?
+  `).get(token, new Date().toISOString()) as AdminMagicLinkRow | undefined
+
+  if (!row) {
+    return null
+  }
+
+  db.prepare('UPDATE admin_magic_links SET used = 1 WHERE token = ?').run(token)
+  return {
+    email: row.email,
+    role: row.role,
+  }
+}
+
+export function createAdminSession(
+  db: Database,
+  input: { email: string; role: AdminRole },
+): { token: string; session: AdminSession } {
+  const id = randomUUID()
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + ADMIN_SESSION_TTL_MS).toISOString()
+  const timestamp = now.toISOString()
+
+  db.prepare(`
+    INSERT INTO admin_sessions (id, email, role, created_at, last_seen_at, expires_at, revoked_at)
+    VALUES (?, ?, ?, ?, ?, ?, NULL)
+  `).run(id, normalizeEmail(input.email), input.role, timestamp, timestamp, expiresAt)
+
+  const token = createSessionJwt({
+    typ: 'beam-admin',
+    sid: id,
+    email: normalizeEmail(input.email),
+    role: input.role,
+    exp: Date.parse(expiresAt),
+  })
+
+  return {
+    token,
+    session: {
+      id,
+      email: normalizeEmail(input.email),
+      role: input.role,
+      expiresAt,
+      authType: 'bearer',
+    },
+  }
+}
+
+export function createAdminSessionFromMagicLink(
+  db: Database,
+  token: string,
+): { token: string; session: AdminSession } | null {
+  const link = consumeMagicLink(db, token)
+  if (!link) {
+    return null
+  }
+
+  const effectiveRole = resolveAdminRole(db, link.email)
+  if (!effectiveRole) {
+    return null
+  }
+
+  return createAdminSession(db, {
+    email: link.email,
+    role: effectiveRole,
+  })
+}
+
+export function revokeAdminSession(db: Database, sessionId: string): void {
+  db.prepare(`
+    UPDATE admin_sessions
+    SET revoked_at = ?
+    WHERE id = ? AND revoked_at IS NULL
+  `).run(new Date().toISOString(), sessionId)
+}
+
+function getAdminTokenFromRequest(request: Request): { token: string; authType: 'cookie' | 'bearer' } | null {
+  const authorization = request.headers.get('authorization') ?? ''
+  if (authorization.toLowerCase().startsWith('bearer ')) {
+    const token = authorization.slice(7).trim()
+    if (token) {
+      return { token, authType: 'bearer' }
+    }
+  }
+
+  const cookies = parseCookieHeader(request.headers.get('cookie'))
+  const cookieToken = cookies[ADMIN_SESSION_COOKIE]
+  if (cookieToken) {
+    return { token: cookieToken, authType: 'cookie' }
+  }
+
+  return null
+}
+
+export function getAdminSessionFromRequest(db: Database, request: Request): AdminSession | null {
+  const token = getAdminTokenFromRequest(request)
+  if (!token) {
+    return null
+  }
+
+  const claims = verifySessionJwt(token.token)
+  if (!claims) {
+    return null
+  }
+
+  const sessionRow = db.prepare(`
+    SELECT *
+    FROM admin_sessions
+    WHERE id = ? AND revoked_at IS NULL AND expires_at > ?
+  `).get(claims.sid, new Date().toISOString()) as AdminSessionRow | undefined
+
+  if (!sessionRow) {
+    return null
+  }
+
+  const effectiveRole = resolveAdminRole(db, claims.email)
+  if (!effectiveRole || effectiveRole !== claims.role || sessionRow.email !== claims.email || sessionRow.role !== claims.role) {
+    revokeAdminSession(db, claims.sid)
+    return null
+  }
+
+  db.prepare('UPDATE admin_sessions SET last_seen_at = ? WHERE id = ?').run(new Date().toISOString(), claims.sid)
+
+  return {
+    id: sessionRow.id,
+    email: sessionRow.email,
+    role: sessionRow.role,
+    expiresAt: sessionRow.expires_at,
+    authType: token.authType,
+  }
+}
+
+export function requireAdminRole(
+  db: Database,
+  request: Request,
+  requiredRole: AdminRole,
+): { ok: true; session: AdminSession } | Response {
+  const session = getAdminSessionFromRequest(db, request)
+  if (!session) {
+    if (!isAdminRoleConfigured(db)) {
+      return new Response(JSON.stringify({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+
+    return new Response(JSON.stringify({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }), {
+      status: 401,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  if (!roleSatisfies(session.role, requiredRole)) {
+    return new Response(JSON.stringify({ error: 'Forbidden', errorCode: 'FORBIDDEN' }), {
+      status: 403,
+      headers: { 'content-type': 'application/json' },
+    })
+  }
+
+  return { ok: true, session }
+}
+
+export function buildAdminSessionCookie(c: Context, token: string, maxAgeSeconds: number): string {
+  const cookieParts = [
+    `${ADMIN_SESSION_COOKIE}=${token}`,
+    'Path=/',
+    'HttpOnly',
+    `Max-Age=${maxAgeSeconds}`,
+    shouldUseCrossSiteCookie(c) ? 'SameSite=None' : 'SameSite=Lax',
+  ]
+
+  if (shouldUseCrossSiteCookie(c)) {
+    cookieParts.push('Secure')
+  }
+
+  return cookieParts.join('; ')
+}
+
+export function clearAdminSessionCookie(c: Context): string {
+  const cookieParts = [
+    `${ADMIN_SESSION_COOKIE}=`,
+    'Path=/',
+    'HttpOnly',
+    'Max-Age=0',
+    shouldUseCrossSiteCookie(c) ? 'SameSite=None' : 'SameSite=Lax',
+  ]
+
+  if (shouldUseCrossSiteCookie(c)) {
+    cookieParts.push('Secure')
+  }
+
+  return cookieParts.join('; ')
+}
+
+export function getAdminSessionTtlSeconds(): number {
+  return Math.floor(ADMIN_SESSION_TTL_MS / 1000)
+}

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -236,6 +236,31 @@ function initSchema(db: DB): void {
     CREATE INDEX IF NOT EXISTS idx_directory_roles_role
       ON directory_roles(role, directory_url);
 
+    CREATE TABLE IF NOT EXISTS admin_magic_links (
+      token TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      role TEXT NOT NULL CHECK(role IN ('admin', 'operator', 'viewer')),
+      created_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      used INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_admin_magic_links_email
+      ON admin_magic_links(email, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS admin_sessions (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      role TEXT NOT NULL CHECK(role IN ('admin', 'operator', 'viewer')),
+      created_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL,
+      expires_at TEXT NOT NULL,
+      revoked_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_admin_sessions_email
+      ON admin_sessions(email, created_at DESC);
+
     CREATE TABLE IF NOT EXISTS audit_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       action TEXT NOT NULL,
@@ -1661,6 +1686,36 @@ export function getDirectoryRole(db: DB, userId: string, directoryUrl: string): 
   `).get(userId, directoryUrl) as DirectoryRoleRow | undefined
 
   return row ?? null
+}
+
+export function listDirectoryRoles(
+  db: DB,
+  directoryUrl: string,
+): DirectoryRoleRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM directory_roles
+    WHERE directory_url = ?
+    ORDER BY
+      CASE role
+        WHEN 'admin' THEN 0
+        WHEN 'operator' THEN 1
+        ELSE 2
+      END,
+      user_id ASC
+  `).all(directoryUrl) as DirectoryRoleRow[]
+}
+
+export function deleteDirectoryRole(
+  db: DB,
+  input: { userId: string; directoryUrl: string }
+): boolean {
+  const result = db.prepare(`
+    DELETE FROM directory_roles
+    WHERE user_id = ? AND directory_url = ?
+  `).run(input.userId, input.directoryUrl)
+
+  return result.changes > 0
 }
 
 export function logAuditEvent(

--- a/packages/directory/src/email.ts
+++ b/packages/directory/src/email.ts
@@ -94,3 +94,31 @@ export async function sendAgentVerificationEmail(input: {
   console.warn('Email verification disabled: set SMTP_HOST or RESEND_API_KEY to enable delivery')
   return false
 }
+
+export async function sendAdminMagicLinkEmail(input: {
+  email: string
+  url: string
+  role: 'admin' | 'operator' | 'viewer'
+}): Promise<boolean> {
+  const message = {
+    from: process.env['SMTP_FROM'],
+    to: input.email,
+    subject: 'Beam admin sign-in link',
+    text: `Use this Beam admin sign-in link to continue as ${input.role}: ${input.url}`,
+    html: `<p>Use this Beam admin sign-in link to continue as <strong>${input.role}</strong>.</p><p><a href="${input.url}">Sign in to Beam Dashboard</a></p>`,
+  }
+
+  if (process.env['SMTP_HOST']) {
+    const transporter = await createTransport()
+    await transporter.sendMail(message)
+    return true
+  }
+
+  if (process.env['RESEND_API_KEY']) {
+    await sendWithResend(message)
+    return true
+  }
+
+  console.warn('Admin email delivery disabled: set SMTP_HOST or RESEND_API_KEY to enable delivery')
+  return false
+}

--- a/packages/directory/src/federation.test.ts
+++ b/packages/directory/src/federation.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { generateKeyPairSync, randomUUID, sign } from 'node:crypto'
+import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
 import {
   assignDirectoryRole,
@@ -250,30 +251,33 @@ test('federation relay forwards intents with hop counting', async () => {
   }
 })
 
-test('audit log endpoint is admin-only through RBAC', async () => {
+test('audit log endpoint accepts authenticated admin sessions', async () => {
   const db = createDatabase(':memory:')
-  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
   const previousDirectoryUrl = process.env['BEAM_DIRECTORY_URL']
 
-  process.env['BEAM_ADMIN_KEY'] = ''
   process.env['BEAM_DIRECTORY_URL'] = 'https://local.example'
 
   try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
     assignDirectoryRole(db, {
-      userId: 'alice',
+      userId: 'alice@example.com',
       role: 'admin',
       directoryUrl: getLocalDirectoryUrl(),
     })
+    const session = createAdminSession(db, {
+      email: 'alice@example.com',
+      role: 'admin',
+    })
     logAuditEvent(db, {
       action: 'federation.peer.register',
-      actor: 'alice',
+      actor: 'alice@example.com',
       target: 'https://peer.example',
       details: { trustLevel: 0.5 },
     })
 
     const app = createApp(db)
     const response = await app.request(new Request('http://localhost/admin/audit?limit=10', {
-      headers: { 'x-directory-user': 'alice' },
+      headers: { Authorization: `Bearer ${session.token}` },
     }))
 
     assert.equal(response.status, 200)
@@ -281,7 +285,6 @@ test('audit log endpoint is admin-only through RBAC', async () => {
     assert.equal(payload.total, 1)
     assert.equal(payload.entries[0]?.action, 'federation.peer.register')
   } finally {
-    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
     process.env['BEAM_DIRECTORY_URL'] = previousDirectoryUrl
     db.close()
   }

--- a/packages/directory/src/observability.test.ts
+++ b/packages/directory/src/observability.test.ts
@@ -1,17 +1,33 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { generateKeyPairSync } from 'node:crypto'
+import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
 import {
   appendIntentTraceEvent,
+  assignDirectoryRole,
   createDatabase,
   finalizeIntentLog,
   logAuditEvent,
   logIntentStart,
   registerAgent,
 } from './db.js'
+import { getLocalDirectoryUrl } from './federation.js'
 import { logShieldEvent } from './shield/audit.js'
 import type { IntentFrame } from './types.js'
+
+function createAdminHeaders(db: ReturnType<typeof createDatabase>, email = 'ops@example.com', role: 'admin' | 'operator' | 'viewer' = 'admin') {
+  process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+  assignDirectoryRole(db, {
+    userId: email,
+    role,
+    directoryUrl: getLocalDirectoryUrl(),
+  })
+  const session = createAdminSession(db, { email, role })
+  return {
+    Authorization: `Bearer ${session.token}`,
+  }
+}
 
 function registerFixtureAgents(db: ReturnType<typeof createDatabase>) {
   const senderKeys = generateKeyPairSync('ed25519')
@@ -48,9 +64,6 @@ function createFrame(nonce: string, timestamp = new Date().toISOString()): Inten
 }
 
 test('observability trace endpoint returns lifecycle, audit, and shield context', async () => {
-  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
-  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
-
   const db = createDatabase(':memory:')
   try {
     registerFixtureAgents(db)
@@ -112,7 +125,7 @@ test('observability trace endpoint returns lifecycle, audit, and shield context'
 
     const app = createApp(db)
     const response = await app.request(new Request(`http://localhost/observability/intents/${encodeURIComponent(frame.nonce)}`, {
-      headers: { 'x-admin-key': 'test-admin' },
+      headers: createAdminHeaders(db),
     }))
 
     assert.equal(response.status, 200)
@@ -128,15 +141,11 @@ test('observability trace endpoint returns lifecycle, audit, and shield context'
     assert.equal(payload.audit[0]?.action, 'federation.relay')
     assert.equal(payload.shield[0]?.decision, 'hold')
   } finally {
-    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
     db.close()
   }
 })
 
 test('alerts endpoint surfaces elevated error rate and error hotspots', async () => {
-  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
-  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
-
   const db = createDatabase(':memory:')
   try {
     registerFixtureAgents(db)
@@ -156,7 +165,7 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
 
     const app = createApp(db)
     const response = await app.request(new Request('http://localhost/observability/alerts?hours=24', {
-      headers: { 'x-admin-key': 'test-admin' },
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
     }))
 
     assert.equal(response.status, 200)
@@ -165,15 +174,11 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
     assert.ok(payload.alerts.some((alert) => alert.id === 'network-error-rate'))
     assert.ok(payload.alerts.some((alert) => alert.id === 'error-hotspot-timeout'))
   } finally {
-    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
     db.close()
   }
 })
 
 test('prune endpoint removes aged intents and trace records', async () => {
-  const previousAdminKey = process.env['BEAM_ADMIN_KEY']
-  process.env['BEAM_ADMIN_KEY'] = 'test-admin'
-
   const db = createDatabase(':memory:')
   try {
     registerFixtureAgents(db)
@@ -196,7 +201,7 @@ test('prune endpoint removes aged intents and trace records', async () => {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'x-admin-key': 'test-admin',
+        ...createAdminHeaders(db),
       },
       body: JSON.stringify({ dataset: 'intents', olderThanDays: 30 }),
     }))
@@ -212,7 +217,28 @@ test('prune endpoint removes aged intents and trace records', async () => {
     assert.equal(remainingIntents.count, 0)
     assert.equal(remainingTraces.count, 0)
   } finally {
-    process.env['BEAM_ADMIN_KEY'] = previousAdminKey
+    db.close()
+  }
+})
+
+test('prune endpoint rejects read-only sessions', async () => {
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const app = createApp(db)
+    const response = await app.request(new Request('http://localhost/observability/prune', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+      },
+      body: JSON.stringify({ dataset: 'intents', olderThanDays: 30 }),
+    }))
+
+    assert.equal(response.status, 403)
+    const payload = await response.json() as { errorCode: string }
+    assert.equal(payload.errorCode, 'FORBIDDEN')
+  } finally {
     db.close()
   }
 })

--- a/packages/directory/src/routes/admin-auth.ts
+++ b/packages/directory/src/routes/admin-auth.ts
@@ -1,0 +1,141 @@
+import { Hono } from 'hono'
+import type { Database } from 'better-sqlite3'
+import { clearAdminSessionCookie, createAdminSessionFromMagicLink, buildAdminSessionCookie, getAdminSessionFromRequest, getAdminSessionTtlSeconds, issueAdminMagicLink, isAdminRoleConfigured, revokeAdminSession } from '../admin-auth.js'
+import { logAuditEvent } from '../db.js'
+import { isEmailDeliveryConfigured, sendAdminMagicLinkEmail } from '../email.js'
+
+function isLocalDevRequest(request: Request): boolean {
+  const origin = request.headers.get('origin') ?? request.url
+  return origin.includes('localhost') || origin.includes('127.0.0.1')
+}
+
+export function adminAuthRouter(db: Database): Hono {
+  const router = new Hono()
+
+  router.get('/config', (c) => {
+    return c.json({
+      configured: isAdminRoleConfigured(db),
+      emailDelivery: isEmailDeliveryConfigured(),
+      localDevMagicLinks: isLocalDevRequest(c.req.raw),
+      sessionTtlSeconds: getAdminSessionTtlSeconds(),
+    })
+  })
+
+  router.post('/magic-link', async (c) => {
+    const body = await c.req.json().catch(() => ({})) as { email?: string }
+    const email = body.email?.trim().toLowerCase()
+
+    if (!email || !email.includes('@')) {
+      return c.json({ error: 'Valid email required', errorCode: 'INVALID_EMAIL' }, 400)
+    }
+
+    const link = issueAdminMagicLink(db, email)
+    if (!link) {
+      return c.json({ error: 'This email is not authorized for admin access', errorCode: 'UNAUTHORIZED' }, 403)
+    }
+
+    if (isEmailDeliveryConfigured()) {
+      try {
+        await sendAdminMagicLinkEmail({
+          email: link.email,
+          url: link.url,
+          role: link.role,
+        })
+      } catch (error) {
+        console.error('Admin magic link delivery failed:', error)
+        return c.json({ error: 'Failed to send admin magic link', errorCode: 'EMAIL_DELIVERY_FAILED' }, 502)
+      }
+    } else if (!isLocalDevRequest(c.req.raw)) {
+      return c.json({ error: 'Admin email delivery is not configured', errorCode: 'EMAIL_NOT_CONFIGURED' }, 503)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.auth.challenge.issued',
+      actor: link.email,
+      target: link.role,
+      details: {
+        origin: c.req.header('origin') ?? null,
+        userAgent: c.req.header('user-agent') ?? null,
+      },
+    })
+
+    return c.json({
+      ok: true,
+      email: link.email,
+      role: link.role,
+      expiresAt: link.expiresAt,
+      dev: !isEmailDeliveryConfigured() && isLocalDevRequest(c.req.raw),
+      url: !isEmailDeliveryConfigured() && isLocalDevRequest(c.req.raw) ? link.url : undefined,
+      token: !isEmailDeliveryConfigured() && isLocalDevRequest(c.req.raw) ? link.token : undefined,
+    })
+  })
+
+  router.post('/verify', async (c) => {
+    const body = await c.req.json().catch(() => ({})) as { token?: string }
+    const token = body.token?.trim()
+
+    if (!token) {
+      return c.json({ error: 'Token required', errorCode: 'MISSING_TOKEN' }, 400)
+    }
+
+    const result = createAdminSessionFromMagicLink(db, token)
+    if (!result) {
+      return c.json({ error: 'Invalid or expired token', errorCode: 'INVALID_TOKEN' }, 401)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.auth.login',
+      actor: result.session.email,
+      target: result.session.role,
+      details: {
+        origin: c.req.header('origin') ?? null,
+        authType: 'magic-link',
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    c.header('Set-Cookie', buildAdminSessionCookie(c, result.token, getAdminSessionTtlSeconds()))
+    return c.json({
+      ok: true,
+      token: result.token,
+      email: result.session.email,
+      role: result.session.role,
+      expiresAt: result.session.expiresAt,
+    })
+  })
+
+  router.get('/session', (c) => {
+    const session = getAdminSessionFromRequest(db, c.req.raw)
+    if (!session) {
+      return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      email: session.email,
+      role: session.role,
+      expiresAt: session.expiresAt,
+    })
+  })
+
+  router.post('/logout', (c) => {
+    const session = getAdminSessionFromRequest(db, c.req.raw)
+    if (session) {
+      revokeAdminSession(db, session.id)
+      logAuditEvent(db, {
+        action: 'admin.auth.logout',
+        actor: session.email,
+        target: session.role,
+        details: {
+          origin: c.req.header('origin') ?? null,
+        },
+      })
+    }
+
+    c.header('Cache-Control', 'no-store')
+    c.header('Set-Cookie', clearAdminSessionCookie(c))
+    return c.json({ ok: true })
+  })
+
+  return router
+}

--- a/packages/directory/src/routes/agents.ts
+++ b/packages/directory/src/routes/agents.ts
@@ -1,6 +1,7 @@
 import { createPublicKey, randomBytes, verify } from 'node:crypto'
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
+import { getAdminSessionFromRequest, roleSatisfies } from '../admin-auth.js'
 import type { AgentRow, RegisterRequest, VerificationTier } from '../types.js'
 import { seedAclsFromCatalog } from '../acl.js'
 import { sendAgentVerificationEmail } from '../email.js'
@@ -138,10 +139,6 @@ function verifySignedUtf8Payload(payload: string, signatureBase64: string, publi
   } catch {
     return false
   }
-}
-
-function isAdminRequest(adminKey: string | undefined): boolean {
-  return Boolean(adminKey) && adminKey === process.env.BEAM_ADMIN_KEY
 }
 
 export function agentsRouter(db: Database): Hono {
@@ -626,10 +623,10 @@ export function agentsRouter(db: Database): Hono {
       const timestamp = c.req.header('x-beam-timestamp')?.trim() ?? ''
       const nonce = c.req.header('x-beam-nonce')?.trim() ?? ''
       const signature = c.req.header('x-beam-signature')?.trim() ?? ''
-      const adminKey = c.req.header('x-admin-key') ?? ''
+      const adminSession = getAdminSessionFromRequest(db, c.req.raw)
 
       const hasSignatureHeaders = Boolean(timestamp || nonce || signature)
-      if (!hasSignatureHeaders && !isAdminRequest(adminKey)) {
+      if (!hasSignatureHeaders && !(adminSession && roleSatisfies(adminSession.role, 'admin'))) {
         return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
       }
 
@@ -664,9 +661,9 @@ export function agentsRouter(db: Database): Hono {
       return c.json({ error: `Agent ${beamId} not found`, errorCode: 'NOT_FOUND' }, 404)
     }
 
-    const adminKey = c.req.header('x-admin-key') ?? ''
+    const adminSession = getAdminSessionFromRequest(db, c.req.raw)
     const suppliedApiKey = getSuppliedApiKey(c.req.raw)
-    if (!isAdminRequest(adminKey) && !agentApiKeyMatches(agent, suppliedApiKey)) {
+    if (!(adminSession && roleSatisfies(adminSession.role, 'admin')) && !agentApiKeyMatches(agent, suppliedApiKey)) {
       return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
     }
 
@@ -679,7 +676,7 @@ export function agentsRouter(db: Database): Hono {
     }
   })
 
-  // Toggle visibility (requires signed request or admin key)
+  // Toggle visibility (requires signed request or admin session)
   router.patch('/:beamId/visibility', async (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
     if (!BEAM_ID_RE.test(beamId)) {
@@ -703,18 +700,18 @@ export function agentsRouter(db: Database): Hono {
       return c.json({ error: 'visibility must be "public" or "unlisted"', errorCode: 'INVALID_VISIBILITY' }, 400)
     }
 
-    // Auth: verify Ed25519 signature or admin key
+    // Auth: verify Ed25519 signature or admin session
     const signature = typeof body.signature === 'string' ? body.signature : ''
-    const adminKey = c.req.header('x-admin-key') ?? ''
+    const adminSession = getAdminSessionFromRequest(db, c.req.raw)
     const suppliedApiKey = getSuppliedApiKey(c.req.raw)
-    const isAdmin = isAdminRequest(adminKey)
+    const isAdmin = Boolean(adminSession && roleSatisfies(adminSession.role, 'admin'))
     const hasApiKey = agentApiKeyMatches(agent, suppliedApiKey)
 
     if (!isAdmin && !hasApiKey) {
       const { verifyPayload } = await import('../crypto.js')
       const payload = { beamId, visibility: newVisibility, timestamp: body.timestamp }
       if (!signature || !verifyPayload(payload, signature, agent.public_key)) {
-        return c.json({ error: 'Invalid signature or missing admin key', errorCode: 'UNAUTHORIZED' }, 401)
+        return c.json({ error: 'Invalid signature or missing admin session', errorCode: 'UNAUTHORIZED' }, 401)
       }
     }
 
@@ -743,10 +740,10 @@ export function agentsRouter(db: Database): Hono {
       return c.json({ error: 'Invalid JSON body' }, 400)
     }
 
-    // Auth: admin key or Ed25519 signature
-    const adminKey = c.req.header('x-admin-key') ?? ''
+    // Auth: admin session or Ed25519 signature
+    const adminSession = getAdminSessionFromRequest(db, c.req.raw)
     const suppliedApiKey = getSuppliedApiKey(c.req.raw)
-    const isAdmin = isAdminRequest(adminKey)
+    const isAdmin = Boolean(adminSession && roleSatisfies(adminSession.role, 'admin'))
     const hasApiKey = agentApiKeyMatches(agent, suppliedApiKey)
 
     if (!isAdmin && !hasApiKey) {

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
-import type { Context } from 'hono'
 import type { Database } from 'better-sqlite3'
-import { getAgent, listAuditLog, listIntentTraceEvents, listShieldAuditLog } from '../db.js'
+import { requireAdminRole } from '../admin-auth.js'
+import { getAgent, listAuditLog, listIntentTraceEvents, listShieldAuditLog, logAuditEvent } from '../db.js'
 import type {
   AuditLogRow,
   FederationPeerRow,
@@ -37,34 +37,6 @@ type IntentQuery = {
 }
 
 const DEFAULT_RETENTION_DAYS = Math.max(1, Number.parseInt(process.env['BEAM_OBSERVABILITY_RETENTION_DAYS'] ?? '30', 10) || 30)
-
-function getSuppliedAdminKey(c: Context): string {
-  const header = c.req.header('x-admin-key') ?? ''
-  if (header) {
-    return header
-  }
-
-  const authorization = c.req.header('authorization') ?? ''
-  if (authorization.toLowerCase().startsWith('bearer ')) {
-    return authorization.slice(7).trim()
-  }
-
-  return c.req.query('key') ?? ''
-}
-
-function requireAdmin(c: Context): Response | null {
-  const configuredKey = process.env['BEAM_ADMIN_KEY'] ?? ''
-  if (!configuredKey) {
-    return c.json({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }, 503)
-  }
-
-  const suppliedKey = getSuppliedAdminKey(c)
-  if (!suppliedKey || suppliedKey !== configuredKey) {
-    return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
-  }
-
-  return null
-}
 
 function parseLimit(value: string | undefined, fallback: number, max = 500): number {
   const parsed = Number.parseInt(value ?? '', 10)
@@ -1054,8 +1026,8 @@ export function observabilityRouter(db: Database): Hono {
   const router = new Hono()
 
   router.get('/overview', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1069,8 +1041,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/intents', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1092,8 +1064,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/intents/:nonce', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1121,8 +1093,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/audit', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1142,8 +1114,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/agents/:beamId/health', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1157,8 +1129,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/federation', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1166,8 +1138,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/errors', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1175,8 +1147,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/alerts', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1200,8 +1172,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/retention', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1212,8 +1184,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.get('/export/:dataset', (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1280,8 +1252,8 @@ export function observabilityRouter(db: Database): Hono {
   })
 
   router.post('/prune', async (c) => {
-    const auth = requireAdmin(c)
-    if (auth) {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
       return auth
     }
 
@@ -1309,6 +1281,16 @@ export function observabilityRouter(db: Database): Hono {
 
     try {
       const result = pruneDataset(db, dataset, olderThanDays)
+      logAuditEvent(db, {
+        action: 'observability.prune',
+        actor: auth.session.email,
+        target: dataset,
+        details: {
+          olderThanDays,
+          deleted: result.deleted,
+          role: auth.session.role,
+        },
+      })
       return c.json({
         dataset,
         olderThanDays,

--- a/packages/directory/src/routes/reports.ts
+++ b/packages/directory/src/routes/reports.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
+import { requireAdminRole } from '../admin-auth.js'
 import type { ReportRow } from '../types.js'
 import { createReport, getAgent, getPendingReportCount, listReportsForTarget } from '../db.js'
 import { BEAM_ID_RE } from '../validation.js'
@@ -13,26 +14,6 @@ function serializeReport(row: ReportRow): object {
     createdAt: row.created_at,
     status: row.status,
   }
-}
-
-function requireAdmin(req: Request): { ok: true } | Response {
-  const configuredKey = process.env['BEAM_ADMIN_KEY'] ?? ''
-  if (!configuredKey) {
-    return new Response(JSON.stringify({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }), {
-      status: 503,
-      headers: { 'content-type': 'application/json' },
-    })
-  }
-
-  const suppliedKey = req.headers.get('x-admin-key') ?? ''
-  if (!suppliedKey || suppliedKey !== configuredKey) {
-    return new Response(JSON.stringify({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }), {
-      status: 401,
-      headers: { 'content-type': 'application/json' },
-    })
-  }
-
-  return { ok: true }
 }
 
 export function reportsRouter(db: Database): Hono {
@@ -106,7 +87,7 @@ export function reportsRouter(db: Database): Hono {
       return c.json({ error: 'Invalid beamId format', errorCode: 'INVALID_BEAM_ID' }, 400)
     }
 
-    const admin = requireAdmin(c.req.raw)
+    const admin = requireAdminRole(db, c.req.raw, 'viewer')
     if (admin instanceof Response) {
       return admin
     }

--- a/packages/directory/src/routes/shield.ts
+++ b/packages/directory/src/routes/shield.ts
@@ -5,6 +5,8 @@
 
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
+import { getAdminSessionFromRequest, requireAdminRole, roleSatisfies } from '../admin-auth.js'
+import { logAuditEvent } from '../db.js'
 import { getRecentEvents, getAuditStats } from '../shield/audit.js'
 
 export interface ShieldConfig {
@@ -42,11 +44,6 @@ export function parseShieldConfig(raw: string | null | undefined): ShieldConfig 
 export function shieldRouter(db: Database): Hono {
   const router = new Hono()
 
-  function requireAdmin(c: { req: { header: (name: string) => string | undefined; query: (name: string) => string | undefined } }): boolean {
-    const key = c.req.header('x-admin-key') ?? c.req.query('key') ?? ''
-    return key === process.env.BEAM_ADMIN_KEY
-  }
-
   // GET /shield/config/:beamId — Get shield config for an agent
   router.get('/config/:beamId', (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
@@ -62,14 +59,14 @@ export function shieldRouter(db: Database): Hono {
   router.patch('/config/:beamId', async (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
 
-    // Auth: admin key or agent's own Ed25519 signature
-    const isAdmin = requireAdmin(c)
+    const adminSession = getAdminSessionFromRequest(db, c.req.raw)
+    const isAdmin = Boolean(adminSession && roleSatisfies(adminSession.role, 'admin'))
     if (!isAdmin) {
       // Check Ed25519 signature auth
       const sigHeader = c.req.header('x-beam-signature')
       const nonceHeader = c.req.header('x-beam-nonce')
       if (!sigHeader || !nonceHeader) {
-        return c.json({ error: 'Admin key or Ed25519 signature required', errorCode: 'UNAUTHORIZED' }, 401)
+        return c.json({ error: 'Admin session or Ed25519 signature required', errorCode: 'UNAUTHORIZED' }, 401)
       }
 
       // Verify signature over beamId + nonce
@@ -113,13 +110,28 @@ export function shieldRouter(db: Database): Hono {
 
     db.prepare('UPDATE agents SET shield_config = ? WHERE beam_id = ?').run(JSON.stringify(updated), beamId)
 
+    if (adminSession) {
+      logAuditEvent(db, {
+        action: 'shield.config.updated',
+        actor: adminSession.email,
+        target: beamId,
+        details: {
+          role: adminSession.role,
+          mode: updated.mode,
+          minTrust: updated.minTrust,
+          rateLimit: updated.rateLimit,
+        },
+      })
+    }
+
     return c.json({ beamId, shield: updated, updated: true })
   })
 
   // GET /shield/audit/:beamId — Recent audit events for a sender
   router.get('/audit/:beamId', (c) => {
-    if (!requireAdmin(c)) {
-      return c.json({ error: 'Admin key required', errorCode: 'UNAUTHORIZED' }, 401)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
     }
 
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
@@ -136,8 +148,9 @@ export function shieldRouter(db: Database): Hono {
 
   // GET /shield/stats — Aggregate shield statistics
   router.get('/stats', (c) => {
-    if (!requireAdmin(c)) {
-      return c.json({ error: 'Admin key required', errorCode: 'UNAUTHORIZED' }, 401)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
     }
 
     const hours = parseInt(c.req.query('hours') ?? '24', 10)

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -1,4 +1,4 @@
-import { randomBytes, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -8,6 +8,7 @@ import { cors } from 'hono/cors'
 import { serve } from '@hono/node-server'
 import type { Server as HttpServer } from 'node:http'
 import type { Database } from 'better-sqlite3'
+import { adminAuthRouter } from './routes/admin-auth.js'
 import { agentsRouter } from './routes/agents.js'
 import { billingRouter } from './routes/billing.js'
 import { businessVerificationRouter } from './routes/business-verify.js'
@@ -24,7 +25,8 @@ import { verificationRouter } from './routes/verify.js'
 import { createTrustGateMiddleware } from './middleware/trust-gate.js'
 import { createWebSocketServer, getConnectedCount, getConnectedBeamIds, relayIntentFromHttp, RelayError } from './websocket.js'
 import { createAcl, deleteAcl, listAclsForBeam, seedAclsFromCatalog } from './acl.js'
-import { getDirectoryRole, listAuditLog, listRecentIntentLogs, listTrustScores, getDIDDocument, getAgent, upsertDIDDocument } from './db.js'
+import { getAdminSessionFromRequest, requireAdminRole } from './admin-auth.js'
+import { assignDirectoryRole, deleteDirectoryRole, listDirectoryRoles, listAuditLog, listRecentIntentLogs, listTrustScores, logAuditEvent, getDIDDocument, getAgent, upsertDIDDocument } from './db.js'
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import type { AgentRow, IntentFrame } from './types.js'
@@ -32,10 +34,6 @@ import type { AgentRow, IntentFrame } from './types.js'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
 const serverStartedAt = Date.now()
-const DASHBOARD_SESSION_COOKIE = 'beam_dash_session'
-const DASHBOARD_SESSION_TTL_MS = 24 * 60 * 60 * 1000
-
-const dashboardSessions = new Map<string, { expiresAt: number }>()
 
 type WaitlistSignupInput = {
   email: string
@@ -75,103 +73,6 @@ function loadIntentCatalog(): unknown {
   }
 }
 
-function getAdminKeyFromRequest(c: Context): string {
-  return c.req.header('x-admin-key') ?? c.req.query('key') ?? ''
-}
-
-function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
-  if (!cookieHeader) {
-    return {}
-  }
-
-  return cookieHeader
-    .split(';')
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .reduce<Record<string, string>>((cookies, part) => {
-      const separatorIndex = part.indexOf('=')
-      if (separatorIndex <= 0) {
-        return cookies
-      }
-
-      const key = part.slice(0, separatorIndex).trim()
-      const value = part.slice(separatorIndex + 1).trim()
-      cookies[key] = value
-      return cookies
-    }, {})
-}
-
-function pruneExpiredDashboardSessions(now = Date.now()): void {
-  for (const [token, session] of dashboardSessions.entries()) {
-    if (session.expiresAt <= now) {
-      dashboardSessions.delete(token)
-    }
-  }
-}
-
-function getDashboardSessionToken(c: Context): string {
-  const cookies = parseCookieHeader(c.req.header('cookie'))
-  return cookies[DASHBOARD_SESSION_COOKIE] ?? ''
-}
-
-function hasValidDashboardSession(c: Context): boolean {
-  pruneExpiredDashboardSessions()
-
-  const sessionToken = getDashboardSessionToken(c)
-  if (!sessionToken) {
-    return false
-  }
-
-  const session = dashboardSessions.get(sessionToken)
-  if (!session) {
-    return false
-  }
-
-  if (session.expiresAt <= Date.now()) {
-    dashboardSessions.delete(sessionToken)
-    return false
-  }
-
-  return true
-}
-
-function createDashboardSession(): string {
-  pruneExpiredDashboardSessions()
-
-  const token = randomBytes(32).toString('hex')
-  dashboardSessions.set(token, { expiresAt: Date.now() + DASHBOARD_SESSION_TTL_MS })
-  return token
-}
-
-function invalidateDashboardSession(c: Context): void {
-  const sessionToken = getDashboardSessionToken(c)
-  if (sessionToken) {
-    dashboardSessions.delete(sessionToken)
-  }
-}
-
-function buildDashboardSessionCookie(token: string, maxAgeSeconds: number): string {
-  return `${DASHBOARD_SESSION_COOKIE}=${token}; Path=/; HttpOnly; SameSite=Strict; Max-Age=${maxAgeSeconds}`
-}
-
-function requireAdmin(c: Context): { ok: true; key: string } | Response {
-  const configuredKey = process.env['BEAM_ADMIN_KEY'] ?? ''
-  if (!configuredKey) {
-    return c.json({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }, 503)
-  }
-
-  if (hasValidDashboardSession(c)) {
-    return { ok: true, key: '' }
-  }
-
-  const suppliedKey = getAdminKeyFromRequest(c)
-  if (!suppliedKey || suppliedKey !== configuredKey) {
-    return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
-  }
-
-  return { ok: true, key: suppliedKey }
-}
-
 function hasFederationAuth(c: Context): boolean {
   if (c.req.header('x-beam-mtls-verified') === 'true') {
     return true
@@ -179,25 +80,6 @@ function hasFederationAuth(c: Context): boolean {
 
   const secret = getFederationSharedSecret()
   return Boolean(secret) && c.req.header('x-beam-federation-secret') === secret
-}
-
-function requireDirectoryAdmin(db: Database, c: Context): { ok: true; actor: string } | Response {
-  const admin = requireAdmin(c)
-  if (!(admin instanceof Response)) {
-    return { ok: true, actor: 'admin-key' }
-  }
-
-  const userId = c.req.header('x-directory-user') ?? c.req.query('user') ?? ''
-  if (!userId) {
-    return admin
-  }
-
-  const role = getDirectoryRole(db, userId, getLocalDirectoryUrl())
-  if (role?.role === 'admin') {
-    return { ok: true, actor: userId }
-  }
-
-  return admin
 }
 
 function tableExists(db: Database, tableName: string): boolean {
@@ -680,9 +562,9 @@ export function createApp(db: Database): Hono {
     allowHeaders: [
       'Content-Type',
       'Authorization',
-      'X-Admin-Key',
       'X-API-Key',
     ],
+    credentials: true,
   }))
 
   app.use('*', createRateLimitMiddleware())
@@ -702,28 +584,12 @@ export function createApp(db: Database): Hono {
     defaultRateLimit: 20,
   }))
 
-  app.post('/dashboard/login', (c) => {
-    const configuredKey = process.env['BEAM_ADMIN_KEY'] ?? ''
-    if (!configuredKey) {
-      return c.json({ error: 'Admin access is not configured', errorCode: 'ADMIN_UNAVAILABLE' }, 503)
-    }
-
-    const suppliedKey = c.req.header('x-admin-key') ?? ''
-    if (!suppliedKey || suppliedKey !== configuredKey) {
-      invalidateDashboardSession(c)
-      c.header('Set-Cookie', buildDashboardSessionCookie('', 0))
-      return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
-    }
-
-    const sessionToken = createDashboardSession()
-    c.header('Cache-Control', 'no-store')
-    c.header('Set-Cookie', buildDashboardSessionCookie(sessionToken, Math.floor(DASHBOARD_SESSION_TTL_MS / 1000)))
-    return c.json({ ok: true, expiresInSeconds: Math.floor(DASHBOARD_SESSION_TTL_MS / 1000) })
-  })
+  app.route('/admin/auth', adminAuthRouter(db))
 
   app.get('/dashboard', (c) => {
-    if (!hasValidDashboardSession(c)) {
-      return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
     }
 
     c.header('Cache-Control', 'no-store')
@@ -731,7 +597,7 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/admin/agents', (c) => {
-    const auth = requireAdmin(c)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
@@ -756,7 +622,7 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/admin/intents', (c) => {
-    const auth = requireAdmin(c)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
@@ -785,10 +651,16 @@ export function createApp(db: Database): Hono {
   })
 
   app.delete('/admin/waitlist', (c) => {
-    const auth = requireAdmin(c)
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
     if (auth instanceof Response) return auth
     try {
       const result = db.prepare('DELETE FROM waitlist').run()
+      logAuditEvent(db, {
+        action: 'admin.waitlist.cleared',
+        actor: auth.session.email,
+        target: 'waitlist',
+        details: { deleted: result.changes, role: auth.session.role },
+      })
       return c.json({ deleted: result.changes })
     } catch (err) {
       console.error('Admin waitlist clear error:', err)
@@ -797,7 +669,7 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/admin/waitlist', (c) => {
-    const auth = requireAdmin(c)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
@@ -813,7 +685,7 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/admin/trust', (c) => {
-    const auth = requireAdmin(c)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
@@ -837,7 +709,7 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/admin/audit', (c) => {
-    const auth = requireDirectoryAdmin(db, c)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
@@ -871,19 +743,22 @@ export function createApp(db: Database): Hono {
 
   // List all agents with connection status (before sub-router to avoid conflict)
   app.get('/directory/agents', (c) => {
-    if (isPrivateDirectoryMode() && !hasFederationAuth(c) && requireAdmin(c) instanceof Response) {
+    const adminSession = getAdminSessionFromRequest(db, c.req.raw)
+    if (isPrivateDirectoryMode() && !hasFederationAuth(c) && !adminSession) {
       return c.json({ error: 'Directory is private', errorCode: 'PRIVATE_DIRECTORY' }, 403)
     }
 
     try {
-      const includeUnlisted = c.req.query('includeUnlisted') === 'true' && !requireAdmin(c)
-      const publicRows = db.prepare("SELECT * FROM agents WHERE visibility = 'public' ORDER BY trust_score DESC, beam_id ASC").all() as AgentRow[]
+      const includeUnlisted = c.req.query('includeUnlisted') === 'true' && Boolean(adminSession)
+      const rows = includeUnlisted
+        ? db.prepare('SELECT * FROM agents ORDER BY trust_score DESC, beam_id ASC').all() as AgentRow[]
+        : db.prepare("SELECT * FROM agents WHERE visibility = 'public' ORDER BY trust_score DESC, beam_id ASC").all() as AgentRow[]
       const totalCount = (db.prepare('SELECT COUNT(*) as cnt FROM agents').get() as { cnt: number }).cnt
       const connected = new Set(getConnectedBeamIds())
       return c.json({
-        agents: publicRows.map((row) => serializeAgent(row, connected)),
+        agents: rows.map((row) => serializeAgent(row, connected)),
         total: totalCount,
-        listed: publicRows.length,
+        listed: rows.length,
       })
     } catch (err) {
       console.error('List agents error:', err)
@@ -928,6 +803,90 @@ export function createApp(db: Database): Hono {
   app.route('/shield', shieldRouter(db))
   app.route('/observability', observabilityRouter(db))
   app.route('/keys', revokedKeysRouter(db))
+
+  app.get('/admin/roles', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const rows = listDirectoryRoles(db, getLocalDirectoryUrl())
+    return c.json({
+      roles: rows.map((row) => ({
+        email: row.user_id,
+        role: row.role,
+      })),
+      total: rows.length,
+    })
+  })
+
+  app.post('/admin/roles', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const body = await c.req.json().catch(() => ({})) as { email?: string; role?: 'admin' | 'operator' | 'viewer' }
+    const email = String(body.email ?? '').trim().toLowerCase()
+    const role = body.role
+    if (!email || !email.includes('@') || (role !== 'admin' && role !== 'operator' && role !== 'viewer')) {
+      return c.json({ error: 'email and role are required', errorCode: 'INVALID_ROLE_ASSIGNMENT' }, 400)
+    }
+
+    const assigned = assignDirectoryRole(db, {
+      userId: email,
+      role,
+      directoryUrl: getLocalDirectoryUrl(),
+    })
+
+    logAuditEvent(db, {
+      action: 'admin.role.assigned',
+      actor: auth.session.email,
+      target: email,
+      details: {
+        role: assigned.role,
+        directoryUrl: assigned.directory_url,
+      },
+    })
+
+    return c.json({
+      email: assigned.user_id,
+      role: assigned.role,
+      directoryUrl: assigned.directory_url,
+    }, 201)
+  })
+
+  app.delete('/admin/roles/:email', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const email = decodeURIComponent(c.req.param('email') ?? '').trim().toLowerCase()
+    if (!email || !email.includes('@')) {
+      return c.json({ error: 'Valid email required', errorCode: 'INVALID_EMAIL' }, 400)
+    }
+
+    const deleted = deleteDirectoryRole(db, {
+      userId: email,
+      directoryUrl: getLocalDirectoryUrl(),
+    })
+
+    if (!deleted) {
+      return c.json({ error: 'Role assignment not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.role.revoked',
+      actor: auth.session.email,
+      target: email,
+      details: {
+        directoryUrl: getLocalDirectoryUrl(),
+      },
+    })
+
+    return new Response(null, { status: 204 })
+  })
 
   app.post('/acl', async (c) => {
     let body: unknown
@@ -1057,15 +1016,9 @@ export function createApp(db: Database): Hono {
   })
 
   app.get('/waitlist', (c) => {
-    const adminKey = process.env['BEAM_ADMIN_KEY']
-    if (!adminKey) {
-      console.error('BEAM_ADMIN_KEY is not configured')
-      return c.json({ error: 'Admin access unavailable', errorCode: 'ADMIN_NOT_CONFIGURED' }, 503)
-    }
-
-    const providedKey = c.req.header('X-Admin-Key')
-    if (providedKey !== adminKey) {
-      return c.json({ error: 'Unauthorized', errorCode: 'UNAUTHORIZED' }, 401)
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
     }
 
     try {

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -104,6 +104,25 @@ export interface DirectoryRoleRow {
   directory_url: string
 }
 
+export interface AdminMagicLinkRow {
+  token: string
+  email: string
+  role: 'admin' | 'operator' | 'viewer'
+  created_at: string
+  expires_at: string
+  used: number
+}
+
+export interface AdminSessionRow {
+  id: string
+  email: string
+  role: 'admin' | 'operator' | 'viewer'
+  created_at: string
+  last_seen_at: string
+  expires_at: string
+  revoked_at: string | null
+}
+
 export interface AuditLogRow {
   id: number
   action: string

--- a/packages/directory/tests/identity-systems.test.ts
+++ b/packages/directory/tests/identity-systems.test.ts
@@ -1,7 +1,9 @@
 import { generateKeyPairSync, sign } from 'node:crypto'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Hono } from 'hono'
-import { createDatabase, getAgent, registerAgent } from '../src/db.js'
+import { createAdminSession } from '../src/admin-auth.js'
+import { createDatabase, getAgent, registerAgent, assignDirectoryRole } from '../src/db.js'
+import { getLocalDirectoryUrl } from '../src/federation.js'
 import { agentKeysRouter, revokedKeysRouter } from '../src/routes/keys.js'
 import { verificationRouter } from '../src/routes/verify.js'
 import { delegationsRouter } from '../src/routes/delegations.js'
@@ -182,7 +184,7 @@ describe('directory identity and verification routes', () => {
   })
 
   it('accepts reports, blocks duplicates, and flags agents after five pending reports', async () => {
-    vi.stubEnv('BEAM_ADMIN_KEY', 'secret-admin')
+    vi.stubEnv('JWT_SECRET', 'secret-admin-jwt')
 
     const targetIdentity = generateIdentity()
     const targetBeamId = 'target@acme.beam.directory'
@@ -237,8 +239,18 @@ describe('directory identity and verification routes', () => {
     expect(target?.flagged).toBe(1)
     expect(target?.trust_score).toBe(0)
 
+    assignDirectoryRole(db, {
+      userId: 'ops@example.com',
+      role: 'admin',
+      directoryUrl: getLocalDirectoryUrl(),
+    })
+    const adminSession = createAdminSession(db, {
+      email: 'ops@example.com',
+      role: 'admin',
+    })
+
     const listed = await jsonRequest(app, `/agents/${encodeURIComponent(targetBeamId)}/reports`, {
-      headers: { 'x-admin-key': 'secret-admin' },
+      headers: { Authorization: `Bearer ${adminSession.token}` },
     })
     expect(listed.response.status).toBe(200)
     expect(listed.body.total).toBe(5)

--- a/scripts/e2e/run.mjs
+++ b/scripts/e2e/run.mjs
@@ -144,12 +144,18 @@ async function runCli(args, cwd, env = {}) {
 }
 
 async function runPython(env) {
+  const pythonPathEntries = [
+    path.join(repoRoot, 'packages/sdk-python'),
+    process.env.PYTHONPATH,
+  ].filter(Boolean)
+
   return execFileAsync('python3', [pythonSenderEntry], {
     cwd: repoRoot,
     env: {
       ...process.env,
       ...env,
       PYTHONUNBUFFERED: '1',
+      PYTHONPATH: pythonPathEntries.join(path.delimiter),
     },
     maxBuffer: 1024 * 1024,
   })
@@ -203,7 +209,6 @@ async function main() {
         PORT: String(directoryPort),
         DB_PATH: directoryDb,
         JWT_SECRET: 'beam-e2e-jwt-secret',
-        BEAM_ADMIN_KEY: 'beam-e2e-admin-key',
       },
     })
 


### PR DESCRIPTION
Closes #6

## Summary
- replace static admin-key flows with signed admin sessions, magic-link auth, and RBAC
- update directory admin, observability, shield, reports, and agent override routes to use session auth
- switch the dashboard to session-based operator login and update docs/tests

## Verification
- npm run build
- npm test
- npm run test:e2e
- npx vitest run packages/directory/tests/identity-systems.test.ts