### PR TITLE
Add restart recovery for directory and message bus

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         { text: 'Verification', link: '/guide/verification' },
         { text: 'Federation', link: '/guide/federation' },
         { text: 'Intent Lifecycle', link: '/guide/intent-lifecycle' },
+        { text: 'Restart Recovery', link: '/guide/restart-recovery' },
         { text: 'Consumer IDs', link: '/guide/consumer-ids' },
         { text: 'Core Concepts', link: '/guide/concepts' },
         { text: 'Self-Hosting', link: '/guide/self-hosting' }

--- a/docs/guide/restart-recovery.md
+++ b/docs/guide/restart-recovery.md
@@ -1,0 +1,43 @@
+# Restart Recovery
+
+Beam persists intent and message state so operators can restart the directory or message bus without silently losing active work.
+
+## Directory recovery
+
+On boot, the directory inspects every non-terminal intent in `intent_log`.
+
+- `received`, `validated`, `queued`, and `dispatched` intents are finalized as `failed` with a retryable recovery error. These requests were interrupted before Beam could prove a delivery outcome.
+- `delivered` intents are treated differently. Beam keeps them open if the original result timeout has not expired yet, because the recipient may still reconnect and return a late result for the same `nonce`.
+- Recovered `delivered` intents are swept in the background. If the original timeout window expires and no late result arrives, Beam finalizes them as `failed` with `TIMEOUT`.
+- If a late result does arrive after restart, Beam reconciles the persisted record instead of creating a second delivery. The original `nonce` stays authoritative.
+
+Operator expectation:
+
+- a restart may turn interrupted dispatches into retryable failures
+- already delivered work can still complete successfully after the process comes back
+- replaying the same `nonce` after recovery never creates a second trace for a cached success
+
+## Message bus recovery
+
+The message bus replays persisted work on startup.
+
+- `received` and `dispatched` bus messages are requeued immediately on boot
+- the original `nonce` is preserved
+- queued retry windows remain intact because `next_retry_at` is stored in SQLite
+- `delivered`, `acked`, `failed`, and `dead_letter` messages are left unchanged
+
+This means a crash during an outbound delivery attempt does not strand the message in an in-memory state that the retry worker can no longer see.
+
+## Operational notes
+
+- Keep the SQLite database on durable storage. Recovery depends on persisted `intent_log`, `intent_trace_events`, and `beam_messages` rows surviving the restart.
+- `RELAY_TIMEOUT_MS` controls the default timeout used when Beam has to recover an orphaned `delivered` intent and no explicit timeout was stored in the trace details.
+- `RELAY_RECOVERY_SWEEP_INTERVAL_MS` controls how often the directory checks recovered `delivered` intents for expiry after restart.
+
+## Recommended verification
+
+For release or deployment checks, verify at least these scenarios:
+
+1. restart the directory after a recipient has received an intent but before it has returned a result
+2. restart the message bus while a message is in `dispatched`
+3. confirm that resending the same `nonce` returns the cached result or cached failure instead of creating a duplicate delivery

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -1567,6 +1567,39 @@ export function finalizeIntentLog(
   const current = normalizeIntentLifecycleStatus(existing?.status) ?? 'received'
   assertIntentLifecycleTransition(current, input.status, `intent ${input.nonce}`)
 
+  writeIntentLogFinalState(db, input, completedAt)
+}
+
+export function reconcileIntentLog(
+  db: DB,
+  input: {
+    nonce: string
+    fromBeamId: string
+    toBeamId: string
+    status: IntentLifecycleStatus
+    latencyMs: number | null
+    errorCode?: string
+    resultJson?: string | null
+  },
+): void {
+  const completedAt = nowIso()
+  writeIntentLogFinalState(db, input, completedAt)
+}
+
+function writeIntentLogFinalState(
+  db: DB,
+  input: {
+    nonce: string
+    fromBeamId: string
+    toBeamId: string
+    status: IntentLifecycleStatus
+    latencyMs: number | null
+    errorCode?: string
+    resultJson?: string | null
+  },
+  completedAt: string,
+): void {
+
   db.prepare(`
     UPDATE intent_log
     SET completed_at = ?,
@@ -1598,6 +1631,15 @@ export function listRecentIntentLogs(db: DB, limit = 50): IntentLogRow[] {
     ORDER BY requested_at DESC
     LIMIT ?
   `).all(safeLimit) as IntentLogRow[]
+}
+
+export function listInFlightIntentLogs(db: DB): IntentLogRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE status IN ('received', 'validated', 'queued', 'dispatched', 'delivered')
+    ORDER BY requested_at ASC, id ASC
+  `).all() as IntentLogRow[]
 }
 
 export function getIntentLogByNonce(db: DB, nonce: string): IntentLogRow | null {

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -23,7 +23,16 @@ import { reportsRouter } from './routes/reports.js'
 import { shieldRouter } from './routes/shield.js'
 import { verificationRouter } from './routes/verify.js'
 import { createTrustGateMiddleware } from './middleware/trust-gate.js'
-import { createWebSocketServer, getConnectedCount, getConnectedBeamIds, relayIntentFromHttp, RelayError } from './websocket.js'
+import {
+  createWebSocketServer,
+  getConnectedCount,
+  getConnectedBeamIds,
+  recoverInterruptedIntentsOnStartup,
+  relayIntentFromHttp,
+  RelayError,
+  startRecoveredIntentTimeoutSweep,
+  stopRecoveredIntentTimeoutSweep,
+} from './websocket.js'
 import { createAcl, deleteAcl, listAclsForBeam, seedAclsFromCatalog } from './acl.js'
 import { getAdminSessionFromRequest, requireAdminRole } from './admin-auth.js'
 import { assignDirectoryRole, deleteDirectoryRole, listDirectoryRoles, listAuditLog, listRecentIntentLogs, listTrustScores, logAuditEvent, getDIDDocument, getAgent, upsertDIDDocument } from './db.js'
@@ -1229,14 +1238,22 @@ export function createApp(db: Database): Hono {
 }
 
 export function startServer(db: Database, port = 3100): HttpServer {
+  const recovery = recoverInterruptedIntentsOnStartup(db)
   const app = createApp(db)
   const wss = createWebSocketServer(db)
+  const recoverySweep = startRecoveredIntentTimeoutSweep(db)
 
   const server = serve(
     { fetch: app.fetch, port },
     (info) => {
       console.log(`Beam Directory Server running on http://localhost:${info.port}`)
       console.log(`WebSocket endpoint: ws://localhost:${info.port}/ws`)
+      if (recovery.failedInterrupted > 0 || recovery.resumedAwaitingResult > 0 || recovery.timedOutAwaitingResult > 0) {
+        console.log(
+          `[beam-directory] Recovery summary: failed=${recovery.failedInterrupted}, ` +
+          `resumed=${recovery.resumedAwaitingResult}, timed_out=${recovery.timedOutAwaitingResult}`,
+        )
+      }
     }
   ) as unknown as HttpServer
 
@@ -1248,6 +1265,10 @@ export function startServer(db: Database, port = 3100): HttpServer {
     } else {
       socket.destroy()
     }
+  })
+
+  server.on('close', () => {
+    stopRecoveredIntentTimeoutSweep(recoverySweep)
   })
 
   return server

--- a/packages/directory/src/websocket.test.ts
+++ b/packages/directory/src/websocket.test.ts
@@ -1,16 +1,30 @@
-import test from 'node:test'
+import test, { afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { once } from 'node:events'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { generateKeyPairSync, randomUUID, sign } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { WebSocket } from 'ws'
 import { createAcl } from './acl.js'
-import { createDatabase, getIntentLogByNonce, registerAgent } from './db.js'
-import { createWebSocketServer, relayIntentFromHttp, RelayError } from './websocket.js'
+import { createDatabase, getIntentLogByNonce, listIntentTraceEvents, registerAgent } from './db.js'
+import {
+  createWebSocketServer,
+  expireRecoveredIntentTimeouts,
+  recoverInterruptedIntentsOnStartup,
+  relayIntentFromHttp,
+  RelayError,
+  resetRelayRuntimeState,
+} from './websocket.js'
 import type { IntentFrame } from './types.js'
 
 const TEST_INTENT = 'agent.ping'
+
+afterEach(() => {
+  resetRelayRuntimeState({ closeConnections: true })
+})
 
 type FixtureAgent = {
   beamId: string
@@ -99,6 +113,7 @@ async function withFetchStub<T>(
 async function createWsHarness(db: ReturnType<typeof createDatabase>) {
   const wss = createWebSocketServer(db)
   const server = createServer()
+  let closed = false
 
   server.on('upgrade', (req, socket, head) => {
     wss.handleUpgrade(req, socket, head, (ws) => {
@@ -110,6 +125,10 @@ async function createWsHarness(db: ReturnType<typeof createDatabase>) {
   const { port } = server.address() as AddressInfo
 
   async function close() {
+    if (closed) {
+      return
+    }
+    closed = true
     await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
     for (const client of wss.clients) {
       client.terminate()
@@ -159,6 +178,14 @@ async function closeSocket(ws: WebSocket): Promise<void> {
 
   ws.terminate()
   await once(ws, 'close')
+}
+
+function createTempDbPath(): { root: string; dbPath: string } {
+  const root = mkdtempSync(join(tmpdir(), 'beam-directory-recovery-'))
+  return {
+    root,
+    dbPath: join(root, 'beam-directory.sqlite'),
+  }
 }
 
 test('relayIntentFromHttp caches direct HTTP results by nonce and suppresses duplicate deliveries', async () => {
@@ -311,5 +338,155 @@ test('relayIntentFromHttp records a retryable timeout for unanswered websocket d
   } finally {
     await harness.close()
     db.close()
+  }
+})
+
+test('directory restart resumes delivered intents and serves a cached late result without redelivery', async () => {
+  const { root, dbPath } = createTempDbPath()
+  let db = createDatabase(dbPath)
+  const sender = createFixtureAgent('sender@local.beam.directory')
+  const receiver = createFixtureAgent('receiver@local.beam.directory')
+  let harness = await createWsHarness(db)
+
+  try {
+    registerFixtureAgent(db, sender, { displayName: 'Sender' })
+    registerFixtureAgent(db, receiver, { displayName: 'Receiver' })
+    createAcl(db, {
+      targetBeamId: receiver.beamId,
+      intentType: TEST_INTENT,
+      allowedFrom: sender.beamId,
+    })
+
+    const receiverWs = await connectClient(harness.url, receiver.beamId)
+    const senderWs = await connectClient(harness.url, sender.beamId)
+    const nonce = randomUUID()
+
+    senderWs.send(JSON.stringify({
+      type: 'intent',
+      frame: createSignedFrame(sender, receiver.beamId, nonce),
+    }))
+
+    const firstDelivery = await waitForJson(receiverWs)
+    assert.equal(firstDelivery.type, 'intent')
+    assert.equal((firstDelivery.frame as { nonce: string }).nonce, nonce)
+    assert.equal(getIntentLogByNonce(db, nonce)?.status, 'delivered')
+
+    await closeSocket(senderWs)
+    await closeSocket(receiverWs)
+    await harness.close()
+    db.close()
+    resetRelayRuntimeState({ closeConnections: true, rejectPending: true })
+
+    db = createDatabase(dbPath)
+    const recovery = recoverInterruptedIntentsOnStartup(db)
+    assert.deepEqual(recovery, {
+      failedInterrupted: 0,
+      resumedAwaitingResult: 1,
+      timedOutAwaitingResult: 0,
+    })
+
+    harness = await createWsHarness(db)
+    const restartedReceiverWs = await connectClient(harness.url, receiver.beamId)
+    restartedReceiverWs.send(JSON.stringify({
+      type: 'result',
+      frame: {
+        v: '1',
+        success: true,
+        nonce,
+        timestamp: new Date().toISOString(),
+        payload: { ok: true },
+      },
+    }))
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    assert.equal(getIntentLogByNonce(db, nonce)?.status, 'acked')
+
+    const restartedSenderWs = await connectClient(harness.url, sender.beamId)
+    const cachedResultPromise = waitForJson(restartedSenderWs)
+    restartedSenderWs.send(JSON.stringify({
+      type: 'intent',
+      frame: createSignedFrame(sender, receiver.beamId, nonce, new Date(Date.now() + 1_000).toISOString()),
+    }))
+
+    const cachedResult = await cachedResultPromise
+    assert.equal(cachedResult.type, 'result')
+    assert.equal((cachedResult.frame as { nonce: string }).nonce, nonce)
+    assert.deepEqual((cachedResult.frame as { payload: Record<string, unknown> }).payload, { ok: true })
+
+    const unexpectedSecondDelivery = await waitForMessageOrTimeout(restartedReceiverWs, 120)
+    assert.equal(unexpectedSecondDelivery, null)
+
+    const trace = listIntentTraceEvents(db, nonce)
+    assert.equal(trace.filter((entry) => entry.stage === 'delivered').length, 1)
+    assert.equal(trace.filter((entry) => entry.stage === 'acked').length, 1)
+
+    await closeSocket(restartedSenderWs)
+    await closeSocket(restartedReceiverWs)
+  } finally {
+    await harness.close()
+    db.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('directory restart expires recovered delivered intents after the original timeout window', async () => {
+  const { root, dbPath } = createTempDbPath()
+  let db = createDatabase(dbPath)
+  const sender = createFixtureAgent('sender@local.beam.directory')
+  const receiver = createFixtureAgent('receiver@local.beam.directory')
+  let harness = await createWsHarness(db)
+
+  try {
+    registerFixtureAgent(db, sender, { displayName: 'Sender' })
+    registerFixtureAgent(db, receiver, { displayName: 'Receiver' })
+    createAcl(db, {
+      targetBeamId: receiver.beamId,
+      intentType: TEST_INTENT,
+      allowedFrom: sender.beamId,
+    })
+
+    const receiverWs = await connectClient(harness.url, receiver.beamId)
+    const nonce = randomUUID()
+    const frame = createSignedFrame(sender, receiver.beamId, nonce)
+    const deliveryPromise = waitForJson(receiverWs)
+
+    const relayPromise = relayIntentFromHttp(db, frame, 30_000).catch(() => null)
+    const deliveredIntent = await deliveryPromise
+    assert.equal(deliveredIntent.type, 'intent')
+    assert.equal((deliveredIntent.frame as { nonce: string }).nonce, nonce)
+
+    await closeSocket(receiverWs)
+    await harness.close()
+    db.close()
+    resetRelayRuntimeState({ closeConnections: true, rejectPending: true })
+    await relayPromise
+
+    db = createDatabase(dbPath)
+    const requestedAtMs = new Date(frame.timestamp).getTime()
+    const recovered = recoverInterruptedIntentsOnStartup(db, {
+      nowMs: requestedAtMs + 5_000,
+      defaultTimeoutMs: 30_000,
+    })
+    assert.deepEqual(recovered, {
+      failedInterrupted: 0,
+      resumedAwaitingResult: 1,
+      timedOutAwaitingResult: 0,
+    })
+
+    const expired = expireRecoveredIntentTimeouts(db, {
+      nowMs: requestedAtMs + 35_000,
+      defaultTimeoutMs: 30_000,
+    })
+    assert.equal(expired, 1)
+
+    const log = getIntentLogByNonce(db, nonce)
+    assert.ok(log)
+    assert.equal(log?.status, 'failed')
+    assert.equal(log?.error_code, 'TIMEOUT')
+    assert.match(log?.result_json ?? '', /"errorCode":"TIMEOUT"/)
+  } finally {
+    await harness.close()
+    db.close()
+    rmSync(root, { recursive: true, force: true })
   }
 })

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -2,8 +2,19 @@ import { createPublicKey, verify } from 'node:crypto'
 import { WebSocketServer, WebSocket } from 'ws'
 import type { IncomingMessage } from 'node:http'
 import type { Database } from 'better-sqlite3'
-import type { IntentFrame, ResultFrame } from './types.js'
-import { finalizeIntentLog, getAgent, getIntentLogByNonce, hasActiveDelegation, logIntentStart, setIntentLifecycleStatus, updateLastSeen } from './db.js'
+import type { IntentFrame, IntentLogRow, IntentTraceEventRow, ResultFrame } from './types.js'
+import {
+  finalizeIntentLog,
+  getAgent,
+  getIntentLogByNonce,
+  getLatestIntentTraceEvent,
+  hasActiveDelegation,
+  listInFlightIntentLogs,
+  logIntentStart,
+  reconcileIntentLog,
+  setIntentLifecycleStatus,
+  updateLastSeen,
+} from './db.js'
 import { isIntentAllowed } from './acl.js'
 import {
   getCachedFederatedPublicKey,
@@ -27,6 +38,8 @@ import {
 
 const REPLAY_WINDOW_MS = 5 * 60 * 1000
 const STALE_PENDING_RETRY_WINDOW_MS = 2 * 60 * 1000
+const DEFAULT_RECOVERY_TIMEOUT_MS = Number(process.env.RELAY_TIMEOUT_MS || 30_000)
+const RECOVERY_SWEEP_INTERVAL_MS = Number(process.env.RELAY_RECOVERY_SWEEP_INTERVAL_MS || 5_000)
 const RETRYABLE_INTENT_ERRORS = new Set(['OFFLINE', 'TIMEOUT', 'DELIVERY_FAILED', 'DIRECT_HTTP_FAILED'])
 
 type ConnectionSession = {
@@ -97,6 +110,53 @@ function buildResultFrame(
     ...(options.errorCode !== undefined ? { errorCode: options.errorCode } : {}),
     ...(typeof options.latency === 'number' ? { latency: options.latency } : {}),
   }
+}
+
+function parseTraceDetails(trace: IntentTraceEventRow | null): Record<string, unknown> | null {
+  if (!trace?.details) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(trace.details) as Record<string, unknown>
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function resolveRecoveryTimeoutMs(
+  trace: IntentTraceEventRow | null,
+  fallbackMs = DEFAULT_RECOVERY_TIMEOUT_MS,
+): number {
+  const traceDetails = parseTraceDetails(trace)
+  const timeoutCandidate = traceDetails?.['timeoutMs']
+  if (typeof timeoutCandidate === 'number' && Number.isFinite(timeoutCandidate) && timeoutCandidate > 0) {
+    return timeoutCandidate
+  }
+
+  return fallbackMs
+}
+
+function getRequestedAtMs(row: IntentLogRow, nowMs = Date.now()): number {
+  const parsed = new Date(row.requested_at).getTime()
+  return Number.isNaN(parsed) ? nowMs : parsed
+}
+
+function buildIntentFrameFromLog(row: IntentLogRow): IntentFrame {
+  return {
+    v: '1',
+    from: row.from_beam_id,
+    to: row.to_beam_id,
+    intent: row.intent_type,
+    payload: {},
+    nonce: row.nonce,
+    timestamp: row.requested_at,
+  }
+}
+
+function isRetryableIntentFailure(errorCode: string | null | undefined): boolean {
+  return Boolean(errorCode && RETRYABLE_INTENT_ERRORS.has(errorCode))
 }
 
 function claimIntentNonce(db: Database, frame: IntentFrame): NonceClaimResult {
@@ -275,6 +335,144 @@ function normalizeDirectHttpResult(
     payload: {},
     latency: latencyMs,
   })
+}
+
+export interface DirectoryRecoverySummary {
+  failedInterrupted: number
+  resumedAwaitingResult: number
+  timedOutAwaitingResult: number
+}
+
+export function recoverInterruptedIntentsOnStartup(
+  db: Database,
+  options: {
+    nowMs?: number
+    defaultTimeoutMs?: number
+  } = {},
+): DirectoryRecoverySummary {
+  const nowMs = options.nowMs ?? Date.now()
+  const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_RECOVERY_TIMEOUT_MS
+  const summary: DirectoryRecoverySummary = {
+    failedInterrupted: 0,
+    resumedAwaitingResult: 0,
+    timedOutAwaitingResult: 0,
+  }
+
+  for (const row of listInFlightIntentLogs(db)) {
+    const status = normalizeIntentLifecycleStatus(row.status) ?? 'received'
+    const frame = buildIntentFrameFromLog(row)
+    const requestedAtMs = getRequestedAtMs(row, nowMs)
+    const latencyMs = Math.max(0, nowMs - requestedAtMs)
+
+    if (status === 'delivered') {
+      const timeoutMs = resolveRecoveryTimeoutMs(getLatestIntentTraceEvent(db, row.nonce), defaultTimeoutMs)
+      if (latencyMs < timeoutMs) {
+        summary.resumedAwaitingResult += 1
+        continue
+      }
+
+      finalizeFailedIntent(db, frame, {
+        error: `Intent timed out waiting for result after restart (${timeoutMs}ms)`,
+        errorCode: 'TIMEOUT',
+        latencyMs,
+        transport: 'recovery',
+        details: {
+          previousStatus: status,
+          recoveryAction: 'timeout_after_restart',
+          recoveredOnBoot: true,
+          timeoutMs,
+        },
+      })
+      summary.timedOutAwaitingResult += 1
+      continue
+    }
+
+    finalizeFailedIntent(db, frame, {
+      error: `Intent recovery failed after restart while it was ${status}`,
+      errorCode: 'DELIVERY_FAILED',
+      latencyMs,
+      transport: 'recovery',
+      details: {
+        previousStatus: status,
+        recoveryAction: 'fail_interrupted_intent',
+        recoveredOnBoot: true,
+      },
+    })
+    summary.failedInterrupted += 1
+  }
+
+  return summary
+}
+
+export function expireRecoveredIntentTimeouts(
+  db: Database,
+  options: {
+    nowMs?: number
+    defaultTimeoutMs?: number
+  } = {},
+): number {
+  const nowMs = options.nowMs ?? Date.now()
+  const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_RECOVERY_TIMEOUT_MS
+  let expiredCount = 0
+
+  for (const row of listInFlightIntentLogs(db)) {
+    const status = normalizeIntentLifecycleStatus(row.status) ?? 'received'
+    if (status !== 'delivered' || pendingResults.has(row.nonce)) {
+      continue
+    }
+
+    const timeoutMs = resolveRecoveryTimeoutMs(getLatestIntentTraceEvent(db, row.nonce), defaultTimeoutMs)
+    const requestedAtMs = getRequestedAtMs(row, nowMs)
+    const latencyMs = Math.max(0, nowMs - requestedAtMs)
+    if (latencyMs < timeoutMs) {
+      continue
+    }
+
+    finalizeFailedIntent(db, buildIntentFrameFromLog(row), {
+      error: `Intent timed out waiting for result after restart (${timeoutMs}ms)`,
+      errorCode: 'TIMEOUT',
+      latencyMs,
+      transport: 'recovery',
+      details: {
+        previousStatus: status,
+        recoveryAction: 'timeout_without_waiter',
+        recoveredOnBoot: true,
+        timeoutMs,
+      },
+    })
+    expiredCount += 1
+  }
+
+  return expiredCount
+}
+
+export function startRecoveredIntentTimeoutSweep(
+  db: Database,
+  options: {
+    intervalMs?: number
+    defaultTimeoutMs?: number
+  } = {},
+): NodeJS.Timeout {
+  const intervalMs = options.intervalMs ?? RECOVERY_SWEEP_INTERVAL_MS
+  const defaultTimeoutMs = options.defaultTimeoutMs ?? DEFAULT_RECOVERY_TIMEOUT_MS
+
+  const timer = setInterval(() => {
+    try {
+      const expired = expireRecoveredIntentTimeouts(db, { defaultTimeoutMs })
+      if (expired > 0) {
+        console.warn(`[beam-directory] Timed out ${expired} recovered intent(s) waiting for late results`)
+      }
+    } catch (err) {
+      console.error('[beam-directory] Intent recovery sweep failed:', err)
+    }
+  }, intervalMs)
+  timer.unref()
+
+  return timer
+}
+
+export function stopRecoveredIntentTimeoutSweep(timer: NodeJS.Timeout): void {
+  clearInterval(timer)
 }
 
 async function attemptDirectHttpDelivery(
@@ -1223,7 +1421,8 @@ function handleResult(db: Database, frame: ResultFrame): void {
     return
   }
 
-  if (isIntentLifecycleFailure(existingStatus) && existing.error_code && !RETRYABLE_INTENT_ERRORS.has(existing.error_code)) {
+  const recoveringFailedAttempt = isIntentLifecycleFailure(existingStatus) && isRetryableIntentFailure(existing.error_code)
+  if (isIntentLifecycleFailure(existingStatus) && !recoveringFailedAttempt) {
     return
   }
 
@@ -1232,15 +1431,20 @@ function handleResult(db: Database, frame: ResultFrame): void {
     ?? (Number.isNaN(requestedAtMs) ? null : Math.max(0, Date.now() - requestedAtMs))
   const resolvedLatencyMs = typeof frame.latency === 'number' ? frame.latency : fallbackLatencyMs
 
-  finalizeIntentLog(db, {
+  const finalState = {
     nonce: frame.nonce,
     fromBeamId: existing.from_beam_id,
     toBeamId: existing.to_beam_id,
-    status: frame.success ? 'acked' : 'failed',
+    status: frame.success ? 'acked' : 'failed' as IntentLifecycleStatus,
     latencyMs: resolvedLatencyMs,
     errorCode: frame.success ? undefined : (frame.errorCode ?? existing.error_code ?? 'RESULT_ERROR'),
     resultJson: serializeResultFrame(frame),
-  })
+  }
+  if (recoveringFailedAttempt) {
+    reconcileIntentLog(db, finalState)
+  } else {
+    finalizeIntentLog(db, finalState)
+  }
   recordIntentStage(db, {
     nonce: frame.nonce,
     from: existing.from_beam_id,
@@ -1251,6 +1455,8 @@ function handleResult(db: Database, frame: ResultFrame): void {
     latencyMs: resolvedLatencyMs,
     errorCode: frame.success ? null : (frame.errorCode ?? existing.error_code ?? 'RESULT_ERROR'),
     lateResult: true,
+    recoveredAfterFailure: recoveringFailedAttempt || undefined,
+    previousStatus: existingStatus,
   })
   broadcastCompletedIntent({
     v: '1',
@@ -1306,6 +1512,43 @@ function clearPendingResult(nonce: string): void {
   if (!pending) return
   clearTimeout(pending.timeout)
   pendingResults.delete(nonce)
+}
+
+export function resetRelayRuntimeState(
+  options: {
+    closeConnections?: boolean
+    rejectPending?: boolean
+  } = {},
+): void {
+  const { closeConnections = false, rejectPending = false } = options
+
+  for (const pending of pendingResults.values()) {
+    clearTimeout(pending.timeout)
+    if (rejectPending) {
+      pending.reject(new RelayError('DELIVERY_FAILED', 'Relay runtime reset'))
+    }
+  }
+  pendingResults.clear()
+
+  if (closeConnections) {
+    for (const session of connections.values()) {
+      try {
+        session.ws.terminate()
+      } catch {
+        // Ignore best-effort connection cleanup during runtime resets.
+      }
+    }
+    for (const ws of intentFeedSubscribers.values()) {
+      try {
+        ws.terminate()
+      } catch {
+        // Ignore best-effort feed cleanup during runtime resets.
+      }
+    }
+  }
+
+  connections.clear()
+  intentFeedSubscribers.clear()
 }
 
 function sendJson(ws: WebSocket, payload: object): void {

--- a/packages/message-bus/src/db.ts
+++ b/packages/message-bus/src/db.ts
@@ -247,6 +247,38 @@ export function requeueMessage(db: Database.Database, id: string): void {
   })
 }
 
+export interface BusStartupRecoverySummary {
+  requeued: number
+}
+
+export function recoverInterruptedMessages(
+  db: Database.Database,
+  nowSeconds = Date.now() / 1000,
+): BusStartupRecoverySummary {
+  const interrupted = db.prepare(`
+    SELECT id
+    FROM beam_messages
+    WHERE status IN ('received', 'dispatched')
+    ORDER BY created_at ASC
+  `).all() as Array<{ id: string }>
+
+  const recover = db.transaction(() => {
+    for (const message of interrupted) {
+      updateMessageLifecycle(db, message.id, 'queued', {
+        nextRetryAt: nowSeconds,
+        error: 'Recovered after message bus restart',
+        failedAt: null,
+      })
+    }
+  })
+
+  recover()
+
+  return {
+    requeued: interrupted.length,
+  }
+}
+
 export function getPendingRetries(db: Database.Database, limit = 10): BeamMessage[] {
   const now = Date.now() / 1000
   return db.prepare(`

--- a/packages/message-bus/src/index.ts
+++ b/packages/message-bus/src/index.ts
@@ -17,14 +17,21 @@
  * ```
  */
 
-export { cleanTestMessages, initDatabase, type BeamMessage, type BusStats } from './db.js'
+export {
+  cleanTestMessages,
+  initDatabase,
+  recoverInterruptedMessages,
+  type BeamMessage,
+  type BusStats,
+  type BusStartupRecoverySummary,
+} from './db.js'
 export { createBusRouter, type RouterOptions } from './router.js'
 export { startRetryWorker, stopRetryWorker, type WorkerOptions } from './worker.js'
 export { loadIdentities, deliverToDirectory, type DeliveryResult } from './delivery.js'
 
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
-import { cleanTestMessages, initDatabase } from './db.js'
+import { cleanTestMessages, initDatabase, recoverInterruptedMessages } from './db.js'
 import { createBusRouter } from './router.js'
 import { startRetryWorker } from './worker.js'
 import { loadIdentities } from './delivery.js'
@@ -68,10 +75,15 @@ export function createBus(options: BusOptions = {}): Bus {
   return {
     async start() {
       const db = initDatabase(dbPath)
+      const recovery = recoverInterruptedMessages(db)
 
       if (process.env.BEAM_BUS_CLEAN_TEST_DATA === 'true') {
         const deleted = cleanTestMessages(db)
         console.log(`[beam-bus] Removed ${deleted} test/demo messages before startup`)
+      }
+
+      if (recovery.requeued > 0) {
+        console.log(`[beam-bus] Requeued ${recovery.requeued} interrupted message(s) after restart`)
       }
 
       if (identityPath) {

--- a/packages/message-bus/tests/bus.test.ts
+++ b/packages/message-bus/tests/bus.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Hono } from 'hono'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -5,7 +8,19 @@ vi.mock('../src/delivery.js', () => ({
   deliverToDirectory: vi.fn(async () => ({ success: true, error: '', retryable: false })),
 }))
 
-import { cleanTestMessages, getMessage, initDatabase, insertMessage, markAcked, markDeadLetter, markDelivered, markDispatched, markFailed, scheduleRetry } from '../src/db.js'
+import {
+  cleanTestMessages,
+  getMessage,
+  initDatabase,
+  insertMessage,
+  markAcked,
+  markDeadLetter,
+  markDelivered,
+  markDispatched,
+  markFailed,
+  recoverInterruptedMessages,
+  scheduleRetry,
+} from '../src/db.js'
 import { deliverToDirectory } from '../src/delivery.js'
 import { createBusRouter } from '../src/router.js'
 import { startRetryWorker, stopRetryWorker } from '../src/worker.js'
@@ -25,6 +40,14 @@ describe('message bus', () => {
     vi.clearAllMocks()
     vi.useRealTimers()
   })
+
+  function createTempDbPath(): { root: string; dbPath: string } {
+    const root = mkdtempSync(join(tmpdir(), 'beam-bus-recovery-'))
+    return {
+      root,
+      dbPath: join(root, 'beam-bus.sqlite'),
+    }
+  }
 
   it('roundtrips insertMessage + getMessage', () => {
     const id = insertMessage(db, {
@@ -505,5 +528,94 @@ describe('message bus', () => {
       { text: 'hello' },
     )
     expect(getMessage(db, id)?.status).toBe('dead_letter')
+  })
+
+  it('requeues interrupted dispatched messages on startup and replays them with the original nonce', async () => {
+    vi.useFakeTimers()
+    const { root, dbPath } = createTempDbPath()
+
+    try {
+      let diskDb = initDatabase(dbPath)
+      const id = insertMessage(diskDb, {
+        nonce: 'restart-replay-nonce',
+        sender: 'alpha@beam.directory',
+        recipient: 'beta@beam.directory',
+        intent: 'chat',
+        payload: { text: 'restart' },
+      })
+      markDispatched(diskDb, id)
+      diskDb.close()
+
+      diskDb = initDatabase(dbPath)
+      const recovery = recoverInterruptedMessages(diskDb, (Date.now() / 1000) - 1)
+      expect(recovery).toEqual({ requeued: 1 })
+      expect(getMessage(diskDb, id)?.status).toBe('queued')
+      expect(getMessage(diskDb, id)?.nonce).toBe('restart-replay-nonce')
+
+      const timer = startRetryWorker({ db: diskDb, directoryUrl: 'http://directory.test', intervalMs: 50 })
+      await vi.advanceTimersByTimeAsync(50)
+      stopRetryWorker(timer)
+
+      expect(vi.mocked(deliverToDirectory)).toHaveBeenCalledWith(
+        'http://directory.test',
+        id,
+        'restart-replay-nonce',
+        'alpha@beam.directory',
+        'beta@beam.directory',
+        'chat',
+        { text: 'restart' },
+      )
+      expect(getMessage(diskDb, id)?.status).toBe('delivered')
+      diskDb.close()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps retry windows intact across a bus restart', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-30T09:00:00Z'))
+    const { root, dbPath } = createTempDbPath()
+
+    try {
+      let diskDb = initDatabase(dbPath)
+      const id = insertMessage(diskDb, {
+        nonce: 'restart-window-nonce',
+        sender: 'alpha@beam.directory',
+        recipient: 'beta@beam.directory',
+        intent: 'chat',
+        payload: { text: 'window' },
+      })
+      const nextRetryAt = (Date.now() / 1000) + 60
+      scheduleRetry(diskDb, id, 1, nextRetryAt, 'offline')
+      diskDb.close()
+
+      diskDb = initDatabase(dbPath)
+      expect(getMessage(diskDb, id)?.status).toBe('queued')
+      expect(getMessage(diskDb, id)?.next_retry_at).toBe(nextRetryAt)
+
+      const timer = startRetryWorker({ db: diskDb, directoryUrl: 'http://directory.test', intervalMs: 50 })
+      await vi.advanceTimersByTimeAsync(50)
+      expect(vi.mocked(deliverToDirectory)).not.toHaveBeenCalled()
+
+      vi.setSystemTime(new Date('2026-03-30T09:01:01Z'))
+      await vi.advanceTimersByTimeAsync(50)
+      stopRetryWorker(timer)
+
+      expect(vi.mocked(deliverToDirectory)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(deliverToDirectory)).toHaveBeenCalledWith(
+        'http://directory.test',
+        id,
+        'restart-window-nonce',
+        'alpha@beam.directory',
+        'beta@beam.directory',
+        'chat',
+        { text: 'window' },
+      )
+      expect(getMessage(diskDb, id)?.status).toBe('delivered')
+      diskDb.close()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add startup recovery for interrupted message-bus deliveries and preserve retry windows across restarts
- recover directory in-flight intents after restart, including orphaned delivered intents and late-result reconciliation
- add restart-focused tests plus operator docs for restart and recovery behavior

## Verification
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build

Closes #9