### PR TITLE
Define the canonical intent lifecycle across Beam transports

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         { text: 'DID Identity', link: '/guide/did' },
         { text: 'Verification', link: '/guide/verification' },
         { text: 'Federation', link: '/guide/federation' },
+        { text: 'Intent Lifecycle', link: '/guide/intent-lifecycle' },
         { text: 'Consumer IDs', link: '/guide/consumer-ids' },
         { text: 'Core Concepts', link: '/guide/concepts' },
         { text: 'Self-Hosting', link: '/guide/self-hosting' }

--- a/docs/guide/intent-lifecycle.md
+++ b/docs/guide/intent-lifecycle.md
@@ -1,0 +1,74 @@
+# Intent Lifecycle
+
+Beam 0.6.0 exposes one canonical lifecycle for intent delivery across HTTP, WebSocket, federation, and the message bus.
+
+## Canonical States
+
+- `received`: Beam accepted the envelope and started handling the nonce.
+- `validated`: identity, signature, ACL, replay, and payload checks passed.
+- `queued`: the message bus is holding the intent for retry or deferred delivery.
+- `dispatched`: Beam selected a route and handed the intent to a transport attempt.
+- `delivered`: the target agent or downstream directory accepted delivery.
+- `acked`: the recipient completed the intent and returned a successful result.
+- `failed`: the intent ended in a terminal failure for this attempt.
+- `dead_letter`: the message bus exhausted retries or hit a non-retryable terminal failure.
+
+## Transition Rules
+
+Beam validates lifecycle transitions in code. The allowed path is:
+
+1. `received`
+2. `validated`
+3. `queued` or `dispatched`
+4. `delivered`
+5. `acked` or `failed`
+
+Additional rules:
+
+- `queued -> dispatched` is the normal retry-worker path.
+- `dispatched -> queued` is allowed when a retryable delivery attempt is rescheduled.
+- `failed -> queued` and `dead_letter -> queued` are allowed only for retry or operator requeue flows.
+- `dead_letter` is terminal unless an operator explicitly requeues the nonce.
+- `acked` is terminal.
+
+## Derived Outcome Buckets
+
+The dashboard still shows aggregate outcome metrics, but they are derived from lifecycle state instead of being stored as primary statuses.
+
+- `success`: `acked`
+- `error`: `failed`, `dead_letter`
+- `in_flight`: `received`, `validated`, `queued`, `dispatched`, `delivered`
+
+## Transport Mapping
+
+### Directory HTTP / WebSocket / Federation
+
+The directory records the same top-level sequence for all delivery paths:
+
+1. `received`
+2. `validated`
+3. `dispatched`
+4. `delivered`
+5. `acked` or `failed`
+
+Transport-specific details such as `direct-http`, `ws`, `federation`, fallback behavior, peer URLs, and timeouts are attached in trace-event `details` instead of inventing transport-only lifecycle names.
+
+### Message Bus
+
+The message bus uses the same status vocabulary, but not every message visits every state:
+
+- synchronous success: `received -> dispatched -> delivered`
+- successful consumer acknowledgement: `... -> acked`
+- retryable delivery failure: `... -> queued`
+- terminal retry exhaustion: `... -> dead_letter`
+
+## Migration Notes
+
+Beam normalizes legacy rows on startup:
+
+- `pending -> received`
+- `success -> acked`
+- `error -> failed`
+- `expired -> dead_letter`
+
+Legacy trace stages are normalized into the canonical state model and keep the original transport-specific labels in `details.legacyStage` and `details.legacyStatus` when needed.

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -2,6 +2,7 @@ export type VerificationTier = 'basic' | 'verified' | 'business' | 'enterprise'
 export type AlertSeverity = 'info' | 'warning' | 'critical'
 export type ExportDataset = 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
 export type ExportFormat = 'json' | 'csv' | 'ndjson'
+export type IntentLifecycleStatus = 'received' | 'validated' | 'queued' | 'dispatched' | 'delivered' | 'acked' | 'failed' | 'dead_letter'
 
 export interface DirectoryAgent {
   beamId: string
@@ -56,7 +57,9 @@ export interface BusHealth {
 
 export interface BusStats {
   total: number
-  pending: number
+  queued: number
+  received: number
+  dispatched: number
   delivered: number
   acked: number
   failed: number
@@ -72,7 +75,7 @@ export interface DeadLetterMessage {
   recipient: string
   intent: string
   payload: Record<string, unknown>
-  status: string
+  status: IntentLifecycleStatus
   priority: number
   retry_count: number
   max_retries: number
@@ -95,7 +98,7 @@ export interface DeadLetterResponse {
 export interface RequeueDeadLetterResponse {
   message_id: string
   nonce: string
-  status: string
+  status: IntentLifecycleStatus
   requeued: boolean
   retry_count?: number
   next_retry_at?: number
@@ -111,7 +114,7 @@ export interface RecentIntent {
   timestamp: string
   completedAt: string | null
   roundTripLatencyMs: number | null
-  status: string
+  status: IntentLifecycleStatus
   errorCode: string | null
 }
 
@@ -126,8 +129,8 @@ export interface IntentTraceStage {
   from: string
   to: string
   intentType: string
-  stage: string
-  status: string
+  stage: IntentLifecycleStatus
+  status: IntentLifecycleStatus
   timestamp: string
   details: Record<string, unknown> | null
 }
@@ -173,7 +176,7 @@ export interface OverviewTimelinePoint {
   total: number
   success: number
   error: number
-  pending: number
+  inFlight: number
   p95LatencyMs: number | null
 }
 
@@ -188,11 +191,11 @@ export interface ObservabilityOverview {
     totalIntents: number
     successCount: number
     errorCount: number
-    pendingCount: number
+    inFlightCount: number
     avgLatencyMs: number | null
     p95LatencyMs: number | null
     successRate: number
-    pendingOlderThan15m: number
+    inFlightOlderThan15m: number
   }
   timeline: OverviewTimelinePoint[]
   topIntents: Array<{

--- a/packages/dashboard/src/lib/intent-lifecycle.ts
+++ b/packages/dashboard/src/lib/intent-lifecycle.ts
@@ -1,0 +1,80 @@
+export const INTENT_LIFECYCLE_STAGES = [
+  'received',
+  'validated',
+  'queued',
+  'dispatched',
+  'delivered',
+  'acked',
+  'failed',
+  'dead_letter',
+] as const
+
+export type IntentLifecycleStatus = (typeof INTENT_LIFECYCLE_STAGES)[number]
+export type IntentLifecycleBucket = 'success' | 'error' | 'in_flight'
+
+export function isIntentLifecycleStatus(value: string): value is IntentLifecycleStatus {
+  return INTENT_LIFECYCLE_STAGES.includes(value as IntentLifecycleStatus)
+}
+
+export function classifyIntentLifecycle(status: string): IntentLifecycleBucket {
+  switch (status) {
+    case 'acked':
+      return 'success'
+    case 'failed':
+    case 'dead_letter':
+      return 'error'
+    default:
+      return 'in_flight'
+  }
+}
+
+export function formatIntentLifecycleLabel(status: string): string {
+  return status.split('_').join(' ')
+}
+
+export function intentLifecycleColor(status: string): string {
+  switch (status) {
+    case 'acked':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
+    case 'failed':
+    case 'dead_letter':
+      return 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
+    case 'delivered':
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300'
+    case 'validated':
+      return 'bg-cyan-100 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-300'
+    case 'queued':
+      return 'bg-violet-100 text-violet-700 dark:bg-violet-500/15 dark:text-violet-300'
+    default:
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+  }
+}
+
+export function intentLifecycleDotColor(status: string): string {
+  switch (status) {
+    case 'acked':
+      return 'bg-emerald-500'
+    case 'failed':
+    case 'dead_letter':
+      return 'bg-red-500'
+    case 'delivered':
+      return 'bg-blue-500'
+    case 'validated':
+      return 'bg-cyan-500'
+    case 'queued':
+      return 'bg-violet-500'
+    default:
+      return 'bg-amber-500'
+  }
+}
+
+export function intentLifecycleTone(status: string): 'default' | 'success' | 'warning' | 'critical' {
+  const bucket = classifyIntentLifecycle(status)
+  if (bucket === 'success') {
+    return 'success'
+  }
+  if (bucket === 'error') {
+    return 'critical'
+  }
+  return status === 'delivered' || status === 'validated' ? 'default' : 'warning'
+}

--- a/packages/dashboard/src/lib/utils.ts
+++ b/packages/dashboard/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from 'clsx'
+import { intentLifecycleColor } from './intent-lifecycle'
 
 export function cn(...inputs: ClassValue[]) {
   return clsx(inputs)
@@ -92,14 +93,7 @@ export function verificationTierColor(tier: string): string {
 }
 
 export function intentStatusColor(status: string): string {
-  switch (status) {
-    case 'success':
-      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
-    case 'pending':
-      return 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
-    default:
-      return 'bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-300'
-  }
+  return intentLifecycleColor(status)
 }
 
 export function alertSeverityColor(severity: string): string {

--- a/packages/dashboard/src/pages/DeadLetterPage.tsx
+++ b/packages/dashboard/src/pages/DeadLetterPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { ApiError, busApi, getBusBaseUrl, type DeadLetterMessage } from '../lib/api'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
 import { formatDateTime, formatNumber } from '../lib/utils'
+import { formatIntentLifecycleLabel } from '../lib/intent-lifecycle'
 
 function formatBusTimestamp(value?: number | null): string {
   if (value == null) {
@@ -71,7 +72,7 @@ export default function DeadLetterPage() {
     try {
       setRequeueingId(messageId)
       const response = await busApi.requeueDeadLetter(messageId)
-      setStatus(`Requeued ${response.nonce} as ${response.status}.`)
+      setStatus(`Requeued ${response.nonce} as ${formatIntentLifecycleLabel(response.status)}.`)
       await load()
     } catch (err) {
       setStatus(err instanceof ApiError ? err.message : 'Failed to requeue dead-letter message')
@@ -181,11 +182,11 @@ export default function DeadLetterPage() {
                       <div className="text-slate-500 dark:text-slate-400">{message.recipient}</div>
                     </td>
                     <td className="table-cell">
-                      <div className="font-medium">{message.intent}</div>
-                      <div className="mt-2">
-                        <StatusPill label={message.status.replace('_', ' ')} tone="critical" />
-                      </div>
-                    </td>
+                        <div className="font-medium">{message.intent}</div>
+                        <div className="mt-2">
+                        <StatusPill label={formatIntentLifecycleLabel(message.status)} tone="critical" />
+                        </div>
+                      </td>
                     <td className="table-cell">{message.retry_count} / {message.max_retries}</td>
                     <td className="table-cell">{message.error ?? '—'}</td>
                     <td className="table-cell">

--- a/packages/dashboard/src/pages/IntentsPage.tsx
+++ b/packages/dashboard/src/pages/IntentsPage.tsx
@@ -4,10 +4,24 @@ import { Radio, Search } from 'lucide-react'
 import { ApiError, connectIntentFeed, directoryApi, type RecentIntent } from '../lib/api'
 import { PageHeader, StatusPill } from '../components/Observability'
 import { cn, formatDateTime, formatLatency, intentStatusColor, truncateBeamId } from '../lib/utils'
+import { classifyIntentLifecycle, formatIntentLifecycleLabel } from '../lib/intent-lifecycle'
 
 const WINDOW_OPTIONS = [
   { value: 24, label: '24h' },
   { value: 24 * 7, label: '7d' },
+]
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'All lifecycle states' },
+  { value: 'in_flight', label: 'In flight' },
+  { value: 'received', label: 'Received' },
+  { value: 'validated', label: 'Validated' },
+  { value: 'queued', label: 'Queued' },
+  { value: 'dispatched', label: 'Dispatched' },
+  { value: 'delivered', label: 'Delivered' },
+  { value: 'acked', label: 'Acked' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'dead_letter', label: 'Dead letter' },
 ]
 
 function matchesFilters(intent: RecentIntent, filters: {
@@ -15,7 +29,8 @@ function matchesFilters(intent: RecentIntent, filters: {
   status: string
   hours: number
 }) {
-  const matchesStatus = filters.status === 'all' || intent.status === filters.status
+  const matchesStatus = filters.status === 'all'
+    || (filters.status === 'in_flight' ? classifyIntentLifecycle(intent.status) === 'in_flight' : intent.status === filters.status)
   const matchesQuery = !filters.query || [
     intent.nonce,
     intent.from,
@@ -140,10 +155,9 @@ export default function IntentsPage() {
             />
           </label>
           <select className="input-field" value={status} onChange={(event) => setStatus(event.target.value)}>
-            <option value="all">All statuses</option>
-            <option value="success">Success</option>
-            <option value="pending">Pending</option>
-            <option value="error">Error</option>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
           </select>
           <select className="input-field" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
             {WINDOW_OPTIONS.map((option) => (
@@ -192,7 +206,7 @@ export default function IntentsPage() {
                     <td className="table-cell">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className={cn('rounded-full px-2 py-1 text-xs font-medium capitalize', intentStatusColor(intent.status))}>
-                          {intent.status}
+                          {formatIntentLifecycleLabel(intent.status)}
                         </span>
                         {intent.errorCode ? <StatusPill label={intent.errorCode} tone="critical" /> : null}
                       </div>

--- a/packages/dashboard/src/pages/OverviewPage.tsx
+++ b/packages/dashboard/src/pages/OverviewPage.tsx
@@ -72,11 +72,11 @@ export default function OverviewPage() {
           <div className="flex items-center justify-between gap-3">
             <div>
               <div className="panel-title">Intent Timeline</div>
-              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Throughput, failures, and pending pressure over time.</div>
+              <div className="mt-2 text-sm text-slate-500 dark:text-slate-400">Throughput, failures, and in-flight pressure over time.</div>
             </div>
             <StatusPill
-              label={overview && overview.summary.pendingOlderThan15m > 0 ? `${overview.summary.pendingOlderThan15m} stuck` : 'healthy'}
-              tone={overview && overview.summary.pendingOlderThan15m > 0 ? 'warning' : 'success'}
+              label={overview && overview.summary.inFlightOlderThan15m > 0 ? `${overview.summary.inFlightOlderThan15m} stuck` : 'healthy'}
+              tone={overview && overview.summary.inFlightOlderThan15m > 0 ? 'warning' : 'success'}
             />
           </div>
           <div className="mt-5">
@@ -88,7 +88,7 @@ export default function OverviewPage() {
                 series={[
                   { key: 'total', label: 'Total', color: '#f97316' },
                   { key: 'error', label: 'Errors', color: '#ef4444' },
-                  { key: 'pending', label: 'Pending', color: '#f59e0b' },
+                  { key: 'inFlight', label: 'In flight', color: '#f59e0b' },
                 ]}
               />
             )}

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -143,7 +143,7 @@ export default function SettingsPage() {
           <InfoRow label="Health status" value={busHealth?.status ?? 'Unavailable'} />
           <InfoRow label="Service" value={busHealth?.service ?? '—'} />
           <InfoRow label="Dead letters" value={busStats ? String(busStats.dead_letter) : '—'} />
-          <InfoRow label="Pending retries" value={busStats ? String(busStats.pending) : '—'} />
+          <InfoRow label="Queued retries" value={busStats ? String(busStats.queued) : '—'} />
         </div>
       </section>
 

--- a/packages/dashboard/src/pages/TraceDetailPage.tsx
+++ b/packages/dashboard/src/pages/TraceDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { ApiError, directoryApi, type IntentTraceResponse } from '../lib/api'
 import { EmptyPanel, PageHeader, StatusPill } from '../components/Observability'
 import { alertSeverityColor, cn, formatDateTime, formatLatency, intentStatusColor, truncateBeamId } from '../lib/utils'
+import { formatIntentLifecycleLabel, intentLifecycleDotColor, intentLifecycleTone } from '../lib/intent-lifecycle'
 
 export default function TraceDetailPage() {
   const { nonce } = useParams<{ nonce: string }>()
@@ -68,7 +69,7 @@ export default function TraceDetailPage() {
           <InfoRow label="Latency" value={formatLatency(trace.intent.roundTripLatencyMs)} />
           <div className="pt-1">
             <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium capitalize', intentStatusColor(trace.intent.status))}>
-              {trace.intent.status}
+              {formatIntentLifecycleLabel(trace.intent.status)}
             </span>
             {trace.intent.errorCode ? <span className="ml-2 text-sm text-red-600 dark:text-red-400">{trace.intent.errorCode}</span> : null}
           </div>
@@ -106,16 +107,13 @@ export default function TraceDetailPage() {
             trace.stages.map((stage, index) => (
               <div key={`${stage.id}-${stage.stage}-${index}`} className="flex gap-4">
                 <div className="flex flex-col items-center">
-                  <div className={cn(
-                    'h-3 w-3 rounded-full',
-                    stage.status === 'success' ? 'bg-emerald-500' : stage.status === 'error' ? 'bg-red-500' : 'bg-orange-500',
-                  )} />
+                  <div className={cn('h-3 w-3 rounded-full', intentLifecycleDotColor(stage.status))} />
                   {index < trace.stages.length - 1 ? <div className="mt-2 h-full w-px bg-slate-200 dark:bg-slate-800" /> : null}
                 </div>
                 <div className="min-w-0 flex-1 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
                   <div className="flex flex-wrap items-center gap-2">
-                    <div className="font-medium capitalize">{stage.stage.split('.').join(' ')}</div>
-                    <StatusPill label={stage.status} tone={stage.status === 'success' ? 'success' : stage.status === 'error' ? 'critical' : 'warning'} />
+                    <div className="font-medium capitalize">{formatIntentLifecycleLabel(stage.stage)}</div>
+                    <StatusPill label={formatIntentLifecycleLabel(stage.status)} tone={intentLifecycleTone(stage.status)} />
                     <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(stage.timestamp)}</span>
                   </div>
                   {stage.details ? (

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -25,6 +25,15 @@ import type {
   VerificationTier,
 } from './types.js'
 import { generateDIDDocument, toBeamDID, type DIDDocument } from './did.js'
+import {
+  assertIntentLifecycleTransition,
+  classifyIntentLifecycle,
+  isIntentLifecycleFailure,
+  isIntentLifecycleSuccess,
+  normalizeIntentLifecycleStatus,
+  normalizeLegacyTraceLifecycle,
+  type IntentLifecycleStatus,
+} from './intent-lifecycle.js'
 
 const BEAM_DOMAIN_SUFFIX = 'beam.directory'
 
@@ -158,7 +167,7 @@ function initSchema(db: DB): void {
       requested_at TEXT NOT NULL,
       completed_at TEXT,
       round_trip_latency_ms INTEGER,
-      status TEXT NOT NULL DEFAULT 'pending',
+      status TEXT NOT NULL DEFAULT 'received',
       error_code TEXT,
       result_json TEXT
     );
@@ -464,6 +473,7 @@ function initSchema(db: DB): void {
   `).run(backfillKeysCreatedAt)
 
   ensureFederationSafeIntentLog(db)
+  migrateIntentLifecycleModel(db)
 }
 
 function ensureColumn(db: DB, tableName: string, columnName: string, definition: string): void {
@@ -498,7 +508,7 @@ function ensureFederationSafeIntentLog(db: DB): void {
           requested_at TEXT NOT NULL,
           completed_at TEXT,
           round_trip_latency_ms INTEGER,
-          status TEXT NOT NULL DEFAULT 'pending',
+          status TEXT NOT NULL DEFAULT 'received',
           error_code TEXT,
           result_json TEXT
         );
@@ -546,6 +556,66 @@ function ensureFederationSafeIntentLog(db: DB): void {
   } finally {
     db.exec('PRAGMA foreign_keys = ON')
   }
+}
+
+function migrateIntentLifecycleModel(db: DB): void {
+  db.prepare(`
+    UPDATE intent_log
+    SET status = CASE
+      WHEN status = 'pending' THEN 'received'
+      WHEN status = 'success' THEN 'acked'
+      WHEN status = 'error' THEN 'failed'
+      ELSE status
+    END
+  `).run()
+
+  const rows = db.prepare(`
+    SELECT id, stage, status, details
+    FROM intent_trace_events
+    ORDER BY id ASC
+  `).all() as Array<{ id: number; stage: string; status: string; details: string | null }>
+
+  const update = db.prepare(`
+    UPDATE intent_trace_events
+    SET stage = ?, status = ?, details = ?
+    WHERE id = ?
+  `)
+  const remove = db.prepare('DELETE FROM intent_trace_events WHERE id = ?')
+
+  const migrate = db.transaction(() => {
+    for (const row of rows) {
+      const lifecycle = normalizeLegacyTraceLifecycle(row.stage, row.status)
+      if (!lifecycle) {
+        remove.run(row.id)
+        continue
+      }
+
+      let details = row.details
+      if (row.stage !== lifecycle || row.status !== lifecycle) {
+        let parsedDetails: Record<string, unknown> | null = null
+        if (row.details) {
+          try {
+            const parsed = JSON.parse(row.details) as unknown
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+              parsedDetails = parsed as Record<string, unknown>
+            }
+          } catch {
+            parsedDetails = null
+          }
+        }
+
+        details = JSON.stringify({
+          ...(parsedDetails ?? {}),
+          legacyStage: row.stage,
+          legacyStatus: row.status,
+        })
+      }
+
+      update.run(lifecycle, lifecycle, details, row.id)
+    }
+  })
+
+  migrate()
 }
 
 function nowIso(): string {
@@ -1431,13 +1501,13 @@ export function logIntentStart(db: DB, frame: IntentFrame): void {
       intent_type,
       requested_at,
       status
-    ) VALUES (?, ?, ?, ?, ?, 'pending')
+    ) VALUES (?, ?, ?, ?, ?, 'received')
     ON CONFLICT(nonce) DO UPDATE SET
       from_beam_id = excluded.from_beam_id,
       to_beam_id = excluded.to_beam_id,
       intent_type = excluded.intent_type,
       requested_at = excluded.requested_at,
-      status = 'pending',
+      status = 'received',
       completed_at = NULL,
       round_trip_latency_ms = NULL,
       error_code = NULL,
@@ -1451,20 +1521,51 @@ export function logIntentStart(db: DB, frame: IntentFrame): void {
   )
 }
 
+export function setIntentLifecycleStatus(
+  db: DB,
+  input: {
+    nonce: string
+    status: IntentLifecycleStatus
+    errorCode?: string | null
+  },
+): void {
+  const existing = getIntentLogByNonce(db, input.nonce)
+  if (!existing) {
+    return
+  }
+
+  const current = normalizeIntentLifecycleStatus(existing.status) ?? 'received'
+  assertIntentLifecycleTransition(current, input.status, `intent ${input.nonce}`)
+
+  const nextBucket = classifyIntentLifecycle(input.status)
+  db.prepare(`
+    UPDATE intent_log
+    SET status = ?,
+        error_code = ?
+    WHERE nonce = ?
+  `).run(
+    input.status,
+    nextBucket === 'error' ? (input.errorCode ?? existing.error_code) : null,
+    input.nonce,
+  )
+}
+
 export function finalizeIntentLog(
   db: DB,
   input: {
     nonce: string
     fromBeamId: string
     toBeamId: string
-    success: boolean
+    status: IntentLifecycleStatus
     latencyMs: number | null
     errorCode?: string
     resultJson?: string | null
   },
 ): void {
   const completedAt = nowIso()
-  const status = input.success ? 'success' : 'error'
+  const existing = getIntentLogByNonce(db, input.nonce)
+  const current = normalizeIntentLifecycleStatus(existing?.status) ?? 'received'
+  assertIntentLifecycleTransition(current, input.status, `intent ${input.nonce}`)
 
   db.prepare(`
     UPDATE intent_log
@@ -1477,13 +1578,16 @@ export function finalizeIntentLog(
   `).run(
     completedAt,
     input.latencyMs,
-    status,
+    input.status,
     input.errorCode ?? null,
     input.resultJson ?? null,
     input.nonce,
   )
 
-  updatePairTrustScore(db, input)
+  updatePairTrustScore(db, {
+    ...input,
+    success: isIntentLifecycleSuccess(input.status),
+  })
 }
 
 export function listRecentIntentLogs(db: DB, limit = 50): IntentLogRow[] {
@@ -1507,6 +1611,18 @@ export function getIntentLogByNonce(db: DB, nonce: string): IntentLogRow | null 
   return row ?? null
 }
 
+export function getLatestIntentTraceEvent(db: DB, nonce: string): IntentTraceEventRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM intent_trace_events
+    WHERE nonce = ?
+    ORDER BY timestamp DESC, id DESC
+    LIMIT 1
+  `).get(nonce) as IntentTraceEventRow | undefined
+
+  return row ?? null
+}
+
 export function appendIntentTraceEvent(
   db: DB,
   input: {
@@ -1514,14 +1630,15 @@ export function appendIntentTraceEvent(
     fromBeamId: string
     toBeamId: string
     intentType: string
-    stage: string
-    status: string
+    stage: IntentLifecycleStatus
+    status?: IntentLifecycleStatus
     timestamp?: string
     details?: unknown
   },
 ): IntentTraceEventRow {
   const timestamp = input.timestamp ?? nowIso()
   const details = input.details === undefined ? null : JSON.stringify(input.details)
+  const status = input.status ?? input.stage
 
   const result = db.prepare(`
     INSERT INTO intent_trace_events (
@@ -1540,7 +1657,7 @@ export function appendIntentTraceEvent(
     input.toBeamId,
     input.intentType,
     input.stage,
-    input.status,
+    status,
     timestamp,
     details,
   )
@@ -1561,8 +1678,8 @@ export function getAgentIntentStats(db: DB, beamId: string): AgentIntentStats {
   const row = db.prepare(`
     SELECT
       COUNT(*) AS received,
-      SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS responded,
-      AVG(CASE WHEN status = 'success' THEN round_trip_latency_ms END) AS avg_response_time_ms
+      SUM(CASE WHEN status = 'acked' THEN 1 ELSE 0 END) AS responded,
+      AVG(CASE WHEN status = 'acked' THEN round_trip_latency_ms END) AS avg_response_time_ms
     FROM intent_log
     WHERE to_beam_id = ?
   `).get(beamId) as {
@@ -1595,7 +1712,7 @@ export function getAgentDirectoryStats(db: DB): {
       (
         SELECT AVG(round_trip_latency_ms)
         FROM intent_log
-        WHERE status = 'success' AND round_trip_latency_ms IS NOT NULL
+        WHERE status = 'acked' AND round_trip_latency_ms IS NOT NULL
       ) AS avg_response_time_ms
     FROM agents
   `).get() as {

--- a/packages/directory/src/intent-lifecycle.ts
+++ b/packages/directory/src/intent-lifecycle.ts
@@ -1,0 +1,132 @@
+export const INTENT_LIFECYCLE_STAGES = [
+  'received',
+  'validated',
+  'queued',
+  'dispatched',
+  'delivered',
+  'acked',
+  'failed',
+  'dead_letter',
+] as const
+
+export type IntentLifecycleStatus = (typeof INTENT_LIFECYCLE_STAGES)[number]
+export type IntentLifecycleBucket = 'success' | 'error' | 'in_flight'
+
+const START = '__start__'
+
+const ALLOWED_TRANSITIONS: Record<IntentLifecycleStatus | typeof START, ReadonlySet<IntentLifecycleStatus>> = {
+  [START]: new Set(['received']),
+  received: new Set(['received', 'validated', 'queued', 'failed', 'dead_letter']),
+  validated: new Set(['validated', 'queued', 'dispatched', 'failed', 'dead_letter']),
+  queued: new Set(['queued', 'dispatched', 'failed', 'dead_letter']),
+  dispatched: new Set(['dispatched', 'queued', 'delivered', 'failed', 'dead_letter']),
+  delivered: new Set(['delivered', 'acked', 'failed', 'queued', 'dead_letter']),
+  acked: new Set(['acked']),
+  failed: new Set(['failed', 'queued']),
+  dead_letter: new Set(['dead_letter', 'queued']),
+}
+
+export function isIntentLifecycleStatus(value: string | null | undefined): value is IntentLifecycleStatus {
+  return typeof value === 'string' && INTENT_LIFECYCLE_STAGES.includes(value as IntentLifecycleStatus)
+}
+
+export function normalizeIntentLifecycleStatus(value: string | null | undefined): IntentLifecycleStatus | null {
+  if (!value) {
+    return null
+  }
+
+  if (isIntentLifecycleStatus(value)) {
+    return value
+  }
+
+  switch (value) {
+    case 'pending':
+      return 'received'
+    case 'success':
+      return 'acked'
+    case 'error':
+      return 'failed'
+    case 'expired':
+      return 'dead_letter'
+    default:
+      return null
+  }
+}
+
+export function classifyIntentLifecycle(status: IntentLifecycleStatus): IntentLifecycleBucket {
+  switch (status) {
+    case 'acked':
+      return 'success'
+    case 'failed':
+    case 'dead_letter':
+      return 'error'
+    default:
+      return 'in_flight'
+  }
+}
+
+export function isIntentLifecycleTerminal(status: IntentLifecycleStatus): boolean {
+  return classifyIntentLifecycle(status) !== 'in_flight'
+}
+
+export function isIntentLifecycleSuccess(status: IntentLifecycleStatus): boolean {
+  return status === 'acked'
+}
+
+export function isIntentLifecycleFailure(status: IntentLifecycleStatus): boolean {
+  return status === 'failed' || status === 'dead_letter'
+}
+
+export function isIntentLifecycleInFlight(status: IntentLifecycleStatus): boolean {
+  return !isIntentLifecycleTerminal(status)
+}
+
+export function assertIntentLifecycleTransition(
+  previous: IntentLifecycleStatus | null,
+  next: IntentLifecycleStatus,
+  context = 'intent lifecycle',
+): void {
+  const allowed = ALLOWED_TRANSITIONS[previous ?? START]
+  if (allowed.has(next)) {
+    return
+  }
+
+  throw new Error(`Invalid ${context} transition from ${previous ?? 'start'} to ${next}`)
+}
+
+export function normalizeLegacyTraceLifecycle(
+  stage: string,
+  status: string,
+): IntentLifecycleStatus | null {
+  const normalizedStage = normalizeIntentLifecycleStatus(stage)
+  if (normalizedStage) {
+    return normalizedStage
+  }
+
+  switch (stage) {
+    case 'sender_lookup':
+      return 'received'
+    case 'validated':
+      return status === 'error' ? 'failed' : 'validated'
+    case 'dispatch':
+      return 'dispatched'
+    case 'delivery':
+      if (status === 'success') {
+        return 'delivered'
+      }
+      return status === 'error' ? 'failed' : 'dispatched'
+    case 'federation.resolve':
+      return status === 'error' ? 'failed' : 'dispatched'
+    case 'federation.relay':
+      if (status === 'success') {
+        return 'delivered'
+      }
+      return status === 'error' ? 'failed' : 'dispatched'
+    case 'completed':
+      return status === 'success' ? 'acked' : 'failed'
+    case 'dedupe':
+      return null
+    default:
+      return normalizeIntentLifecycleStatus(status)
+  }
+}

--- a/packages/directory/src/observability-hooks.ts
+++ b/packages/directory/src/observability-hooks.ts
@@ -1,8 +1,14 @@
 import type { Database } from 'better-sqlite3'
-import { appendIntentTraceEvent, getAgent } from './db.js'
+import { appendIntentTraceEvent, getAgent, getLatestIntentTraceEvent } from './db.js'
 import { hashPayload, logShieldEvent } from './shield/audit.js'
 import { sanitizeExternalMessage } from './shield/content-sandbox.js'
 import { AnomalyDetector } from './shield/anomaly.js'
+import {
+  assertIntentLifecycleTransition,
+  normalizeIntentLifecycleStatus,
+  normalizeLegacyTraceLifecycle,
+  type IntentLifecycleStatus,
+} from './intent-lifecycle.js'
 
 type TraceFrame = {
   nonce: string
@@ -41,18 +47,22 @@ function stringifyPayload(payload: unknown): string {
 export function recordIntentStage(
   db: Database,
   frame: TraceFrame,
-  stage: string,
-  status: string,
+  stage: IntentLifecycleStatus,
   details?: unknown,
   timestamp?: string,
 ): void {
+  const previous = getLatestIntentTraceEvent(db, frame.nonce)
+  const previousStage = previous
+    ? (normalizeIntentLifecycleStatus(previous.stage) ?? normalizeLegacyTraceLifecycle(previous.stage, previous.status))
+    : null
+
+  assertIntentLifecycleTransition(previousStage, stage, `trace ${frame.nonce}`)
   appendIntentTraceEvent(db, {
     nonce: frame.nonce,
     fromBeamId: frame.from,
     toBeamId: frame.to,
     intentType: frame.intent,
     stage,
-    status,
     details,
     timestamp,
   })

--- a/packages/directory/src/observability.test.ts
+++ b/packages/directory/src/observability.test.ts
@@ -11,9 +11,11 @@ import {
   logAuditEvent,
   logIntentStart,
   registerAgent,
+  setIntentLifecycleStatus,
 } from './db.js'
 import { getLocalDirectoryUrl } from './federation.js'
 import { logShieldEvent } from './shield/audit.js'
+import { recordIntentStage } from './observability-hooks.js'
 import type { IntentFrame } from './types.js'
 
 function createAdminHeaders(db: ReturnType<typeof createDatabase>, email = 'ops@example.com', role: 'admin' | 'operator' | 'viewer' = 'admin') {
@@ -76,7 +78,6 @@ test('observability trace endpoint returns lifecycle, audit, and shield context'
       toBeamId: frame.to,
       intentType: frame.intent,
       stage: 'received',
-      status: 'pending',
       timestamp: frame.timestamp,
     })
     appendIntentTraceEvent(db, {
@@ -85,21 +86,36 @@ test('observability trace endpoint returns lifecycle, audit, and shield context'
       toBeamId: frame.to,
       intentType: frame.intent,
       stage: 'validated',
-      status: 'success',
     })
     appendIntentTraceEvent(db, {
       nonce: frame.nonce,
       fromBeamId: frame.from,
       toBeamId: frame.to,
       intentType: frame.intent,
-      stage: 'completed',
-      status: 'success',
+      stage: 'dispatched',
     })
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'delivered',
+    })
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'acked',
+    })
+    setIntentLifecycleStatus(db, { nonce: frame.nonce, status: 'validated' })
+    setIntentLifecycleStatus(db, { nonce: frame.nonce, status: 'dispatched' })
+    setIntentLifecycleStatus(db, { nonce: frame.nonce, status: 'delivered' })
     finalizeIntentLog(db, {
       nonce: frame.nonce,
       fromBeamId: frame.from,
       toBeamId: frame.to,
-      success: true,
+      status: 'acked',
       latencyMs: 42,
     })
 
@@ -137,7 +153,7 @@ test('observability trace endpoint returns lifecycle, audit, and shield context'
     }
 
     assert.equal(payload.intent.nonce, frame.nonce)
-    assert.deepEqual(payload.stages.map((stage) => stage.stage), ['received', 'validated', 'completed'])
+    assert.deepEqual(payload.stages.map((stage) => stage.stage), ['received', 'validated', 'dispatched', 'delivered', 'acked'])
     assert.equal(payload.audit[0]?.action, 'federation.relay')
     assert.equal(payload.shield[0]?.decision, 'hold')
   } finally {
@@ -157,7 +173,7 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
         nonce: frame.nonce,
         fromBeamId: frame.from,
         toBeamId: frame.to,
-        success: false,
+        status: 'failed',
         latencyMs: 3200,
         errorCode: 'TIMEOUT',
       })
@@ -192,7 +208,6 @@ test('prune endpoint removes aged intents and trace records', async () => {
       toBeamId: frame.to,
       intentType: frame.intent,
       stage: 'received',
-      status: 'pending',
       timestamp: oldTimestamp,
     })
 
@@ -216,6 +231,26 @@ test('prune endpoint removes aged intents and trace records', async () => {
     const remainingTraces = db.prepare('SELECT COUNT(*) AS count FROM intent_trace_events').get() as { count: number }
     assert.equal(remainingIntents.count, 0)
     assert.equal(remainingTraces.count, 0)
+  } finally {
+    db.close()
+  }
+})
+
+test('recordIntentStage rejects out-of-order lifecycle stages', () => {
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const frame = createFrame('invalid-order')
+
+    recordIntentStage(db, frame, 'received', undefined, frame.timestamp)
+    recordIntentStage(db, frame, 'validated')
+    recordIntentStage(db, frame, 'dispatched')
+    recordIntentStage(db, frame, 'delivered')
+
+    assert.throws(
+      () => recordIntentStage(db, frame, 'validated'),
+      /Invalid trace invalid-order transition from delivered to validated/,
+    )
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -2,6 +2,14 @@ import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
 import { requireAdminRole } from '../admin-auth.js'
 import { getAgent, listAuditLog, listIntentTraceEvents, listShieldAuditLog, logAuditEvent } from '../db.js'
+import {
+  classifyIntentLifecycle,
+  isIntentLifecycleFailure,
+  isIntentLifecycleSuccess,
+  normalizeIntentLifecycleStatus,
+  normalizeLegacyTraceLifecycle,
+  type IntentLifecycleStatus,
+} from '../intent-lifecycle.js'
 import type {
   AuditLogRow,
   FederationPeerRow,
@@ -126,6 +134,7 @@ function toBucketStart(isoTimestamp: string, bucketHours: number): string {
 }
 
 function serializeIntentRow(row: IntentLogRow) {
+  const lifecycleStatus = normalizeIntentLifecycleStatus(row.status) ?? 'received'
   return {
     nonce: row.nonce,
     from: row.from_beam_id,
@@ -134,20 +143,23 @@ function serializeIntentRow(row: IntentLogRow) {
     timestamp: row.requested_at,
     completedAt: row.completed_at,
     roundTripLatencyMs: row.round_trip_latency_ms,
-    status: row.status,
-    errorCode: row.error_code,
+    status: lifecycleStatus,
+    errorCode: isIntentLifecycleFailure(lifecycleStatus) ? row.error_code : null,
   }
 }
 
 function serializeTraceEvent(row: IntentTraceEventRow) {
+  const lifecycleStatus = normalizeIntentLifecycleStatus(row.stage)
+    ?? normalizeLegacyTraceLifecycle(row.stage, row.status)
+    ?? 'received'
   return {
     id: row.id,
     nonce: row.nonce,
     from: row.from_beam_id,
     to: row.to_beam_id,
     intentType: row.intent_type,
-    stage: row.stage,
-    status: row.status,
+    stage: lifecycleStatus,
+    status: lifecycleStatus,
     timestamp: row.timestamp,
     details: parseJson<Record<string, unknown> | null>(row.details, null),
   }
@@ -201,8 +213,20 @@ function buildIntentWhereClause(query: IntentQuery): { whereClause: string; para
   }
 
   if (query.status && query.status !== 'all') {
-    conditions.push('status = ?')
-    params.push(query.status)
+    const normalized = normalizeIntentLifecycleStatus(query.status)
+    if (query.status === 'success') {
+      conditions.push(`status = 'acked'`)
+    } else if (query.status === 'error') {
+      conditions.push(`status IN ('failed', 'dead_letter')`)
+    } else if (query.status === 'pending' || query.status === 'in_flight') {
+      conditions.push(`status NOT IN ('acked', 'failed', 'dead_letter')`)
+    } else if (normalized) {
+      conditions.push('status = ?')
+      params.push(normalized)
+    } else {
+      conditions.push('status = ?')
+      params.push(query.status)
+    }
   }
 
   if (query.errorCode) {
@@ -313,7 +337,7 @@ function buildOverviewPayload(db: Database, windowHours: number) {
     total: number
     success: number
     error: number
-    pending: number
+    inFlight: number
     latencies: number[]
   }>()
 
@@ -335,22 +359,24 @@ function buildOverviewPayload(db: Database, windowHours: number) {
     .filter((value): value is number => typeof value === 'number')
 
   for (const row of rows) {
+    const lifecycleStatus = normalizeIntentLifecycleStatus(row.status) ?? 'received'
+    const lifecycleBucket = classifyIntentLifecycle(lifecycleStatus)
     const bucketStart = toBucketStart(row.requested_at, bucketHours)
     const bucket = bucketMap.get(bucketStart) ?? {
       bucketStart,
       total: 0,
       success: 0,
       error: 0,
-      pending: 0,
+      inFlight: 0,
       latencies: [],
     }
     bucket.total += 1
-    if (row.status === 'success') {
+    if (lifecycleBucket === 'success') {
       bucket.success += 1
-    } else if (row.status === 'error') {
+    } else if (lifecycleBucket === 'error') {
       bucket.error += 1
     } else {
-      bucket.pending += 1
+      bucket.inFlight += 1
     }
     if (typeof row.round_trip_latency_ms === 'number') {
       bucket.latencies.push(row.round_trip_latency_ms)
@@ -364,7 +390,7 @@ function buildOverviewPayload(db: Database, windowHours: number) {
       latencies: [],
     }
     intentEntry.total += 1
-    if (row.status === 'error') {
+    if (lifecycleBucket === 'error') {
       intentEntry.errors += 1
     }
     if (typeof row.round_trip_latency_ms === 'number') {
@@ -392,10 +418,10 @@ function buildOverviewPayload(db: Database, windowHours: number) {
   const federatedAgents = (db.prepare('SELECT COUNT(*) AS count FROM federated_agents').get() as { count: number } | undefined)?.count ?? 0
   const federationPeers = (db.prepare('SELECT COUNT(*) AS count FROM federation_peers').get() as { count: number } | undefined)?.count ?? 0
 
-  const pendingOlderThan15m = (db.prepare(`
+  const inFlightOlderThan15m = (db.prepare(`
     SELECT COUNT(*) AS count
     FROM intent_log
-    WHERE status = 'pending' AND requested_at < ?
+    WHERE status NOT IN ('acked', 'failed', 'dead_letter') AND requested_at < ?
   `).get(new Date(Date.now() - 15 * 60 * 1000).toISOString()) as { count: number } | undefined)?.count ?? 0
 
   const timeline = Array.from(bucketMap.values())
@@ -405,7 +431,7 @@ function buildOverviewPayload(db: Database, windowHours: number) {
       total: bucket.total,
       success: bucket.success,
       error: bucket.error,
-      pending: bucket.pending,
+      inFlight: bucket.inFlight,
       p95LatencyMs: percentile(bucket.latencies, 0.95),
     }))
 
@@ -416,13 +442,13 @@ function buildOverviewPayload(db: Database, windowHours: number) {
     federatedAgents,
     federationPeers,
     totalIntents: rows.length,
-    successCount: rows.filter((row) => row.status === 'success').length,
-    errorCount: rows.filter((row) => row.status === 'error').length,
-    pendingCount: rows.filter((row) => row.status === 'pending').length,
+    successCount: rows.filter((row) => isIntentLifecycleSuccess(normalizeIntentLifecycleStatus(row.status) ?? 'received')).length,
+    errorCount: rows.filter((row) => isIntentLifecycleFailure(normalizeIntentLifecycleStatus(row.status) ?? 'received')).length,
+    inFlightCount: rows.filter((row) => classifyIntentLifecycle(normalizeIntentLifecycleStatus(row.status) ?? 'received') === 'in_flight').length,
     avgLatencyMs: latencies.length > 0 ? round(latencies.reduce((sum, value) => sum + value, 0) / latencies.length) : null,
     p95LatencyMs: percentile(latencies, 0.95),
-    successRate: rows.length > 0 ? round(rows.filter((row) => row.status === 'success').length / rows.length, 4) : 0,
-    pendingOlderThan15m,
+    successRate: rows.length > 0 ? round(rows.filter((row) => isIntentLifecycleSuccess(normalizeIntentLifecycleStatus(row.status) ?? 'received')).length / rows.length, 4) : 0,
+    inFlightOlderThan15m,
   }
 
   return {
@@ -460,7 +486,7 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
 
   const outbound = rows.filter((row) => row.from_beam_id === beamId)
   const inbound = rows.filter((row) => row.to_beam_id === beamId)
-  const completed = rows.filter((row) => row.status !== 'pending')
+  const completed = rows.filter((row) => classifyIntentLifecycle(normalizeIntentLifecycleStatus(row.status) ?? 'received') !== 'in_flight')
   const latencies = completed
     .map((row) => row.round_trip_latency_ms)
     .filter((value): value is number => typeof value === 'number')
@@ -496,6 +522,8 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
   }>()
 
   for (const row of rows) {
+    const lifecycleStatus = normalizeIntentLifecycleStatus(row.status) ?? 'received'
+    const lifecycleBucket = classifyIntentLifecycle(lifecycleStatus)
     const bucketStart = toBucketStart(row.requested_at, bucketHours)
     const bucket = timelineMap.get(bucketStart) ?? {
       bucketStart,
@@ -511,10 +539,10 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
     if (row.to_beam_id === beamId) {
       bucket.received += 1
     }
-    if (row.status === 'success') {
+    if (lifecycleBucket === 'success') {
       bucket.success += 1
     }
-    if (row.status === 'error') {
+    if (lifecycleBucket === 'error') {
       bucket.error += 1
     }
     if (typeof row.round_trip_latency_ms === 'number') {
@@ -534,7 +562,7 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
     } else {
       counterparty.inbound += 1
     }
-    if (row.status === 'error') {
+    if (lifecycleBucket === 'error') {
       counterparty.errors += 1
     }
     counterpartyMap.set(counterpartyBeamId, counterparty)
@@ -546,7 +574,7 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
       latencies: [],
     }
     intentEntry.total += 1
-    if (row.status === 'error') {
+    if (lifecycleBucket === 'error') {
       intentEntry.errors += 1
     }
     if (typeof row.round_trip_latency_ms === 'number') {
@@ -595,8 +623,8 @@ function buildAgentHealthPayload(db: Database, beamId: string, windowHours: numb
       sentCount: outbound.length,
       receivedCount: inbound.length,
       completedCount: completed.length,
-      successRate: completed.length > 0 ? round(completed.filter((row) => row.status === 'success').length / completed.length, 4) : 0,
-      errorRate: completed.length > 0 ? round(completed.filter((row) => row.status === 'error').length / completed.length, 4) : 0,
+      successRate: completed.length > 0 ? round(completed.filter((row) => isIntentLifecycleSuccess(normalizeIntentLifecycleStatus(row.status) ?? 'received')).length / completed.length, 4) : 0,
+      errorRate: completed.length > 0 ? round(completed.filter((row) => isIntentLifecycleFailure(normalizeIntentLifecycleStatus(row.status) ?? 'received')).length / completed.length, 4) : 0,
       avgLatencyMs: latencies.length > 0 ? round(latencies.reduce((sum, value) => sum + value, 0) / latencies.length) : null,
       p95LatencyMs: percentile(latencies, 0.95),
       uniqueCounterparties: counterpartyMap.size,
@@ -744,7 +772,7 @@ function buildErrorsPayload(db: Database, windowHours: number) {
   const rows = db.prepare(`
     SELECT *
     FROM intent_log
-    WHERE status = 'error' AND requested_at >= ?
+    WHERE status IN ('failed', 'dead_letter') AND requested_at >= ?
     ORDER BY requested_at ASC, id ASC
   `).all(since) as IntentLogRow[]
 
@@ -854,15 +882,15 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
     })
   }
 
-  if (overview.summary.pendingOlderThan15m > 0) {
+  if (overview.summary.inFlightOlderThan15m > 0) {
     alerts.push({
-      id: 'network-pending-backlog',
-      severity: overview.summary.pendingOlderThan15m >= 5 ? 'critical' : 'warning',
-      title: 'Pending intent backlog detected',
+      id: 'network-in-flight-backlog',
+      severity: overview.summary.inFlightOlderThan15m >= 5 ? 'critical' : 'warning',
+      title: 'In-flight intent backlog detected',
       scope: 'network',
-      message: `${overview.summary.pendingOlderThan15m} intents have been pending for more than 15 minutes.`,
-      metric: 'pending_older_than_15m',
-      value: overview.summary.pendingOlderThan15m,
+      message: `${overview.summary.inFlightOlderThan15m} intents have remained in-flight for more than 15 minutes.`,
+      metric: 'in_flight_older_than_15m',
+      value: overview.summary.inFlightOlderThan15m,
       threshold: 1,
       startedAt: new Date().toISOString(),
     })
@@ -928,6 +956,7 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
 }
 
 function createSyntheticTrace(intent: IntentLogRow): Array<ReturnType<typeof serializeTraceEvent>> {
+  const lifecycleStatus = normalizeIntentLifecycleStatus(intent.status) ?? 'received'
   const stages: Array<ReturnType<typeof serializeTraceEvent>> = [
     {
       id: 0,
@@ -936,22 +965,22 @@ function createSyntheticTrace(intent: IntentLogRow): Array<ReturnType<typeof ser
       to: intent.to_beam_id,
       intentType: intent.intent_type,
       stage: 'received',
-      status: 'pending',
+      status: 'received',
       timestamp: intent.requested_at,
       details: null,
     },
   ]
 
-  if (intent.completed_at) {
+  if (lifecycleStatus !== 'received') {
     stages.push({
       id: -1,
       nonce: intent.nonce,
       from: intent.from_beam_id,
       to: intent.to_beam_id,
       intentType: intent.intent_type,
-      stage: 'completed',
-      status: intent.status,
-      timestamp: intent.completed_at,
+      stage: lifecycleStatus,
+      status: lifecycleStatus,
+      timestamp: intent.completed_at ?? intent.requested_at,
       details: {
         latencyMs: intent.round_trip_latency_ms,
         errorCode: intent.error_code,

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -1,3 +1,5 @@
+import type { IntentLifecycleStatus } from './intent-lifecycle.js'
+
 // Beam ID string format: agent@org.beam.directory or agent@beam.directory
 export type BeamIdString = string
 
@@ -46,7 +48,7 @@ export interface IntentLogRow {
   requested_at: string
   completed_at: string | null
   round_trip_latency_ms: number | null
-  status: string
+  status: IntentLifecycleStatus
   error_code: string | null
   result_json: string | null
 }
@@ -57,8 +59,8 @@ export interface IntentTraceEventRow {
   from_beam_id: string
   to_beam_id: string
   intent_type: string
-  stage: string
-  status: string
+  stage: IntentLifecycleStatus
+  status: IntentLifecycleStatus
   timestamp: string
   details: string | null
 }

--- a/packages/directory/src/websocket.test.ts
+++ b/packages/directory/src/websocket.test.ts
@@ -303,7 +303,7 @@ test('relayIntentFromHttp records a retryable timeout for unanswered websocket d
 
     const log = getIntentLogByNonce(db, frame.nonce)
     assert.ok(log)
-    assert.equal(log?.status, 'error')
+    assert.equal(log?.status, 'failed')
     assert.equal(log?.error_code, 'TIMEOUT')
     assert.match(log?.result_json ?? '', /"errorCode":"TIMEOUT"/)
 

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -3,7 +3,7 @@ import { WebSocketServer, WebSocket } from 'ws'
 import type { IncomingMessage } from 'node:http'
 import type { Database } from 'better-sqlite3'
 import type { IntentFrame, ResultFrame } from './types.js'
-import { finalizeIntentLog, getAgent, getIntentLogByNonce, hasActiveDelegation, logIntentStart, updateLastSeen } from './db.js'
+import { finalizeIntentLog, getAgent, getIntentLogByNonce, hasActiveDelegation, logIntentStart, setIntentLifecycleStatus, updateLastSeen } from './db.js'
 import { isIntentAllowed } from './acl.js'
 import {
   getCachedFederatedPublicKey,
@@ -17,6 +17,13 @@ import { validateIntentPayload } from './validation.js'
 import { checkAgentRateLimit, getRateLimitPerMinute, pruneRateLimitState } from './rate-limit.js'
 import { agentApiKeyMatches, getSuppliedApiKey } from './api-key.js'
 import { recordIntentStage, recordShieldDecision } from './observability-hooks.js'
+import {
+  isIntentLifecycleFailure,
+  isIntentLifecycleInFlight,
+  isIntentLifecycleSuccess,
+  normalizeIntentLifecycleStatus,
+  type IntentLifecycleStatus,
+} from './intent-lifecycle.js'
 
 const REPLAY_WINDOW_MS = 5 * 60 * 1000
 const STALE_PENDING_RETRY_WINDOW_MS = 2 * 60 * 1000
@@ -63,6 +70,12 @@ function serializeResultFrame(result: ResultFrame): string {
   return JSON.stringify(result)
 }
 
+function lifecycleErrorCode(status: IntentLifecycleStatus, errorCode: string | null | undefined): string | null {
+  return status === 'failed' || status === 'dead_letter'
+    ? (errorCode ?? 'RESULT_ERROR')
+    : null
+}
+
 function buildResultFrame(
   frame: IntentFrame,
   options: {
@@ -101,7 +114,9 @@ function claimIntentNonce(db: Database, frame: IntentFrame): NonceClaimResult {
     throw new RelayError('BAD_REQUEST', `Nonce ${frame.nonce} was already used for a different intent`)
   }
 
-  if (existing.status === 'pending') {
+  const existingStatus = normalizeIntentLifecycleStatus(existing.status) ?? 'received'
+
+  if (isIntentLifecycleInFlight(existingStatus)) {
     const existingRequestedAt = new Date(existing.requested_at).getTime()
     const ageMs = Number.isNaN(existingRequestedAt) ? 0 : Date.now() - existingRequestedAt
     if (ageMs <= STALE_PENDING_RETRY_WINDOW_MS) {
@@ -116,10 +131,10 @@ function claimIntentNonce(db: Database, frame: IntentFrame): NonceClaimResult {
     try {
       const parsed = JSON.parse(existing.result_json) as ResultFrame
       if (parsed && typeof parsed === 'object' && parsed.nonce === frame.nonce) {
-        if (existing.status === 'success') {
+        if (isIntentLifecycleSuccess(existingStatus)) {
           return { kind: 'cached', result: parsed }
         }
-        if (existing.error_code && !RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
+        if (isIntentLifecycleFailure(existingStatus) && existing.error_code && !RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
           return { kind: 'cached', result: parsed }
         }
       }
@@ -128,7 +143,7 @@ function claimIntentNonce(db: Database, frame: IntentFrame): NonceClaimResult {
     }
   }
 
-  if (existing.status === 'error' && existing.error_code && RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
+  if (isIntentLifecycleFailure(existingStatus) && existing.error_code && RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
     logIntentStart(db, frame)
     return { kind: 'accepted' }
   }
@@ -138,23 +153,18 @@ function claimIntentNonce(db: Database, frame: IntentFrame): NonceClaimResult {
 }
 
 function applyNonceClaimResult(
-  db: Database,
-  frame: IntentFrame,
+  nonce: string,
   claim: NonceClaimResult,
 ): ResultFrame | null {
   if (claim.kind === 'accepted') {
     return null
   }
 
-  recordIntentStage(db, frame, 'dedupe', 'success', {
-    outcome: claim.kind,
-  })
-
   if (claim.kind === 'cached') {
     return claim.result
   }
 
-  throw new RelayError('IN_PROGRESS', `Intent with nonce ${frame.nonce} is already being processed`)
+  throw new RelayError('IN_PROGRESS', `Intent with nonce ${nonce} is already being processed`)
 }
 
 function finalizeIntentWithResult(
@@ -167,7 +177,7 @@ function finalizeIntentWithResult(
     nonce: frame.nonce,
     fromBeamId: frame.from,
     toBeamId: frame.to,
-    success: result.success,
+    status: result.success ? 'acked' : 'failed',
     latencyMs,
     errorCode: result.success ? undefined : (result.errorCode ?? 'RESULT_ERROR'),
     resultJson: serializeResultFrame(result),
@@ -175,6 +185,7 @@ function finalizeIntentWithResult(
 }
 
 function broadcastCompletedIntent(frame: IntentFrame, result: ResultFrame, latencyMs: number | null): void {
+  const lifecycleStatus: IntentLifecycleStatus = result.success ? 'acked' : 'failed'
   broadcastIntentFeed({
     nonce: frame.nonce,
     from: frame.from,
@@ -183,8 +194,8 @@ function broadcastCompletedIntent(frame: IntentFrame, result: ResultFrame, laten
     timestamp: frame.timestamp,
     completedAt: new Date().toISOString(),
     roundTripLatencyMs: latencyMs,
-    status: result.success ? 'success' : 'error',
-    errorCode: result.success ? null : (result.errorCode ?? 'RESULT_ERROR'),
+    status: lifecycleStatus,
+    errorCode: lifecycleErrorCode(lifecycleStatus, result.errorCode),
   })
 }
 
@@ -207,7 +218,7 @@ function finalizeFailedIntent(
   })
 
   finalizeIntentWithResult(db, frame, result, options.latencyMs)
-  recordIntentStage(db, frame, 'completed', 'error', {
+  recordIntentStage(db, frame, 'failed', {
     transport: options.transport,
     latencyMs: options.latencyMs,
     errorCode: options.errorCode,
@@ -271,11 +282,6 @@ async function attemptDirectHttpDelivery(
   frame: IntentFrame,
   endpoint: string,
 ): Promise<ResultFrame | null> {
-  recordIntentStage(db, frame, 'delivery', 'pending', {
-    transport: 'direct-http',
-    endpoint,
-  })
-
   try {
     const startedAt = Date.now()
     const directResponse = await fetch(endpoint, {
@@ -299,9 +305,10 @@ async function attemptDirectHttpDelivery(
 
     const latencyMs = Date.now() - startedAt
     if (!directResponse.ok) {
-      recordIntentStage(db, frame, 'delivery', 'error', {
+      recordIntentStage(db, frame, 'dispatched', {
         transport: 'direct-http',
         endpoint,
+        outcome: 'fallback',
         status: directResponse.status,
         errorCode: 'DIRECT_HTTP_FAILED',
       })
@@ -316,25 +323,42 @@ async function attemptDirectHttpDelivery(
     }
 
     const result = normalizeDirectHttpResult(frame, body, latencyMs)
+    recordIntentStage(db, frame, 'delivered', {
+      transport: 'direct-http',
+      endpoint,
+      status: directResponse.status,
+      latencyMs,
+    })
+    setIntentLifecycleStatus(db, {
+      nonce: frame.nonce,
+      status: 'delivered',
+    })
+    broadcastIntentFeed({
+      nonce: frame.nonce,
+      from: frame.from,
+      to: frame.to,
+      intentType: frame.intent,
+      timestamp: frame.timestamp,
+      completedAt: null,
+      roundTripLatencyMs: null,
+      status: 'delivered',
+      errorCode: null,
+    })
     finalizeIntentWithResult(db, frame, result, latencyMs)
-    recordIntentStage(db, frame, 'delivery', result.success ? 'success' : 'error', {
+    recordIntentStage(db, frame, result.success ? 'acked' : 'failed', {
       transport: 'direct-http',
       endpoint,
       status: directResponse.status,
       latencyMs,
       errorCode: result.success ? null : (result.errorCode ?? 'DIRECT_HTTP_ERROR'),
     })
-    recordIntentStage(db, frame, 'completed', result.success ? 'success' : 'error', {
-      transport: 'direct-http',
-      latencyMs,
-      errorCode: result.success ? null : (result.errorCode ?? 'DIRECT_HTTP_ERROR'),
-    })
     broadcastCompletedIntent(frame, result, latencyMs)
     return result
   } catch (err) {
-    recordIntentStage(db, frame, 'delivery', 'error', {
+    recordIntentStage(db, frame, 'dispatched', {
       transport: 'direct-http',
       endpoint,
+      outcome: 'fallback',
       errorCode: 'DIRECT_HTTP_FAILED',
       message: err instanceof Error ? err.message : 'Direct delivery failed',
     })
@@ -443,56 +467,53 @@ export async function relayIntentFromHttp(
     throw new RelayError('BAD_REQUEST', `Federation hop limit exceeded (${MAX_FEDERATION_HOPS})`)
   }
 
-  recordIntentStage(db, prepared, 'received', 'pending', {
-    transport: 'http',
-    sourceDirectory,
-    hopCount,
-  }, prepared.timestamp)
-
   const sender = getAgent(db, prepared.from)
   const senderPublicKey = sender?.public_key ?? await resolveSenderPublicKey(db, prepared.from, sourceDirectory)
 
   if (!senderPublicKey) {
-    recordIntentStage(db, prepared, 'sender_lookup', 'error', {
-      sourceDirectory,
-      errorCode: 'UNKNOWN_SENDER',
-    })
     throw new RelayError('BAD_REQUEST', `Sender ${prepared.from} is not registered`)
   }
-
-  recordIntentStage(db, prepared, 'sender_lookup', 'success', {
-    sourceDirectory,
-    source: sender ? 'local' : 'federated',
-  })
 
   try {
     enforceSecurityChecks(db, prepared, senderPublicKey)
     recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
-    recordIntentStage(db, prepared, 'validated', 'success', {
-      transport: 'http',
-    })
   } catch (err) {
     recordShieldDecision(db, prepared, {
       decision: 'reject',
       timestamp: prepared.timestamp,
       extraFlags: [err instanceof RelayError ? err.code : 'INVALID_INTENT'],
     })
-    recordIntentStage(db, prepared, 'validated', 'error', {
-      transport: 'http',
-      errorCode: err instanceof RelayError ? err.code : 'INVALID_INTENT',
-      message: err instanceof Error ? err.message : 'Rejected by security checks',
-    })
     throw err
   }
 
-  const cachedResult = applyNonceClaimResult(db, prepared, claimIntentNonce(db, prepared))
+  const cachedResult = applyNonceClaimResult(prepared.nonce, claimIntentNonce(db, prepared))
   if (cachedResult) {
     updateLastSeen(db, prepared.from)
     return cachedResult
   }
 
-  recordIntentStage(db, prepared, 'dispatch', 'pending', {
+  recordIntentStage(db, prepared, 'received', {
+    transport: 'http',
+    sourceDirectory,
+    hopCount,
+  }, prepared.timestamp)
+  recordIntentStage(db, prepared, 'validated', {
+    transport: 'http',
+    sourceDirectory,
+    senderSource: sender ? 'local' : 'federated',
+  })
+  setIntentLifecycleStatus(db, {
+    nonce: prepared.nonce,
+    status: 'validated',
+  })
+
+  recordIntentStage(db, prepared, 'dispatched', {
     deliveryTarget: 'local-or-federated',
+    transport: 'http',
+  })
+  setIntentLifecycleStatus(db, {
+    nonce: prepared.nonce,
+    status: 'dispatched',
   })
   broadcastIntentFeed({
     nonce: prepared.nonce,
@@ -502,13 +523,13 @@ export async function relayIntentFromHttp(
     timestamp: prepared.timestamp,
     completedAt: null,
     roundTripLatencyMs: null,
-    status: 'pending',
+    status: 'dispatched',
     errorCode: null,
   })
 
   const localRecipient = getAgent(db, prepared.to)
   if (!localRecipient) {
-    recordIntentStage(db, prepared, 'dispatch', 'pending', {
+    recordIntentStage(db, prepared, 'dispatched', {
       deliveryTarget: 'federation',
     })
     const federatedResult = await relayIntentToFederatedPeer(db, prepared, timeoutMs, {
@@ -530,10 +551,6 @@ export async function relayIntentFromHttp(
   const recipientSession = connections.get(prepared.to)
   const recipientWs = recipientSession?.ws
   if (!recipientWs || recipientWs.readyState !== WebSocket.OPEN) {
-    recordIntentStage(db, prepared, 'delivery', 'error', {
-      transport: 'ws',
-      errorCode: 'OFFLINE',
-    })
     finalizeFailedIntent(db, prepared, {
       error: `Agent ${prepared.to} is not currently connected`,
       errorCode: 'OFFLINE',
@@ -544,7 +561,7 @@ export async function relayIntentFromHttp(
   }
 
   const resultPromise = createResultWaiter(db, prepared, timeoutMs)
-  recordIntentStage(db, prepared, 'delivery', 'pending', {
+  recordIntentStage(db, prepared, 'dispatched', {
     transport: 'ws',
     timeoutMs,
   })
@@ -555,13 +572,27 @@ export async function relayIntentFromHttp(
       frame: prepared,
       senderPublicKey,
     })
+    recordIntentStage(db, prepared, 'delivered', {
+      transport: 'ws',
+      timeoutMs,
+    })
+    setIntentLifecycleStatus(db, {
+      nonce: prepared.nonce,
+      status: 'delivered',
+    })
+    broadcastIntentFeed({
+      nonce: prepared.nonce,
+      from: prepared.from,
+      to: prepared.to,
+      intentType: prepared.intent,
+      timestamp: prepared.timestamp,
+      completedAt: null,
+      roundTripLatencyMs: null,
+      status: 'delivered',
+      errorCode: null,
+    })
   } catch (err) {
     clearPendingResult(prepared.nonce)
-    recordIntentStage(db, prepared, 'delivery', 'error', {
-      transport: 'ws',
-      errorCode: 'DELIVERY_FAILED',
-      message: err instanceof Error ? err.message : 'Failed to deliver to recipient socket',
-    })
     finalizeFailedIntent(db, prepared, {
       error: err instanceof Error ? err.message : 'Failed to relay intent',
       errorCode: 'DELIVERY_FAILED',
@@ -629,12 +660,6 @@ async function handleIntent(
   try {
     senderAgent = resolveIntentSender(db, senderBeamId, prepared)
   } catch (err) {
-    recordIntentStage(db, prepared, 'sender_lookup', 'error', {
-      transport: 'ws',
-      connectedBeamId: senderBeamId,
-      errorCode: err instanceof RelayError ? err.code : 'UNKNOWN_SENDER',
-      message: err instanceof Error ? err.message : 'Sender is not registered in the directory',
-    })
     sendJson(senderWs, {
       type: 'error',
       nonce: prepared.nonce,
@@ -644,34 +669,14 @@ async function handleIntent(
     return
   }
 
-  recordIntentStage(db, prepared, 'received', 'pending', {
-    transport: 'ws',
-    connectedBeamId: senderBeamId,
-  }, prepared.timestamp)
-  recordIntentStage(db, prepared, 'sender_lookup', 'success', {
-    transport: 'ws',
-    connectedBeamId: senderBeamId,
-    actingOnBehalf: senderBeamId !== prepared.from,
-  })
-
   try {
     enforceSecurityChecks(db, prepared, senderAgent.public_key, { skipSignatureVerification: auth.authenticatedViaApiKey })
     recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
-    recordIntentStage(db, prepared, 'validated', 'success', {
-      transport: 'ws',
-      authenticatedViaApiKey: auth.authenticatedViaApiKey,
-    })
   } catch (err) {
     recordShieldDecision(db, prepared, {
       decision: 'reject',
       timestamp: prepared.timestamp,
       extraFlags: [err instanceof RelayError ? err.code : 'INVALID_INTENT'],
-    })
-    recordIntentStage(db, prepared, 'validated', 'error', {
-      transport: 'ws',
-      authenticatedViaApiKey: auth.authenticatedViaApiKey,
-      errorCode: err instanceof RelayError ? err.code : 'INVALID_INTENT',
-      message: err instanceof Error ? err.message : 'Rejected by relay security checks',
     })
     if (err instanceof RelayError && err.code === 'RATE_LIMITED') {
       sendJson(senderWs, {
@@ -695,7 +700,7 @@ async function handleIntent(
 
   let cachedResult: ResultFrame | null
   try {
-    cachedResult = applyNonceClaimResult(db, prepared, claimIntentNonce(db, prepared))
+    cachedResult = applyNonceClaimResult(prepared.nonce, claimIntentNonce(db, prepared))
   } catch (err) {
     sendJson(senderWs, {
       type: 'error',
@@ -712,8 +717,28 @@ async function handleIntent(
     return
   }
 
-  recordIntentStage(db, prepared, 'dispatch', 'pending', {
+  recordIntentStage(db, prepared, 'received', {
+    transport: 'ws',
+    connectedBeamId: senderBeamId,
+  }, prepared.timestamp)
+  recordIntentStage(db, prepared, 'validated', {
+    transport: 'ws',
+    connectedBeamId: senderBeamId,
+    actingOnBehalf: senderBeamId !== prepared.from,
+    authenticatedViaApiKey: auth.authenticatedViaApiKey,
+  })
+  setIntentLifecycleStatus(db, {
+    nonce: prepared.nonce,
+    status: 'validated',
+  })
+
+  recordIntentStage(db, prepared, 'dispatched', {
     deliveryTarget: 'local-or-federated',
+    transport: 'ws',
+  })
+  setIntentLifecycleStatus(db, {
+    nonce: prepared.nonce,
+    status: 'dispatched',
   })
   broadcastIntentFeed({
     nonce: prepared.nonce,
@@ -723,13 +748,13 @@ async function handleIntent(
     timestamp: prepared.timestamp,
     completedAt: null,
     roundTripLatencyMs: null,
-    status: 'pending',
+    status: 'dispatched',
     errorCode: null,
   })
 
   const localRecipient = getAgent(db, prepared.to)
   if (!localRecipient) {
-    recordIntentStage(db, prepared, 'dispatch', 'pending', {
+    recordIntentStage(db, prepared, 'dispatched', {
       deliveryTarget: 'federation',
     })
     try {
@@ -763,10 +788,6 @@ async function handleIntent(
   const recipientSession = connections.get(prepared.to)
   const recipientWs = recipientSession?.ws
   if (!recipientWs || recipientWs.readyState !== WebSocket.OPEN) {
-    recordIntentStage(db, prepared, 'delivery', 'error', {
-      transport: 'ws',
-      errorCode: 'OFFLINE',
-    })
     finalizeFailedIntent(db, prepared, {
       error: `Agent ${prepared.to} is not currently connected`,
       errorCode: 'OFFLINE',
@@ -786,7 +807,7 @@ async function handleIntent(
   }
 
   const resultPromise = createResultWaiter(db, prepared, 30_000)
-  recordIntentStage(db, prepared, 'delivery', 'pending', {
+  recordIntentStage(db, prepared, 'dispatched', {
     transport: 'ws',
     timeoutMs: 30_000,
     actingBeamId: senderBeamId !== prepared.from ? senderBeamId : undefined,
@@ -799,13 +820,28 @@ async function handleIntent(
       senderPublicKey: senderAgent.public_key,
       actingBeamId: senderBeamId !== prepared.from ? senderBeamId : undefined,
     })
+    recordIntentStage(db, prepared, 'delivered', {
+      transport: 'ws',
+      timeoutMs: 30_000,
+      actingBeamId: senderBeamId !== prepared.from ? senderBeamId : undefined,
+    })
+    setIntentLifecycleStatus(db, {
+      nonce: prepared.nonce,
+      status: 'delivered',
+    })
+    broadcastIntentFeed({
+      nonce: prepared.nonce,
+      from: prepared.from,
+      to: prepared.to,
+      intentType: prepared.intent,
+      timestamp: prepared.timestamp,
+      completedAt: null,
+      roundTripLatencyMs: null,
+      status: 'delivered',
+      errorCode: null,
+    })
   } catch (err) {
     clearPendingResult(prepared.nonce)
-    recordIntentStage(db, prepared, 'delivery', 'error', {
-      transport: 'ws',
-      errorCode: 'DELIVERY_FAILED',
-      message: err instanceof Error ? err.message : 'Failed to deliver to recipient socket',
-    })
     finalizeFailedIntent(db, prepared, {
       error: err instanceof Error ? err.message : 'Failed to relay intent',
       errorCode: 'DELIVERY_FAILED',
@@ -878,9 +914,6 @@ async function relayIntentToFederatedPeer(
   const peerUrl = resolved?.directoryUrl
 
   if (!resolved || !peerUrl || peerUrl === getLocalDirectoryUrl()) {
-    recordIntentStage(db, frame, 'federation.resolve', 'error', {
-      errorCode: 'OFFLINE',
-    })
     finalizeFailedIntent(db, frame, {
       error: `Agent ${frame.to} is not available locally or through federation`,
       errorCode: 'OFFLINE',
@@ -890,17 +923,14 @@ async function relayIntentToFederatedPeer(
     throw new RelayError('OFFLINE', `Agent ${frame.to} is not available locally or through federation`)
   }
 
-  recordIntentStage(db, frame, 'federation.resolve', 'success', {
+  recordIntentStage(db, frame, 'dispatched', {
     peerUrl,
     scope: resolved.scope,
+    transport: 'federation',
   })
 
   const nextHopCount = options.hopCount + 1
   if (nextHopCount > MAX_FEDERATION_HOPS) {
-    recordIntentStage(db, frame, 'federation.relay', 'error', {
-      errorCode: 'BAD_REQUEST',
-      hopCount: nextHopCount,
-    })
     finalizeFailedIntent(db, frame, {
       error: `Federation hop limit exceeded (${MAX_FEDERATION_HOPS})`,
       errorCode: 'BAD_REQUEST',
@@ -914,9 +944,10 @@ async function relayIntentToFederatedPeer(
   }
 
   const startedAt = Date.now()
-  recordIntentStage(db, frame, 'federation.relay', 'pending', {
+  recordIntentStage(db, frame, 'dispatched', {
     peerUrl,
     hopCount: nextHopCount,
+    transport: 'federation',
   })
   try {
     const response = await fetch(`${peerUrl}/federation/relay`, {
@@ -932,12 +963,6 @@ async function relayIntentToFederatedPeer(
 
     const latencyMs = Date.now() - startedAt
     if (!response.ok) {
-      recordIntentStage(db, frame, 'federation.relay', 'error', {
-        peerUrl,
-        hopCount: nextHopCount,
-        errorCode: 'DELIVERY_FAILED',
-        status: response.status,
-      })
       finalizeFailedIntent(db, frame, {
         error: `Federated relay failed with status ${response.status}`,
         errorCode: 'DELIVERY_FAILED',
@@ -954,13 +979,29 @@ async function relayIntentToFederatedPeer(
 
     const result = await response.json() as ResultFrame
     const resolvedLatencyMs = typeof result.latency === 'number' ? result.latency : latencyMs
-    recordIntentStage(db, frame, 'federation.relay', result.success ? 'success' : 'error', {
+    recordIntentStage(db, frame, 'delivered', {
       peerUrl,
       hopCount: nextHopCount,
-      errorCode: result.success ? null : (result.errorCode ?? 'RESULT_ERROR'),
+      transport: 'federation',
+      latencyMs: resolvedLatencyMs,
+    })
+    setIntentLifecycleStatus(db, {
+      nonce: frame.nonce,
+      status: 'delivered',
+    })
+    broadcastIntentFeed({
+      nonce: frame.nonce,
+      from: frame.from,
+      to: frame.to,
+      intentType: frame.intent,
+      timestamp: frame.timestamp,
+      completedAt: null,
+      roundTripLatencyMs: null,
+      status: 'delivered',
+      errorCode: null,
     })
     finalizeIntentWithResult(db, frame, result, resolvedLatencyMs)
-    recordIntentStage(db, frame, 'completed', result.success ? 'success' : 'error', {
+    recordIntentStage(db, frame, result.success ? 'acked' : 'failed', {
       transport: 'federation',
       peerUrl,
       latencyMs: resolvedLatencyMs,
@@ -975,12 +1016,6 @@ async function relayIntentToFederatedPeer(
 
     const latencyMs = Date.now() - startedAt
     const message = err instanceof Error ? err.message : 'Federated relay failed'
-    recordIntentStage(db, frame, 'federation.relay', 'error', {
-      peerUrl,
-      hopCount: nextHopCount,
-      errorCode: 'DELIVERY_FAILED',
-      message,
-    })
     finalizeFailedIntent(db, frame, {
       error: message,
       errorCode: 'DELIVERY_FAILED',
@@ -1160,7 +1195,7 @@ function handleResult(db: Database, frame: ResultFrame): void {
       from: pending.fromBeamId,
       to: pending.toBeamId,
       intent: pending.intentType,
-    }, 'completed', frame.success ? 'success' : 'error', {
+    }, frame.success ? 'acked' : 'failed', {
       transport: 'ws',
       latencyMs,
       errorCode: frame.success ? null : (frame.errorCode ?? 'RESULT_ERROR'),
@@ -1183,11 +1218,12 @@ function handleResult(db: Database, frame: ResultFrame): void {
     return
   }
 
-  if (existing.status === 'success') {
+  const existingStatus = normalizeIntentLifecycleStatus(existing.status) ?? 'received'
+  if (isIntentLifecycleSuccess(existingStatus)) {
     return
   }
 
-  if (existing.status === 'error' && existing.error_code && !RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
+  if (isIntentLifecycleFailure(existingStatus) && existing.error_code && !RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
     return
   }
 
@@ -1200,7 +1236,7 @@ function handleResult(db: Database, frame: ResultFrame): void {
     nonce: frame.nonce,
     fromBeamId: existing.from_beam_id,
     toBeamId: existing.to_beam_id,
-    success: frame.success,
+    status: frame.success ? 'acked' : 'failed',
     latencyMs: resolvedLatencyMs,
     errorCode: frame.success ? undefined : (frame.errorCode ?? existing.error_code ?? 'RESULT_ERROR'),
     resultJson: serializeResultFrame(frame),
@@ -1210,7 +1246,7 @@ function handleResult(db: Database, frame: ResultFrame): void {
     from: existing.from_beam_id,
     to: existing.to_beam_id,
     intent: existing.intent_type,
-  }, 'completed', frame.success ? 'success' : 'error', {
+  }, frame.success ? 'acked' : 'failed', {
     transport: 'ws',
     latencyMs: resolvedLatencyMs,
     errorCode: frame.success ? null : (frame.errorCode ?? existing.error_code ?? 'RESULT_ERROR'),
@@ -1286,7 +1322,7 @@ function broadcastIntentFeed(entry: {
   timestamp: string
   completedAt: string | null
   roundTripLatencyMs: number | null
-  status: string
+  status: IntentLifecycleStatus
   errorCode: string | null
 }): void {
   for (const ws of intentFeedSubscribers) {

--- a/packages/directory/tests/agents.test.ts
+++ b/packages/directory/tests/agents.test.ts
@@ -364,7 +364,7 @@ describe('directory agent enhancements', () => {
         status,
         error_code
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run('n1', 'sender@testorg.beam.directory', 'recipient@testorg.beam.directory', 'chat.send', new Date().toISOString(), new Date().toISOString(), 100, 'success', null)
+    `).run('n1', 'sender@testorg.beam.directory', 'recipient@testorg.beam.directory', 'chat.send', new Date().toISOString(), new Date().toISOString(), 100, 'acked', null)
     db.prepare(`
       INSERT INTO intent_log (
         nonce,
@@ -377,7 +377,7 @@ describe('directory agent enhancements', () => {
         status,
         error_code
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run('n2', 'recipient@testorg.beam.directory', 'sender@testorg.beam.directory', 'chat.reply', new Date().toISOString(), new Date().toISOString(), 300, 'success', null)
+    `).run('n2', 'recipient@testorg.beam.directory', 'sender@testorg.beam.directory', 'chat.reply', new Date().toISOString(), new Date().toISOString(), 300, 'acked', null)
     db.prepare(`
       INSERT INTO intent_log (
         nonce,
@@ -388,7 +388,7 @@ describe('directory agent enhancements', () => {
         status,
         error_code
       ) VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run('n3', 'sender@testorg.beam.directory', 'recipient@testorg.beam.directory', 'chat.pending', new Date().toISOString(), 'pending', null)
+    `).run('n3', 'sender@testorg.beam.directory', 'recipient@testorg.beam.directory', 'chat.pending', new Date().toISOString(), 'received', null)
 
     const response = await app.request('http://localhost/agents/stats')
     expect(response.status).toBe(200)

--- a/packages/message-bus/README.md
+++ b/packages/message-bus/README.md
@@ -12,6 +12,7 @@ Persistent Beam relay for queued delivery, retries, audit history, and delivery 
 
 ## Delivery Model
 
+- The bus uses the canonical Beam lifecycle: `received`, `queued`, `dispatched`, `delivered`, `acked`, `failed`, `dead_letter`.
 - Every bus message gets a persisted `nonce`. If the same `nonce` is submitted again with the same sender, recipient, intent, and payload, the bus returns the existing message instead of redelivering it.
 - Retryable errors from the directory (`OFFLINE`, `TIMEOUT`, `DELIVERY_FAILED`, `DIRECT_HTTP_FAILED`, `IN_PROGRESS`, `RATE_LIMITED`, transport timeouts, and connection errors) are retried.
 - Non-retryable errors (`INVALID_INTENT`, `FORBIDDEN`, `UNAUTHORIZED`, nonce conflicts, and other hard 4xx failures) are dead-lettered immediately.

--- a/packages/message-bus/src/db.ts
+++ b/packages/message-bus/src/db.ts
@@ -4,6 +4,11 @@
 
 import Database from 'better-sqlite3'
 import { randomUUID } from 'node:crypto'
+import {
+  assertBeamMessageLifecycleTransition,
+  normalizeBeamMessageLifecycleStatus,
+  type BeamMessageLifecycleStatus,
+} from './lifecycle.js'
 
 export interface BeamMessage {
   id: string
@@ -12,7 +17,7 @@ export interface BeamMessage {
   recipient: string
   intent: string
   payload: string  // JSON
-  status: 'pending' | 'delivered' | 'acked' | 'failed' | 'dead_letter' | 'expired'
+  status: BeamMessageLifecycleStatus
   priority: number
   retry_count: number
   max_retries: number
@@ -40,7 +45,7 @@ export function initDatabase(dbPath: string): Database.Database {
       recipient TEXT NOT NULL,
       intent TEXT NOT NULL,
       payload TEXT NOT NULL DEFAULT '{}',
-      status TEXT NOT NULL DEFAULT 'pending',
+      status TEXT NOT NULL DEFAULT 'received',
       priority INTEGER DEFAULT 0,
       retry_count INTEGER DEFAULT 0,
       max_retries INTEGER DEFAULT 5,
@@ -65,6 +70,14 @@ export function initDatabase(dbPath: string): Database.Database {
     UPDATE beam_messages
     SET nonce = id
     WHERE nonce IS NULL OR nonce = ''
+  `).run()
+  db.prepare(`
+    UPDATE beam_messages
+    SET status = CASE
+      WHEN status = 'pending' THEN 'queued'
+      WHEN status = 'expired' THEN 'dead_letter'
+      ELSE status
+    END
   `).run()
   db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_beam_nonce ON beam_messages(nonce)')
 
@@ -110,7 +123,7 @@ export function insertMessage(
   db.prepare(`
     INSERT INTO beam_messages (id, nonce, sender, recipient, intent, payload, status, priority,
                                retry_count, max_retries, created_at, trace_id, metadata)
-    VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, 0, ?, ?, ?, ?)
+    VALUES (?, ?, ?, ?, ?, ?, 'received', ?, 0, ?, ?, ?, ?)
   `).run(
     id,
     nonce,
@@ -128,51 +141,117 @@ export function insertMessage(
   return id
 }
 
+function updateMessageLifecycle(
+  db: Database.Database,
+  id: string,
+  nextStatus: BeamMessageLifecycleStatus,
+  fields: {
+    retryCount?: number
+    nextRetryAt?: number | null
+    deliveredAt?: number | null
+    ackedAt?: number | null
+    failedAt?: number | null
+    error?: string | null
+    response?: string | null
+  } = {},
+): void {
+  const message = getMessage(db, id)
+  if (!message) {
+    throw new Error(`Message ${id} not found`)
+  }
+
+  const current = normalizeBeamMessageLifecycleStatus(message.status) ?? 'received'
+  assertBeamMessageLifecycleTransition(current, nextStatus, `message ${id} lifecycle`)
+
+  db.prepare(`
+    UPDATE beam_messages
+    SET status = ?,
+        retry_count = ?,
+        next_retry_at = ?,
+        delivered_at = ?,
+        acked_at = ?,
+        failed_at = ?,
+        error = ?,
+        response = ?
+    WHERE id = ?
+  `).run(
+    nextStatus,
+    fields.retryCount ?? message.retry_count,
+    'nextRetryAt' in fields ? (fields.nextRetryAt ?? null) : message.next_retry_at,
+    'deliveredAt' in fields ? (fields.deliveredAt ?? null) : message.delivered_at,
+    'ackedAt' in fields ? (fields.ackedAt ?? null) : message.acked_at,
+    'failedAt' in fields ? (fields.failedAt ?? null) : message.failed_at,
+    'error' in fields ? (fields.error ?? null) : message.error,
+    'response' in fields ? (fields.response ?? null) : message.response,
+    id,
+  )
+}
+
+export function markDispatched(db: Database.Database, id: string): void {
+  updateMessageLifecycle(db, id, 'dispatched', {
+    nextRetryAt: null,
+  })
+}
+
 export function markDelivered(db: Database.Database, id: string): void {
-  db.prepare('UPDATE beam_messages SET status = ?, delivered_at = ?, next_retry_at = NULL, error = NULL WHERE id = ?')
-    .run('delivered', Date.now() / 1000, id)
+  updateMessageLifecycle(db, id, 'delivered', {
+    deliveredAt: Date.now() / 1000,
+    nextRetryAt: null,
+    error: null,
+  })
 }
 
 export function markFailed(db: Database.Database, id: string, error: string): void {
-  db.prepare('UPDATE beam_messages SET status = ?, failed_at = ?, next_retry_at = NULL, error = ? WHERE id = ?')
-    .run('failed', Date.now() / 1000, error, id)
+  updateMessageLifecycle(db, id, 'failed', {
+    failedAt: Date.now() / 1000,
+    nextRetryAt: null,
+    error,
+  })
 }
 
 export function markDeadLetter(db: Database.Database, id: string, error: string): void {
-  db.prepare('UPDATE beam_messages SET status = ?, failed_at = ?, next_retry_at = NULL, error = ? WHERE id = ?')
-    .run('dead_letter', Date.now() / 1000, error, id)
+  updateMessageLifecycle(db, id, 'dead_letter', {
+    failedAt: Date.now() / 1000,
+    nextRetryAt: null,
+    error,
+  })
 }
 
 export function markAcked(db: Database.Database, id: string, response?: Record<string, unknown>): void {
-  db.prepare('UPDATE beam_messages SET status = ?, acked_at = ?, next_retry_at = NULL, error = NULL, response = ? WHERE id = ?')
-    .run('acked', Date.now() / 1000, response ? JSON.stringify(response) : null, id)
+  updateMessageLifecycle(db, id, 'acked', {
+    ackedAt: Date.now() / 1000,
+    nextRetryAt: null,
+    error: null,
+    response: response ? JSON.stringify(response) : null,
+  })
 }
 
 export function scheduleRetry(db: Database.Database, id: string, retryCount: number, nextRetryAt: number, error: string): void {
-  db.prepare('UPDATE beam_messages SET status = ?, retry_count = ?, next_retry_at = ?, failed_at = NULL, error = ? WHERE id = ?')
-    .run('pending', retryCount, nextRetryAt, error, id)
+  updateMessageLifecycle(db, id, 'queued', {
+    retryCount,
+    nextRetryAt,
+    failedAt: null,
+    error,
+  })
 }
 
 export function requeueMessage(db: Database.Database, id: string): void {
-  db.prepare(`
-    UPDATE beam_messages
-    SET status = 'pending',
-        retry_count = 0,
-        next_retry_at = NULL,
-        delivered_at = NULL,
-        acked_at = NULL,
-        failed_at = NULL,
-        error = NULL,
-        response = NULL
-    WHERE id = ?
-  `).run(id)
+  updateMessageLifecycle(db, id, 'queued', {
+    retryCount: 0,
+    nextRetryAt: null,
+    deliveredAt: null,
+    ackedAt: null,
+    failedAt: null,
+    error: null,
+    response: null,
+  })
 }
 
 export function getPendingRetries(db: Database.Database, limit = 10): BeamMessage[] {
   const now = Date.now() / 1000
   return db.prepare(`
     SELECT * FROM beam_messages
-    WHERE status = 'pending' AND next_retry_at IS NOT NULL AND next_retry_at <= ?
+    WHERE status = 'queued' AND next_retry_at IS NOT NULL AND next_retry_at <= ?
     ORDER BY priority DESC, created_at ASC
     LIMIT ?
   `).all(now, limit) as BeamMessage[]
@@ -273,7 +352,9 @@ export function listDeadLetters(
 
 export interface BusStats {
   total: number
-  pending: number
+  queued: number
+  received: number
+  dispatched: number
   delivered: number
   acked: number
   failed: number
@@ -308,7 +389,9 @@ export function getStats(db: Database.Database): BusStats {
 
   return {
     total,
-    pending: statusCounts['pending'] ?? 0,
+    queued: statusCounts['queued'] ?? 0,
+    received: statusCounts['received'] ?? 0,
+    dispatched: statusCounts['dispatched'] ?? 0,
     delivered: statusCounts['delivered'] ?? 0,
     acked: statusCounts['acked'] ?? 0,
     failed: statusCounts['failed'] ?? 0,

--- a/packages/message-bus/src/lifecycle.ts
+++ b/packages/message-bus/src/lifecycle.ts
@@ -1,0 +1,62 @@
+export const BEAM_MESSAGE_LIFECYCLE = [
+  'received',
+  'validated',
+  'queued',
+  'dispatched',
+  'delivered',
+  'acked',
+  'failed',
+  'dead_letter',
+] as const
+
+export type BeamMessageLifecycleStatus = (typeof BEAM_MESSAGE_LIFECYCLE)[number]
+
+const START = '__start__'
+
+const ALLOWED_TRANSITIONS: Record<BeamMessageLifecycleStatus | typeof START, ReadonlySet<BeamMessageLifecycleStatus>> = {
+  [START]: new Set(['received']),
+  received: new Set(['received', 'validated', 'queued', 'failed', 'dead_letter', 'dispatched']),
+  validated: new Set(['validated', 'queued', 'dispatched', 'failed', 'dead_letter']),
+  queued: new Set(['queued', 'dispatched', 'failed', 'dead_letter']),
+  dispatched: new Set(['dispatched', 'queued', 'delivered', 'failed', 'dead_letter']),
+  delivered: new Set(['delivered', 'acked', 'failed', 'queued', 'dead_letter']),
+  acked: new Set(['acked']),
+  failed: new Set(['failed', 'queued']),
+  dead_letter: new Set(['dead_letter', 'queued']),
+}
+
+export function isBeamMessageLifecycleStatus(value: string | null | undefined): value is BeamMessageLifecycleStatus {
+  return typeof value === 'string' && BEAM_MESSAGE_LIFECYCLE.includes(value as BeamMessageLifecycleStatus)
+}
+
+export function normalizeBeamMessageLifecycleStatus(value: string | null | undefined): BeamMessageLifecycleStatus | null {
+  if (!value) {
+    return null
+  }
+
+  if (isBeamMessageLifecycleStatus(value)) {
+    return value
+  }
+
+  switch (value) {
+    case 'pending':
+      return 'queued'
+    case 'expired':
+      return 'dead_letter'
+    default:
+      return null
+  }
+}
+
+export function assertBeamMessageLifecycleTransition(
+  previous: BeamMessageLifecycleStatus | null,
+  next: BeamMessageLifecycleStatus,
+  context = 'beam message lifecycle',
+): void {
+  const allowed = ALLOWED_TRANSITIONS[previous ?? START]
+  if (allowed.has(next)) {
+    return
+  }
+
+  throw new Error(`Invalid ${context} transition from ${previous ?? 'start'} to ${next}`)
+}

--- a/packages/message-bus/src/router.ts
+++ b/packages/message-bus/src/router.ts
@@ -7,6 +7,7 @@ import { Hono, type Context } from 'hono'
 import type Database from 'better-sqlite3'
 import {
   insertMessage,
+  markDispatched,
   markDelivered,
   markAcked,
   markDeadLetter,
@@ -153,6 +154,7 @@ export function createBusRouter(options: RouterOptions): Hono {
     const now = Date.now() / 1000
 
     // Attempt immediate delivery
+    markDispatched(db, msgId)
     const result = await deliverToDirectory(directoryUrl, msgId, messageNonce, sender, recipient, intent, payload)
 
     if (result.success) {
@@ -181,7 +183,7 @@ export function createBusRouter(options: RouterOptions): Hono {
     return c.json({
       message_id: msgId,
       nonce: messageNonce,
-      status: 'pending',
+      status: 'queued',
       created_at: now,
       retry_count: retryCount,
       next_retry_at: nextRetry,
@@ -239,6 +241,7 @@ export function createBusRouter(options: RouterOptions): Hono {
     }
 
     requeueMessage(db, messageId)
+    markDispatched(db, messageId)
     const payload = JSON.parse(message.payload) as Record<string, unknown>
     const result = await deliverToDirectory(
       directoryUrl,
@@ -279,7 +282,7 @@ export function createBusRouter(options: RouterOptions): Hono {
     return c.json({
       message_id: messageId,
       nonce: message.nonce,
-      status: 'pending',
+      status: 'queued',
       requeued: true,
       retry_count: retryCount,
       next_retry_at: nextRetry,
@@ -309,10 +312,17 @@ export function createBusRouter(options: RouterOptions): Hono {
     const msg = getMessage(db, messageId)
     if (!msg) return c.json({ error: `Message ${messageId} not found`, errorCode: 'MESSAGE_NOT_FOUND' }, 404)
 
-    if (status === 'acked') {
-      markAcked(db, messageId, response)
-    } else {
-      markFailed(db, messageId, response ? JSON.stringify(response) : 'Manually failed')
+    try {
+      if (status === 'acked') {
+        markAcked(db, messageId, response)
+      } else {
+        markFailed(db, messageId, response ? JSON.stringify(response) : 'Manually failed')
+      }
+    } catch (err) {
+      return c.json({
+        error: err instanceof Error ? err.message : 'Invalid lifecycle transition',
+        errorCode: 'INVALID_STATE',
+      }, 409)
     }
 
     return c.json({ message_id: messageId, status, updated_at: Date.now() / 1000 })

--- a/packages/message-bus/src/worker.ts
+++ b/packages/message-bus/src/worker.ts
@@ -3,7 +3,7 @@
  */
 
 import type Database from 'better-sqlite3'
-import { getPendingRetries, markDeadLetter, markDelivered, scheduleRetry } from './db.js'
+import { getPendingRetries, markDeadLetter, markDelivered, markDispatched, scheduleRetry } from './db.js'
 import { deliverToDirectory } from './delivery.js'
 import { computeRetryAt } from './retry.js'
 
@@ -24,6 +24,7 @@ export function startRetryWorker(options: WorkerOptions): NodeJS.Timeout {
       if (pending.length === 0) return
 
       for (const msg of pending) {
+        markDispatched(db, msg.id)
         const payload = JSON.parse(msg.payload) as Record<string, unknown>
         const result = await deliverToDirectory(
           directoryUrl,

--- a/packages/message-bus/tests/bus.test.ts
+++ b/packages/message-bus/tests/bus.test.ts
@@ -5,7 +5,7 @@ vi.mock('../src/delivery.js', () => ({
   deliverToDirectory: vi.fn(async () => ({ success: true, error: '', retryable: false })),
 }))
 
-import { cleanTestMessages, getMessage, initDatabase, insertMessage, markAcked, markDeadLetter, markDelivered, markFailed, scheduleRetry } from '../src/db.js'
+import { cleanTestMessages, getMessage, initDatabase, insertMessage, markAcked, markDeadLetter, markDelivered, markDispatched, markFailed, scheduleRetry } from '../src/db.js'
 import { deliverToDirectory } from '../src/delivery.js'
 import { createBusRouter } from '../src/router.js'
 import { startRetryWorker, stopRetryWorker } from '../src/worker.js'
@@ -184,6 +184,7 @@ describe('message bus', () => {
       intent: 'chat',
       payload: { text: 'hi' },
     })
+    markDispatched(db, id)
     markDelivered(db, id)
 
     const response = await app.request('http://localhost/v1/beam/poll?agent=beta@beam.directory')
@@ -209,6 +210,8 @@ describe('message bus', () => {
       intent: 'chat',
       payload: { text: 'hello' },
     })
+    markDispatched(db, id)
+    markDelivered(db, id)
 
     const response = await app.request('http://localhost/v1/beam/ack', {
       method: 'POST',
@@ -259,6 +262,27 @@ describe('message bus', () => {
 
     expect(response.status).toBe(400)
     expect(await response.json()).toEqual({ error: 'status must be "acked" or "failed"', errorCode: 'INVALID_STATUS' })
+  })
+
+  it('returns 409 when /ack receives a message in the wrong lifecycle state', async () => {
+    const id = insertMessage(db, {
+      sender: 'alpha@beam.directory',
+      recipient: 'beta@beam.directory',
+      intent: 'chat',
+      payload: { text: 'hello' },
+    })
+
+    const response = await app.request('http://localhost/v1/beam/ack', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message_id: id, status: 'acked' }),
+    })
+
+    expect(response.status).toBe(409)
+    expect(await response.json()).toEqual({
+      error: `Invalid message ${id} lifecycle transition from received to acked`,
+      errorCode: 'INVALID_STATE',
+    })
   })
 
   it('dead-letters non-retryable send failures immediately', async () => {
@@ -366,19 +390,25 @@ describe('message bus', () => {
       payload: { seq: 4 },
     })
 
+    markDispatched(db, deliveredId)
     markDelivered(db, deliveredId)
+    markDispatched(db, ackedId)
     markDelivered(db, ackedId)
     markAcked(db, ackedId, { ok: true })
+    markDispatched(db, failedId)
     markFailed(db, failedId, 'boom')
+    scheduleRetry(db, pendingId, 1, (Date.now() / 1000) + 60, 'offline')
 
-    expect(getMessage(db, pendingId)?.status).toBe('pending')
+    expect(getMessage(db, pendingId)?.status).toBe('queued')
 
     const response = await app.request('http://localhost/v1/beam/stats')
     expect(response.status).toBe(200)
 
     const body = await response.json() as Record<string, unknown>
     expect(body['total']).toBe(4)
-    expect(body['pending']).toBe(1)
+    expect(body['queued']).toBe(1)
+    expect(body['received']).toBe(0)
+    expect(body['dispatched']).toBe(0)
     expect(body['delivered']).toBe(1)
     expect(body['acked']).toBe(1)
     expect(body['failed']).toBe(1)
@@ -438,10 +468,10 @@ describe('message bus', () => {
     })
 
     expect(cleanTestMessages(db)).toBe(2)
-    expect(getMessage(db, keptId)?.status).toBe('pending')
+    expect(getMessage(db, keptId)?.status).toBe('received')
   })
 
-  it('retries pending messages with a stable nonce and dead-letters after max retries', async () => {
+  it('retries queued messages with a stable nonce and dead-letters after max retries', async () => {
     vi.useFakeTimers()
     vi.mocked(deliverToDirectory).mockResolvedValueOnce({
       success: false,


### PR DESCRIPTION
## Summary
- define canonical lifecycle states and transition guards for directory traces, intent logs, and message-bus messages
- align observability APIs and dashboard UI on lifecycle-first statuses, keeping success/error metrics as derived summaries
- document the 0.6.0 lifecycle model and add transition tests plus cross-stack verification

## Verification
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build

Closes #8.