### PR TITLE
Add key lifecycle and abuse controls

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -44,6 +44,16 @@ beam verify domain acme.example
 beam verify check
 ```
 
+## Key lifecycle
+
+```bash
+beam keys list
+beam keys rotate
+beam keys revoke MCowBQYDK2VwAyEA...
+```
+
+`beam keys rotate` generates a fresh local keypair for the same Beam ID, submits the signed rotation request, and updates `.beam/identity.json` on success.
+
 ## Directory stats
 
 ```bash

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -28,6 +28,13 @@ Successful responses return the created agent record with trust and verification
 Registration responses also return an API key with the prefix `bk_`. Store it securely — it is only meant to
 be shown in plaintext at creation time.
 
+Detailed registration and lookup responses now also include `keyState` with:
+
+- `active`
+- `revoked`
+- `keys`
+- `total`
+
 ## API key authentication
 
 Agent-authenticated endpoints accept `x-api-key: bk_...` as a simpler alternative to Ed25519 request signing.
@@ -48,6 +55,12 @@ Typical search example:
 
 ```text
 GET /agents/search?org=demo&capabilities=chat,search&minTrustScore=0.5&limit=20
+```
+
+Detailed lookup:
+
+```text
+GET /agents/:beamId
 ```
 
 ## `GET /stats`
@@ -77,6 +90,33 @@ Admin and operator access is session-based.
 - `POST /admin/auth/logout`
 
 Successful verification returns a short-lived signed bearer token and also sets the admin session cookie for dashboard clients.
+
+## Key lifecycle endpoints
+
+```text
+GET  /agents/:beamId/keys
+POST /agents/:beamId/keys/rotate
+POST /agents/:beamId/keys/revoke
+GET  /keys/revoked
+```
+
+Rotation accepts either:
+
+- `x-api-key` / bearer API key auth
+- a signed key-management payload from the current active key
+
+Revocation is intended for rotated-out historical keys. The active key must be replaced through rotation first.
+
+## Public Beam Shield policy
+
+Operators can inspect and update public HTTP abuse controls with:
+
+```text
+GET   /shield/policies/public-endpoints
+PATCH /shield/policies/public-endpoints
+```
+
+The policy covers registration, discovery, DID resolution, `POST /intents/send`, admin auth, and key mutation limits, plus trusted IP / trusted Beam ID overrides.
 
 ## `DELETE /admin/waitlist`
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -57,6 +57,23 @@ next_identity = BeamIdentity.generate(agent_name="planner", org_name="acme")
 await client.rotate_keys(next_identity)
 ```
 
+The SDK signs the rotation request with the current active key and returns `KeyRotationResult`
+with the latest `key_state`.
+
+### `list_keys()`
+
+```python
+key_state = await client.list_keys()
+print(key_state.active.public_key if key_state.active else None)
+print([key.public_key for key in key_state.revoked])
+```
+
+### `revoke_key(public_key)`
+
+```python
+await client.revoke_key("MCowBQYDK2VwAyEA...")
+```
+
 ### `browse(page=1, filters=None)`
 
 ```python
@@ -120,3 +137,6 @@ await thread.say("Draft a response to this customer issue.")
 - `Report`
 - `DomainVerification`
 - `KeyRotationResult`
+- `KeyRevocationResult`
+- `AgentKeyState`
+- `AgentKeyRecord`

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -66,6 +66,25 @@ const nextIdentity = BeamIdentity.generate({ agentName: 'planner', orgName: 'acm
 await client.rotateKeys(nextIdentity)
 ```
 
+The SDK signs the rotation request with the current active key, updates the local `BeamClient`
+identity on success, and the returned `KeyRotationResult` includes `keyState`.
+
+### `listKeys()`
+
+```ts
+const keyState = await client.listKeys()
+console.log(keyState.active?.publicKey)
+console.log(keyState.revoked.map((key) => key.publicKey))
+```
+
+### `revokeKey(publicKey)`
+
+```ts
+await client.revokeKey('MCowBQYDK2VwAyEA...')
+```
+
+Use `rotateKeys(...)` for the current active key. `revokeKey(...)` is for rotated-out historical keys.
+
 ### `browse(page?, filters?)`
 
 ```ts
@@ -146,6 +165,19 @@ interface BrowseFilters {
 ### `AgentProfile`
 
 `AgentProfile` extends the base agent record with `description`, `logoUrl`, `website`, `verificationTier`, `verificationStatus`, `domain`, and `intentsHandled`.
+
+### `AgentKeyState`
+
+Returned by `listKeys()`, and also exposed as `keyState` on detailed agent lookups and key lifecycle responses.
+
+```ts
+interface AgentKeyState {
+  active: AgentKeyRecord | null
+  revoked: AgentKeyRecord[]
+  keys: AgentKeyRecord[]
+  total: number
+}
+```
 
 ### `DirectoryStats`
 

--- a/docs/guide/did.md
+++ b/docs/guide/did.md
@@ -26,6 +26,7 @@ DID:      did:beam:coppen:jarvis
 ## DID Document
 
 Every registered agent gets a DID Document that follows the [W3C DID v1.1 specification](https://www.w3.org/TR/did-core/).
+Beam keeps historical signing keys in the DID document so older signatures remain auditable after key rotation.
 
 ### Resolve a DID
 
@@ -43,23 +44,48 @@ curl https://api.beam.directory/agents/did/did:beam:coppen:jarvis
   ],
   "id": "did:beam:coppen:jarvis",
   "alsoKnownAs": ["jarvis@coppen.beam.directory"],
-  "verificationMethod": [{
-    "id": "did:beam:coppen:jarvis#key-1",
-    "type": "Ed25519VerificationKey2020",
-    "controller": "did:beam:coppen:jarvis",
-    "publicKeyMultibase": "z6MkrvPsTYcb..."
-  }],
-  "authentication": ["did:beam:coppen:jarvis#key-1"],
-  "assertionMethod": ["did:beam:coppen:jarvis#key-1"],
-  "capabilityInvocation": ["did:beam:coppen:jarvis#key-1"],
-  "capabilityDelegation": ["did:beam:coppen:jarvis#key-1"],
-  "service": [{
-    "id": "did:beam:coppen:jarvis#directory",
-    "type": "BeamDirectoryService",
-    "serviceEndpoint": "https://beam.directory/agents/jarvis@coppen.beam.directory"
-  }]
+  "verificationMethod": [
+    {
+      "id": "did:beam:coppen:jarvis#z6MkrvPsTYcb...",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:beam:coppen:jarvis",
+      "publicKeyMultibase": "z6MkrvPsTYcb...",
+      "beamStatus": "active"
+    },
+    {
+      "id": "did:beam:coppen:jarvis#z6Mklegacy...",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:beam:coppen:jarvis",
+      "publicKeyMultibase": "z6Mklegacy...",
+      "beamStatus": "revoked",
+      "beamRevokedAt": "2026-03-30T10:22:11.000Z"
+    }
+  ],
+  "authentication": ["did:beam:coppen:jarvis#z6MkrvPsTYcb..."],
+  "assertionMethod": ["did:beam:coppen:jarvis#z6MkrvPsTYcb..."],
+  "capabilityInvocation": ["did:beam:coppen:jarvis#z6MkrvPsTYcb..."],
+  "capabilityDelegation": ["did:beam:coppen:jarvis#z6MkrvPsTYcb..."],
+  "service": [
+    {
+      "id": "did:beam:coppen:jarvis#directory",
+      "type": "BeamDirectoryService",
+      "serviceEndpoint": "https://beam.directory/agents/jarvis@coppen.beam.directory"
+    },
+    {
+      "id": "did:beam:coppen:jarvis#keys",
+      "type": "BeamKeyStateService",
+      "serviceEndpoint": "https://beam.directory/agents/jarvis@coppen.beam.directory/keys"
+    }
+  ]
 }
 ```
+
+### Key lifecycle semantics
+
+- Only the current active key appears in `authentication`, `assertionMethod`, `capabilityInvocation`, and `capabilityDelegation`.
+- Rotated-out keys stay in `verificationMethod` with `beamStatus: "revoked"` so historical signatures can still be verified.
+- Revoked keys are not accepted for new intents.
+- The directory key inventory is also available at `GET /agents/:beamId/keys`.
 
 ## Architecture
 

--- a/docs/security/beam-shield.md
+++ b/docs/security/beam-shield.md
@@ -2,6 +2,11 @@
 
 Beam Shield is a 5-wall defense system that protects every agent in the Beam network from prompt injection, PII leaks, and unauthorized access.
 
+It now covers both:
+
+- **per-agent intent controls** via `/shield/config/:beamId`
+- **public HTTP abuse controls** via `/shield/policies/public-endpoints`
+
 ## Architecture
 
 Every incoming intent passes through five sequential security layers:
@@ -109,6 +114,37 @@ The Output Filter scans agent responses before sending to detect:
 
 Detected PII is auto-redacted: `[REDACTED-iban]`, `[REDACTED-email]`
 
+## Public Endpoint Policy
+
+Operators can tune unauthenticated and semi-authenticated HTTP limits without redeploying the directory.
+
+```bash
+# Read the active policy
+curl -H "Authorization: Bearer <admin-session-token>" \
+  https://api.beam.directory/shield/policies/public-endpoints
+
+# Tighten registration and trust a private ingress IP
+curl -X PATCH https://api.beam.directory/shield/policies/public-endpoints \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
+  -d '{
+    "registrationPerMinute": 5,
+    "intentSendPerIpPerMinute": 20,
+    "intentSendPerSenderPerMinute": 10,
+    "trustedIps": ["203.0.113.44"],
+    "trustedBeamIds": ["*@internal.beam.directory"]
+  }'
+```
+
+The public policy currently covers:
+
+- registration bursts
+- search and browse scraping
+- direct lookup and DID resolution
+- `POST /intents/send` throttling by both IP and sender identity
+- admin magic-link challenge abuse
+- key mutation endpoints
+
 ## Admin API
 
 ```bash
@@ -124,6 +160,12 @@ GET /shield/audit/:beamId?hours=24
 
 # Get aggregate shield statistics (admin only)
 GET /shield/stats?hours=24
+
+# Get public endpoint abuse policy (admin/operator/viewer)
+GET /shield/policies/public-endpoints
+
+# Update public endpoint abuse policy (admin/operator)
+PATCH /shield/policies/public-endpoints
 ```
 
 ## Security Model
@@ -134,3 +176,5 @@ This means:
 - **Protocol level** (always on): Ed25519 signatures, nonce replay protection, rate limiting
 - **Agent level** (configurable): Trust Gate mode, Content Sandbox, Output Filter
 - **Receiver level** (agent's responsibility): Application-specific filtering, business logic validation
+
+Blocked and throttled traffic is surfaced to operators in both the audit log and the shield event stream.

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -11,7 +11,8 @@ Every agent identity is backed by an Ed25519 keypair:
 - **Private key** stays with the agent, never transmitted
 - **Public key** registered in the directory
 - **Every intent is signed** — the directory verifies signatures before relaying
-- **Key rotation** supported via the `/agents/:beamId/keys` API
+- **Key rotation and revocation** supported via `/agents/:beamId/keys/rotate`, `/agents/:beamId/keys/revoke`, and `GET /agents/:beamId/keys`
+- **Historical verification** preserved in DID resolution: rotated-out keys remain visible as revoked verification methods
 
 ```
 Agent generates Ed25519 keypair
@@ -29,17 +30,22 @@ Every signed intent includes a nonce:
 - The directory rejects any intent with a reused nonce
 - Prevents replay attacks where a captured message is re-sent
 
-### 3. Rate Limiting
+### 3. Rate Limiting and Abuse Controls
 
-IP-based rate limiting on all endpoints:
+Public endpoints are protected by configurable Beam Shield policies. Limits can be enforced by IP, Beam identity, or both, and trusted IPs / trusted Beam IDs can bypass those controls in managed environments.
 
 | Endpoint | Limit |
 |----------|-------|
 | `POST /agents/register` | 10/minute |
 | `GET /agents/search` | 30/minute |
-| All other endpoints | 60/minute |
+| `GET /agents/browse` | 30/minute |
+| `GET /agents/:beamId` | 120/minute |
+| `GET /did/*` | 120/minute |
+| `POST /intents/send` | 30/minute per IP, 20/minute per sender |
+| `POST /admin/auth/*` | 6/minute |
 
 Exceeded limits return `429 Too Many Requests`.
+All throttled and blocked requests are written into audit and shield observability views.
 
 ### 4. Input Validation
 
@@ -91,7 +97,7 @@ No wildcard origins. No `*`.
 | **Replay attacks** | Nonce-based. Each nonce is single-use and time-limited. |
 | **Man-in-the-middle** | TLS in transit. Signatures on payloads. Receiver can verify sender independently. |
 | **Directory poisoning** | Registration rate-limited. Verification tiers add trust signals. Abuse reporting API. |
-| **Spam/flooding** | Rate limiting per IP. Trust score affects relay priority. |
+| **Spam/flooding** | Public endpoint limits by IP and sender identity, per-agent trust gates, audit trails, and trusted-environment overrides. |
 | **SQL injection** | Prepared statements everywhere. No string concatenation in queries. |
 | **XSS on dashboard** | `escapeHtml()` on all dynamic output. |
 

--- a/packages/cli/src/commands/keys-list.ts
+++ b/packages/cli/src/commands/keys-list.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk'
+import { BeamDirectory } from 'beam-protocol-sdk'
+import type { BeamIdString } from 'beam-protocol-sdk'
+import { loadOptionalConfig, resolveDirectoryUrl } from '../config.js'
+
+interface KeysListOptions {
+  directory?: string
+  json?: boolean
+}
+
+export async function cmdKeysList(beamId: string | undefined, options: KeysListOptions): Promise<void> {
+  const config = loadOptionalConfig()
+  const resolvedBeamId = beamId ?? config?.identity.beamId
+  if (!resolvedBeamId) {
+    throw new Error('keys list requires <beamId> or a local .beam/identity.json')
+  }
+
+  const directory = new BeamDirectory({
+    baseUrl: resolveDirectoryUrl(options.directory),
+  })
+  const keyState = await directory.listKeys(resolvedBeamId as BeamIdString)
+
+  if (options.json) {
+    console.log(JSON.stringify({ beamId: resolvedBeamId, keyState }, null, 2))
+    return
+  }
+
+  console.log(chalk.bold(`Keys for ${resolvedBeamId}`))
+  console.log(chalk.dim('─'.repeat(60)))
+  if (!keyState.active && keyState.revoked.length === 0) {
+    console.log(chalk.yellow('No keys recorded'))
+    return
+  }
+
+  if (keyState.active) {
+    console.log(`${chalk.green('ACTIVE')}  ${keyState.active.publicKey}`)
+    console.log(chalk.dim(`         created ${new Date(keyState.active.createdAt).toLocaleString()}`))
+  }
+
+  for (const revoked of keyState.revoked) {
+    console.log(`${chalk.red('REVOKED')} ${revoked.publicKey}`)
+    console.log(chalk.dim(`         created ${new Date(revoked.createdAt).toLocaleString()}  revoked ${revoked.revokedAt ? new Date(revoked.revokedAt).toLocaleString() : 'unknown'}`))
+  }
+}

--- a/packages/cli/src/commands/keys-revoke.ts
+++ b/packages/cli/src/commands/keys-revoke.ts
@@ -1,0 +1,44 @@
+import chalk from 'chalk'
+import ora from 'ora'
+import { BeamClient } from 'beam-protocol-sdk'
+import { loadConfig, resolveDirectoryUrl } from '../config.js'
+
+interface KeysRevokeOptions {
+  directory?: string
+  json?: boolean
+}
+
+export async function cmdKeysRevoke(publicKey: string, options: KeysRevokeOptions): Promise<void> {
+  const config = loadConfig()
+  const directoryUrl = resolveDirectoryUrl(options.directory)
+  const trimmedKey = publicKey.trim()
+  if (!trimmedKey) {
+    throw new Error('publicKey is required')
+  }
+
+  const spinner = ora(`Revoking key for ${chalk.bold(config.identity.beamId)}...`).start()
+
+  try {
+    const client = new BeamClient({
+      identity: config.identity,
+      directoryUrl,
+    })
+    const result = await client.revokeKey(trimmedKey)
+    spinner.succeed('Key revoked')
+
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2))
+      return
+    }
+
+    console.log('')
+    console.log(chalk.bold('🧾 Key Revoked'))
+    console.log(chalk.dim('─'.repeat(60)))
+    console.log(`${chalk.cyan('Beam ID:')}     ${config.identity.beamId}`)
+    console.log(`${chalk.cyan('Revoked key:')} ${result.revokedKey?.publicKey ?? trimmedKey}`)
+    console.log(`${chalk.cyan('Active key:')}  ${result.keyState.active?.publicKey ?? chalk.dim('none')}`)
+  } catch (error) {
+    spinner.fail('Key revocation failed')
+    throw error
+  }
+}

--- a/packages/cli/src/commands/keys-rotate.ts
+++ b/packages/cli/src/commands/keys-rotate.ts
@@ -1,0 +1,59 @@
+import chalk from 'chalk'
+import ora from 'ora'
+import { BeamClient, BeamIdentity } from 'beam-protocol-sdk'
+import { loadConfig, resolveDirectoryUrl, saveConfig } from '../config.js'
+
+interface KeysRotateOptions {
+  directory?: string
+  json?: boolean
+}
+
+export async function cmdKeysRotate(options: KeysRotateOptions): Promise<void> {
+  const config = loadConfig()
+  const directoryUrl = resolveDirectoryUrl(options.directory)
+  const parsed = BeamIdentity.parseBeamId(config.identity.beamId)
+  if (!parsed) {
+    throw new Error('Invalid Beam ID in local config')
+  }
+
+  const replacementIdentity = BeamIdentity.generate({
+    agentName: parsed.agent,
+    ...(parsed.org ? { orgName: parsed.org } : {}),
+  })
+
+  const spinner = ora(`Rotating signing key for ${chalk.bold(config.identity.beamId)}...`).start()
+
+  try {
+    const client = new BeamClient({
+      identity: config.identity,
+      directoryUrl,
+    })
+    const result = await client.rotateKeys(replacementIdentity.export())
+
+    saveConfig({
+      ...config,
+      identity: replacementIdentity.export(),
+      directoryUrl,
+    })
+
+    spinner.succeed('Key rotated')
+
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2))
+      return
+    }
+
+    console.log('')
+    console.log(chalk.bold('🔐 Key Rotation Complete'))
+    console.log(chalk.dim('─'.repeat(60)))
+    console.log(`${chalk.cyan('Beam ID:')}        ${config.identity.beamId}`)
+    console.log(`${chalk.cyan('New active key:')} ${replacementIdentity.publicKeyBase64}`)
+    if (result.previousKey) {
+      console.log(`${chalk.cyan('Revoked key:')}    ${result.previousKey}`)
+    }
+    console.log(chalk.dim('The local .beam/identity.json has been updated to the new keypair.'))
+  } catch (error) {
+    spinner.fail('Key rotation failed')
+    throw error
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,9 @@ import { cmdStats } from './commands/stats.js'
 import { cmdDelegate } from './commands/delegate.js'
 import { cmdReport } from './commands/report.js'
 import { cmdTalk } from './commands/talk.js'
+import { cmdKeysList } from './commands/keys-list.js'
+import { cmdKeysRotate } from './commands/keys-rotate.js'
+import { cmdKeysRevoke } from './commands/keys-revoke.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json') as { version: string }
@@ -177,6 +180,34 @@ program
   .option('--json', 'Output raw JSON')
   .action(async (to: string, message: string, opts: { directory?: string; timeout?: string; language?: string; context?: string; json?: boolean }) => {
     await cmdTalk(to, message, opts)
+  })
+
+const keys = program.command('keys').description('Signing key lifecycle commands')
+keys
+  .command('list [beamId]')
+  .description('List active and revoked signing keys for an agent')
+  .option('-d, --directory <url>', 'Override directory URL')
+  .option('--json', 'Output raw JSON')
+  .action(async (beamId: string | undefined, opts: { directory?: string; json?: boolean }) => {
+    await cmdKeysList(beamId, opts)
+  })
+
+keys
+  .command('rotate')
+  .description('Rotate the local agent signing key and update .beam/identity.json')
+  .option('-d, --directory <url>', 'Override directory URL')
+  .option('--json', 'Output raw JSON')
+  .action(async (opts: { directory?: string; json?: boolean }) => {
+    await cmdKeysRotate(opts)
+  })
+
+keys
+  .command('revoke <publicKey>')
+  .description('Revoke a previously rotated-out signing key')
+  .option('-d, --directory <url>', 'Override directory URL')
+  .option('--json', 'Output raw JSON')
+  .action(async (publicKey: string, opts: { directory?: string; json?: boolean }) => {
+    await cmdKeysRevoke(publicKey, opts)
   })
 
 program.configureOutput({

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -24,7 +24,7 @@ import type {
   TrustScoreRow,
   VerificationTier,
 } from './types.js'
-import { generateDIDDocument, toBeamDID, type DIDDocument } from './did.js'
+import { generateDIDDocument, generateDIDDocumentWithKeys, toBeamDID, type DIDDocument } from './did.js'
 import {
   assertIntentLifecycleTransition,
   classifyIntentLifecycle,
@@ -34,8 +34,13 @@ import {
   normalizeLegacyTraceLifecycle,
   type IntentLifecycleStatus,
 } from './intent-lifecycle.js'
+import {
+  parsePublicEndpointShieldPolicy,
+  type PublicEndpointShieldPolicy,
+} from './shield/policies.js'
 
 const BEAM_DOMAIN_SUFFIX = 'beam.directory'
+const PUBLIC_ENDPOINT_POLICY_KEY = 'public-endpoints'
 
 export function createDatabase(dbPath = process.env.DB_PATH || './beam-directory.db'): DB {
   const db = new Database(dbPath)
@@ -405,6 +410,12 @@ function initSchema(db: DB): void {
     CREATE INDEX IF NOT EXISTS idx_shield_audit_created ON shield_audit_log(created_at);
     CREATE INDEX IF NOT EXISTS idx_shield_audit_nonce ON shield_audit_log(nonce);
 
+    CREATE TABLE IF NOT EXISTS shield_policies (
+      policy_key TEXT PRIMARY KEY,
+      config_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS pinned_keys (
       beam_id TEXT NOT NULL,
       pinned_beam_id TEXT NOT NULL,
@@ -760,11 +771,67 @@ function syncOrgAgentPublicKey(db: DB, beamId: string, publicKey: string): void 
   `).run(publicKey, nowIso(), beamId)
 }
 
+function createKeyLifecycleError(code: 'ACTIVE_KEY_REQUIRED' | 'KEY_ALREADY_REVOKED' | 'KEY_NOT_FOUND', message: string): Error & { code: string } {
+  const error = new Error(message) as Error & { code: string }
+  error.code = code
+  return error
+}
+
+function assertKeyCanBecomeActive(db: DB, beamId: string, publicKey: string): void {
+  const existing = db.prepare(`
+    SELECT revoked_at
+    FROM agent_keys
+    WHERE beam_id = ? AND public_key = ?
+    LIMIT 1
+  `).get(beamId, publicKey) as { revoked_at: number | null } | undefined
+
+  if (existing && existing.revoked_at !== null) {
+    throw createKeyLifecycleError(
+      'KEY_ALREADY_REVOKED',
+      `Key ${publicKey.slice(0, 16)}… has already been revoked for ${beamId}`,
+    )
+  }
+}
+
 function ensureAgentKeyRecorded(db: DB, beamId: string, publicKey: string, createdAt: number): void {
+  assertKeyCanBecomeActive(db, beamId, publicKey)
   db.prepare(`
     INSERT OR IGNORE INTO agent_keys (beam_id, public_key, created_at, revoked_at)
     VALUES (?, ?, ?, NULL)
   `).run(beamId, publicKey, createdAt)
+}
+
+export function listAgentKeys(db: DB, beamId: string): AgentKeyRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM agent_keys
+    WHERE beam_id = ?
+    ORDER BY CASE WHEN revoked_at IS NULL THEN 0 ELSE 1 END ASC,
+             COALESCE(revoked_at, created_at) DESC,
+             id DESC
+  `).all(beamId) as AgentKeyRow[]
+}
+
+export function getActiveAgentKey(db: DB, beamId: string): AgentKeyRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM agent_keys
+    WHERE beam_id = ? AND revoked_at IS NULL
+    ORDER BY created_at DESC, id DESC
+    LIMIT 1
+  `).get(beamId) as AgentKeyRow | undefined
+
+  return row ?? null
+}
+
+export function refreshAgentDIDDocument(db: DB, beamId: string): DIDDocument | null {
+  const agent = getAgent(db, beamId)
+  if (!agent) {
+    return null
+  }
+
+  const document = generateDIDDocumentWithKeys(agent, listAgentKeys(db, beamId))
+  return upsertDIDDocument(db, document)
 }
 
 export function registerAgent(db: DB, data: RegisterRequest): AgentRow {
@@ -774,6 +841,9 @@ export function registerAgent(db: DB, data: RegisterRequest): AgentRow {
   const personal = data.personal === true ? 1 : 0
 
   const existing = getAgent(db, data.beamId)
+  if (!existing || existing.public_key !== data.publicKey) {
+    assertKeyCanBecomeActive(db, data.beamId, data.publicKey)
+  }
   const normalizedEmail = data.email?.trim().toLowerCase() || null
   const emailChanged = normalizedEmail !== (existing?.email ?? null)
   const emailVerified = normalizedEmail
@@ -877,12 +947,19 @@ export function registerAgent(db: DB, data: RegisterRequest): AgentRow {
 
   syncOrgAgent(db, data, existing?.created_at ?? now)
   ensureAgentKeyRecorded(db, data.beamId, data.publicKey, createdAtMs)
+  if (existing && existing.public_key !== data.publicKey) {
+    db.prepare(`
+      UPDATE agent_keys
+      SET revoked_at = ?
+      WHERE beam_id = ? AND public_key = ? AND revoked_at IS NULL
+    `).run(createdAtMs, data.beamId, existing.public_key)
+  }
 
   const score = calculateTrustScore(db, data.beamId)
   db.prepare('UPDATE agents SET trust_score = ? WHERE beam_id = ?').run(score, data.beamId)
 
   const agent = getAgent(db, data.beamId) as AgentRow
-  upsertDIDDocument(db, generateDIDDocument(agent))
+  refreshAgentDIDDocument(db, data.beamId)
   return agent
 }
 
@@ -1093,6 +1170,39 @@ export function getDIDDocument(db: DB, did: string): DIDDocument | null {
   }
 
   return JSON.parse(row.document) as DIDDocument
+}
+
+export function getPublicEndpointShieldPolicy(db: DB): { policy: PublicEndpointShieldPolicy; updatedAt: string | null } {
+  const row = db.prepare(`
+    SELECT config_json, updated_at
+    FROM shield_policies
+    WHERE policy_key = ?
+    LIMIT 1
+  `).get(PUBLIC_ENDPOINT_POLICY_KEY) as { config_json: string; updated_at: string } | undefined
+
+  return {
+    policy: parsePublicEndpointShieldPolicy(row?.config_json),
+    updatedAt: row?.updated_at ?? null,
+  }
+}
+
+export function updatePublicEndpointShieldPolicy(
+  db: DB,
+  patch: Partial<PublicEndpointShieldPolicy>,
+): { policy: PublicEndpointShieldPolicy; updatedAt: string } {
+  const current = getPublicEndpointShieldPolicy(db).policy
+  const merged = parsePublicEndpointShieldPolicy(JSON.stringify({ ...current, ...patch }))
+  const updatedAt = nowIso()
+
+  db.prepare(`
+    INSERT INTO shield_policies (policy_key, config_json, updated_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(policy_key) DO UPDATE SET
+      config_json = excluded.config_json,
+      updated_at = excluded.updated_at
+  `).run(PUBLIC_ENDPOINT_POLICY_KEY, JSON.stringify(merged), updatedAt)
+
+  return { policy: merged, updatedAt }
 }
 
 export interface SearchQuery {
@@ -1359,6 +1469,8 @@ export function rotateAgentKey(db: DB, beamId: string, newPublicKey: string): Ag
     return null
   }
 
+  assertKeyCanBecomeActive(db, beamId, newPublicKey)
+
   const revokedAt = nowMs()
   const transaction = db.transaction(() => {
     db.prepare('UPDATE agents SET public_key = ? WHERE beam_id = ?').run(newPublicKey, beamId)
@@ -1372,6 +1484,49 @@ export function rotateAgentKey(db: DB, beamId: string, newPublicKey: string): Ag
       VALUES (?, ?, ?, NULL)
     `).run(beamId, newPublicKey, revokedAt)
     syncOrgAgentPublicKey(db, beamId, newPublicKey)
+    refreshAgentDIDDocument(db, beamId)
+  })
+
+  transaction()
+  return getAgent(db, beamId)
+}
+
+export function revokeAgentKey(db: DB, beamId: string, publicKey: string): AgentRow | null {
+  const existing = getAgent(db, beamId)
+  if (!existing) {
+    return null
+  }
+
+  if (existing.public_key === publicKey) {
+    throw createKeyLifecycleError(
+      'ACTIVE_KEY_REQUIRED',
+      'The active signing key must be rotated before it can be revoked',
+    )
+  }
+
+  const key = db.prepare(`
+    SELECT *
+    FROM agent_keys
+    WHERE beam_id = ? AND public_key = ?
+    LIMIT 1
+  `).get(beamId, publicKey) as AgentKeyRow | undefined
+
+  if (!key) {
+    throw createKeyLifecycleError('KEY_NOT_FOUND', `Key ${publicKey.slice(0, 16)}… was not found for ${beamId}`)
+  }
+
+  if (key.revoked_at !== null) {
+    throw createKeyLifecycleError('KEY_ALREADY_REVOKED', `Key ${publicKey.slice(0, 16)}… has already been revoked`)
+  }
+
+  const revokedAt = nowMs()
+  const transaction = db.transaction(() => {
+    db.prepare(`
+      UPDATE agent_keys
+      SET revoked_at = ?
+      WHERE beam_id = ? AND public_key = ? AND revoked_at IS NULL
+    `).run(revokedAt, beamId, publicKey)
+    refreshAgentDIDDocument(db, beamId)
   })
 
   transaction()

--- a/packages/directory/src/did.ts
+++ b/packages/directory/src/did.ts
@@ -1,4 +1,4 @@
-import type { AgentRow } from './types.js'
+import type { AgentKeyRow, AgentRow } from './types.js'
 import { multibaseToRawEd25519, publicKeyBase64ToMultibase, rawEd25519ToPublicKeyBase64 } from './crypto.js'
 import { getDirectoryIssuerDid, getDirectoryIssuerPublicKeyBase64 } from './issuer.js'
 
@@ -9,6 +9,8 @@ export interface VerificationMethod {
   type: 'Ed25519VerificationKey2020'
   controller: string
   publicKeyMultibase: string
+  beamStatus?: 'active' | 'revoked'
+  beamRevokedAt?: string
 }
 
 export interface ServiceEndpoint {
@@ -37,6 +39,7 @@ type ResolverConfig = {
   getStoredDocument?: (did: string) => DIDDocument | null
   getAgentByBeamId?: (beamId: string) => AgentRow | null
   findAgentByHandle?: (handle: string) => AgentRow | null
+  listAgentKeysByBeamId?: (beamId: string) => AgentKeyRow[]
 }
 
 const resolverConfig: ResolverConfig = {}
@@ -45,6 +48,7 @@ export function configureDIDResolver(config: ResolverConfig): void {
   resolverConfig.getStoredDocument = config.getStoredDocument
   resolverConfig.getAgentByBeamId = config.getAgentByBeamId
   resolverConfig.findAgentByHandle = config.findAgentByHandle
+  resolverConfig.listAgentKeysByBeamId = config.listAgentKeysByBeamId
 }
 
 function getDirectoryBaseUrl(): string {
@@ -71,13 +75,38 @@ function extractOrgName(beamId: string): string | null {
 function createDocument(input: {
   did: string
   publicKeyBase64: string
+  keys?: AgentKeyRow[]
   createdAt?: string
   updatedAt?: string
   alsoKnownAs?: string[]
   service?: ServiceEndpoint[]
   deactivated?: boolean
 }): DIDDocument {
-  const verificationMethodId = `${input.did}#key-1`
+  const keyEntries = (input.keys?.length ? input.keys : [
+    {
+      id: 1,
+      beam_id: input.did,
+      public_key: input.publicKeyBase64,
+      created_at: Date.now(),
+      revoked_at: null,
+    },
+  ]).map((key) => {
+    const publicKeyMultibase = publicKeyBase64ToMultibase(key.public_key)
+    return {
+      id: `${input.did}#${publicKeyMultibase}`,
+      type: 'Ed25519VerificationKey2020' as const,
+      controller: input.did,
+      publicKeyMultibase,
+      ...(key.revoked_at === null
+        ? { beamStatus: 'active' as const }
+        : {
+            beamStatus: 'revoked' as const,
+            beamRevokedAt: new Date(key.revoked_at).toISOString(),
+          }),
+    }
+  })
+  const activeVerificationMethod = keyEntries.find((entry) => entry.beamStatus === 'active') ?? keyEntries[0]
+  const verificationMethodId = activeVerificationMethod?.id ?? `${input.did}#key-1`
 
   return {
     '@context': [
@@ -86,14 +115,7 @@ function createDocument(input: {
     ],
     id: input.did,
     ...(input.alsoKnownAs?.length ? { alsoKnownAs: input.alsoKnownAs } : {}),
-    verificationMethod: [
-      {
-        id: verificationMethodId,
-        type: 'Ed25519VerificationKey2020',
-        controller: input.did,
-        publicKeyMultibase: publicKeyBase64ToMultibase(input.publicKeyBase64),
-      },
-    ],
+    verificationMethod: keyEntries,
     authentication: [verificationMethodId],
     assertionMethod: [verificationMethodId],
     capabilityInvocation: [verificationMethodId],
@@ -146,12 +168,17 @@ export function toBeamDID(beamId: string): string {
 }
 
 export function generateDIDDocument(agent: AgentRow): DIDDocument {
+  return generateDIDDocumentWithKeys(agent)
+}
+
+export function generateDIDDocumentWithKeys(agent: AgentRow, keys: AgentKeyRow[] = []): DIDDocument {
   const did = toBeamDID(agent.beam_id)
   const baseUrl = getDirectoryBaseUrl()
 
   return createDocument({
     did,
     publicKeyBase64: agent.public_key,
+    keys: keys.length > 0 ? keys : undefined,
     createdAt: agent.created_at,
     updatedAt: agent.last_seen,
     alsoKnownAs: agent.beam_id.includes('@') ? [agent.beam_id] : undefined,
@@ -165,6 +192,11 @@ export function generateDIDDocument(agent: AgentRow): DIDDocument {
         id: `${did}#did-resolution`,
         type: 'DIDResolutionService',
         serviceEndpoint: `${baseUrl}/did/${encodeURIComponent(did)}`,
+      },
+      {
+        id: `${did}#keys`,
+        type: 'BeamKeyStateService',
+        serviceEndpoint: `${baseUrl}/agents/${encodeURIComponent(agent.beam_id)}/keys`,
       },
     ],
   })
@@ -223,7 +255,8 @@ function resolvePersonalDID(methodSpecificId: string): DIDDocument | null {
   }
 
   const agent = resolverConfig.findAgentByHandle?.(methodSpecificId) ?? null
-  return agent ? generateDIDDocument(agent) : null
+  const keys = agent ? resolverConfig.listAgentKeysByBeamId?.(agent.beam_id) ?? [] : []
+  return agent ? generateDIDDocumentWithKeys(agent, keys) : null
 }
 
 function resolveOrgBoundDID(org: string, agentName: string): DIDDocument | null {
@@ -235,7 +268,8 @@ function resolveOrgBoundDID(org: string, agentName: string): DIDDocument | null 
 
   const beamId = `${agentName}@${org}.beam.directory`
   const agent = resolverConfig.getAgentByBeamId?.(beamId) ?? null
-  return agent ? generateDIDDocument(agent) : null
+  const keys = agent ? resolverConfig.listAgentKeysByBeamId?.(agent.beam_id) ?? [] : []
+  return agent ? generateDIDDocumentWithKeys(agent, keys) : null
 }
 
 export function resolveDID(did: string): DIDDocument | null {

--- a/packages/directory/src/middleware/rate-limit.ts
+++ b/packages/directory/src/middleware/rate-limit.ts
@@ -1,74 +1,293 @@
 import type { MiddlewareHandler } from 'hono'
+import type { Database } from 'better-sqlite3'
+import { getPublicEndpointShieldPolicy, logAuditEvent } from '../db.js'
+import { hashPayload, logShieldEvent } from '../shield/audit.js'
+import { matchesBeamPattern, type PublicEndpointShieldPolicy } from '../shield/policies.js'
 
 const WINDOW_MS = 60_000
 
-type RateLimitRule = {
-  key: string
+type BucketSpec = {
+  bucket: string
   limit: number
-  method?: string
-  path: string
+  actorKey: string
+  actorLabel: string
+  intentType: string
+  payload: unknown
 }
-
-type RateLimitEntry = {
-  count: number
-  windowStart: number
-}
-
-type RateLimitOptions = {
-  defaultLimit?: number
-  rules?: RateLimitRule[]
-}
-
-const DEFAULT_RULES: RateLimitRule[] = [
-  { key: 'registration', method: 'POST', path: '/agents/register', limit: 10 },
-  { key: 'search', method: 'GET', path: '/agents/search', limit: 30 },
-]
 
 function getClientIp(req: Request): string {
   return (
-    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    req.headers.get('x-real-ip') ??
-    'unknown'
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? req.headers.get('x-real-ip')
+    ?? 'unknown'
   )
 }
 
-function pruneExpiredEntries(entries: Map<string, RateLimitEntry>, now: number): void {
-  for (const [key, entry] of entries.entries()) {
-    if (now - entry.windowStart >= WINDOW_MS) {
-      entries.delete(key)
+function consumeRate(db: Database, rateKey: string, limit: number): boolean {
+  const now = Date.now()
+  const minimumWindowStart = now - WINDOW_MS
+  const row = db.prepare('SELECT count, window_start FROM rate_limits WHERE rate_key = ?').get(rateKey) as { count: number; window_start: number } | undefined
+
+  if (!row || row.window_start < minimumWindowStart) {
+    db.prepare('INSERT OR REPLACE INTO rate_limits (rate_key, count, window_start) VALUES (?, 1, ?)').run(rateKey, now)
+    return true
+  }
+
+  if (row.count >= limit) {
+    return false
+  }
+
+  db.prepare('UPDATE rate_limits SET count = count + 1 WHERE rate_key = ?').run(rateKey)
+  return true
+}
+
+async function parseRequestBody(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const body = await request.clone().json()
+    if (body && typeof body === 'object' && !Array.isArray(body)) {
+      return body as Record<string, unknown>
     }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function isTrusted(policy: PublicEndpointShieldPolicy, ip: string, beamId?: string | null): boolean {
+  return policy.trustedIps.includes(ip) || Boolean(beamId && matchesBeamPattern(beamId, policy.trustedBeamIds))
+}
+
+function createLookupBucket(path: string, ip: string, policy: PublicEndpointShieldPolicy): BucketSpec | null {
+  const reserved = new Set(['search', 'browse', 'stats', 'verify', 'verify-email'])
+  const match = /^\/agents\/([^/]+)$/.exec(path)
+  if (!match || reserved.has(match[1] ?? '')) {
+    return null
+  }
+
+  return {
+    bucket: 'agent-lookup',
+    limit: policy.lookupPerMinute,
+    actorKey: `ip:${ip}`,
+    actorLabel: `ip:${ip}`,
+    intentType: 'http.agent.lookup',
+    payload: { path },
   }
 }
 
-export function createRateLimitMiddleware(options: RateLimitOptions = {}): MiddlewareHandler {
-  const entries = new Map<string, RateLimitEntry>()
-  const defaultLimit = options.defaultLimit ?? 60
-  const rules = options.rules ?? DEFAULT_RULES
+async function resolveBuckets(
+  request: Request,
+  path: string,
+  method: string,
+  ip: string,
+  policy: PublicEndpointShieldPolicy,
+): Promise<{ trusted: boolean; buckets: BucketSpec[] }> {
+  if (method === 'POST' && path === '/agents/register') {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [{
+        bucket: 'agent-registration',
+        limit: policy.registrationPerMinute,
+        actorKey: `ip:${ip}`,
+        actorLabel: `ip:${ip}`,
+        intentType: 'http.agent.register',
+        payload: { path },
+      }],
+    }
+  }
+
+  if (method === 'GET' && path === '/agents/search') {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [{
+        bucket: 'agent-search',
+        limit: policy.searchPerMinute,
+        actorKey: `ip:${ip}`,
+        actorLabel: `ip:${ip}`,
+        intentType: 'http.agent.search',
+        payload: { path },
+      }],
+    }
+  }
+
+  if (method === 'GET' && path === '/agents/browse') {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [{
+        bucket: 'agent-browse',
+        limit: policy.browsePerMinute,
+        actorKey: `ip:${ip}`,
+        actorLabel: `ip:${ip}`,
+        intentType: 'http.agent.browse',
+        payload: { path },
+      }],
+    }
+  }
+
+  if (method === 'GET' && (path === '/.well-known/did.json' || path.startsWith('/did/'))) {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [{
+        bucket: 'did-resolution',
+        limit: policy.didResolutionPerMinute,
+        actorKey: `ip:${ip}`,
+        actorLabel: `ip:${ip}`,
+        intentType: 'http.did.resolve',
+        payload: { path },
+      }],
+    }
+  }
+
+  if (method === 'POST' && (path === '/admin/auth/magic-link' || path === '/admin/auth/verify')) {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [{
+        bucket: 'admin-auth',
+        limit: policy.adminAuthPerMinute,
+        actorKey: `ip:${ip}`,
+        actorLabel: `ip:${ip}`,
+        intentType: 'http.admin.auth',
+        payload: { path },
+      }],
+    }
+  }
+
+  if (method === 'POST' && /^\/agents\/[^/]+\/keys\/(?:rotate|revoke)$/.test(path)) {
+    const beamId = decodeURIComponent(path.split('/')[2] ?? '')
+    return {
+      trusted: isTrusted(policy, ip, beamId),
+      buckets: [{
+        bucket: 'key-mutation',
+        limit: policy.keyMutationPerMinute,
+        actorKey: `beam:${beamId}`,
+        actorLabel: beamId,
+        intentType: 'http.agent.keys',
+        payload: { path, beamId },
+      }],
+    }
+  }
+
+  if (method === 'POST' && path === '/intents/send') {
+    const body = await parseRequestBody(request)
+    const sender = typeof body?.from === 'string' ? body.from : null
+    const buckets: BucketSpec[] = [{
+      bucket: 'intent-send-ip',
+      limit: policy.intentSendPerIpPerMinute,
+      actorKey: `ip:${ip}`,
+      actorLabel: `ip:${ip}`,
+      intentType: 'http.intent.send',
+      payload: body ?? { path, malformed: true },
+    }]
+
+    if (sender) {
+      buckets.push({
+        bucket: 'intent-send-sender',
+        limit: policy.intentSendPerSenderPerMinute,
+        actorKey: `beam:${sender}`,
+        actorLabel: sender,
+        intentType: 'http.intent.send',
+        payload: body ?? { path, malformed: true },
+      })
+    }
+
+    return {
+      trusted: isTrusted(policy, ip, sender),
+      buckets,
+    }
+  }
+
+  const lookupBucket = createLookupBucket(path, ip, policy)
+  if (method === 'GET' && lookupBucket) {
+    return {
+      trusted: isTrusted(policy, ip),
+      buckets: [lookupBucket],
+    }
+  }
+
+  return { trusted: false, buckets: [] }
+}
+
+function logThrottle(
+  db: Database,
+  input: {
+    actor: string
+    path: string
+    bucket: string
+    limit: number
+    ip: string
+    intentType: string
+    payload: unknown
+  },
+): void {
+  const timestamp = new Date().toISOString()
+
+  logAuditEvent(db, {
+    action: 'public.rate_limit.throttled',
+    actor: input.actor,
+    target: input.path,
+    timestamp,
+    details: {
+      bucket: input.bucket,
+      limit: input.limit,
+      ip: input.ip,
+      intentType: input.intentType,
+    },
+  })
+
+  logShieldEvent(db, {
+    nonce: null,
+    timestamp,
+    senderBeamId: input.actor,
+    senderTrust: 0,
+    intentType: input.intentType,
+    payloadHash: hashPayload(input.payload),
+    decision: 'reject',
+    riskScore: 0.9,
+    responseSize: 0,
+    anomalyFlags: ['RATE_LIMITED', `bucket:${input.bucket}`, `ip:${input.ip}`],
+  })
+}
+
+export function createRateLimitMiddleware(db: Database): MiddlewareHandler {
+  const cleanupTimer = setInterval(() => {
+    const cutoff = Date.now() - WINDOW_MS
+    try {
+      db.prepare('DELETE FROM rate_limits WHERE window_start < ?').run(cutoff)
+    } catch {
+      // ignore cleanup errors
+    }
+  }, 300_000)
+  cleanupTimer.unref?.()
 
   return async (c, next) => {
-    const now = Date.now()
-    pruneExpiredEntries(entries, now)
-
-    const path = c.req.path
     const method = c.req.method.toUpperCase()
-    const rule = rules.find((candidate) => candidate.path === path && (candidate.method?.toUpperCase() ?? method) === method)
-    const bucket = rule?.key ?? 'default'
-    const limit = rule?.limit ?? defaultLimit
+    const path = c.req.path
     const ip = getClientIp(c.req.raw)
-    const key = `${bucket}:${ip}`
-    const entry = entries.get(key)
+    const { policy } = getPublicEndpointShieldPolicy(db)
+    const { trusted, buckets } = await resolveBuckets(c.req.raw, path, method, ip, policy)
 
-    if (!entry || now - entry.windowStart >= WINDOW_MS) {
-      entries.set(key, { count: 1, windowStart: now })
+    if (trusted || buckets.length === 0) {
       await next()
       return
     }
 
-    if (entry.count >= limit) {
-      return c.json({ error: 'Too many requests', errorCode: 'RATE_LIMITED' }, 429)
+    for (const bucket of buckets) {
+      const allowed = consumeRate(db, `${bucket.bucket}:${bucket.actorKey}`, bucket.limit)
+      if (!allowed) {
+        logThrottle(db, {
+          actor: bucket.actorLabel,
+          path,
+          bucket: bucket.bucket,
+          limit: bucket.limit,
+          ip,
+          intentType: bucket.intentType,
+          payload: bucket.payload,
+        })
+        c.header('Retry-After', '60')
+        return c.json({ error: 'Too many requests', errorCode: 'RATE_LIMITED' }, 429)
+      }
     }
 
-    entry.count += 1
     await next()
   }
 }

--- a/packages/directory/src/middleware/trust-gate.ts
+++ b/packages/directory/src/middleware/trust-gate.ts
@@ -1,16 +1,16 @@
 /**
  * Beam Shield — Wall 2: Trust Gate
- * Per-agent shield config: whitelist, open, or closed mode.
+ * Per-agent allowlist/blocklist/trust/rate-limit enforcement for intent delivery.
  */
 
 import type { MiddlewareHandler } from 'hono'
 import type { Database } from 'better-sqlite3'
-import { parseShieldConfig, type ShieldConfig } from '../routes/shield.js'
+import { logAuditEvent } from '../db.js'
+import { hashPayload, logShieldEvent } from '../shield/audit.js'
+import { matchesBeamPattern, parseShieldConfig, type ShieldConfig } from '../shield/policies.js'
 
 export interface TrustGateGlobalConfig {
-  /** Fallback min trust when agent has no shield config */
   defaultMinTrust: number
-  /** Fallback rate limit */
   defaultRateLimit: number
 }
 
@@ -21,48 +21,107 @@ const DEFAULT_GLOBAL: TrustGateGlobalConfig = {
 
 const WINDOW_MS = 3600_000
 
-// H2 FIX: Persistent rate limiting in SQLite instead of in-memory Map
+function getClientIp(req: Request): string {
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? req.headers.get('x-real-ip')
+    ?? 'unknown'
+  )
+}
+
 function checkAndIncrementRate(db: Database, rateKey: string, limit: number): boolean {
   const now = Date.now()
   const windowStart = now - WINDOW_MS
   const row = db.prepare('SELECT count, window_start FROM rate_limits WHERE rate_key = ?').get(rateKey) as { count: number; window_start: number } | undefined
 
   if (!row || row.window_start < windowStart) {
-    // Expired or new — reset
     db.prepare('INSERT OR REPLACE INTO rate_limits (rate_key, count, window_start) VALUES (?, 1, ?)').run(rateKey, now)
-    return true // allowed
+    return true
   }
 
   if (row.count >= limit) {
-    return false // rate limited
+    return false
   }
 
   db.prepare('UPDATE rate_limits SET count = count + 1 WHERE rate_key = ?').run(rateKey)
-  return true // allowed
+  return true
 }
 
-/** Match beam_id against pattern (exact or *@suffix wildcard) */
-export function matchesPattern(beamId: string, patterns: string[]): boolean {
-  return patterns.some((p) => {
-    if (p === beamId) return true
-    if (p.startsWith('*@')) return beamId.endsWith(p.slice(1))
-    if (p.startsWith('*.')) return beamId.includes(p.slice(1))
-    return false
+async function parseIntentEnvelope(request: Request): Promise<{
+  sender: string | null
+  recipient: string | null
+  intentType: string | null
+  payload: unknown
+}> {
+  if (request.method.toUpperCase() !== 'POST') {
+    return { sender: null, recipient: null, intentType: null, payload: null }
+  }
+
+  const path = new URL(request.url).pathname
+  if (path !== '/intents/send') {
+    return { sender: null, recipient: null, intentType: null, payload: null }
+  }
+
+  try {
+    const cloned = request.clone()
+    const body = await cloned.json() as Record<string, unknown>
+    return {
+      sender: typeof body.from === 'string' ? body.from : null,
+      recipient: typeof body.to === 'string' ? body.to : null,
+      intentType: typeof body.intent === 'string' ? body.intent : 'http.intent.send',
+      payload: body.payload ?? body.params ?? body,
+    }
+  } catch {
+    return {
+      sender: null,
+      recipient: null,
+      intentType: 'http.intent.send',
+      payload: { malformed: true },
+    }
+  }
+}
+
+function logShieldRejection(
+  db: Database,
+  input: {
+    sender: string
+    recipient: string | null
+    senderTrust: number
+    intentType: string
+    errorCode: string
+    reason: string
+    ip: string
+    payload: unknown
+  },
+): void {
+  const timestamp = new Date().toISOString()
+
+  logAuditEvent(db, {
+    action: 'shield.request.blocked',
+    actor: input.sender,
+    target: input.recipient ?? input.intentType,
+    timestamp,
+    details: {
+      errorCode: input.errorCode,
+      reason: input.reason,
+      ip: input.ip,
+      intentType: input.intentType,
+      recipient: input.recipient,
+    },
   })
-}
 
-/**
- * Resolves which agent is being targeted by this request.
- * Checks x-beam-recipient header, then URL path for known beam-id patterns.
- */
-function resolveRecipient(c: { req: { header: (n: string) => string | undefined; url: string } }): string | null {
-  // Explicit header (set by bridge/SDK)
-  const recipient = c.req.header('x-beam-recipient')
-  if (recipient) return recipient
-
-  // Try to extract from intent send body (POST /intents/send)
-  // Can't read body in middleware without consuming it, so rely on header
-  return null
+  logShieldEvent(db, {
+    nonce: null,
+    timestamp,
+    senderBeamId: input.sender,
+    senderTrust: input.senderTrust,
+    intentType: input.intentType,
+    payloadHash: hashPayload(input.payload),
+    decision: 'reject',
+    riskScore: 0.85,
+    responseSize: 0,
+    anomalyFlags: [input.errorCode, `ip:${input.ip}`],
+  })
 }
 
 export function createTrustGateMiddleware(
@@ -70,31 +129,34 @@ export function createTrustGateMiddleware(
   globalConfig: Partial<TrustGateGlobalConfig> = {},
 ): MiddlewareHandler {
   const cfg = { ...DEFAULT_GLOBAL, ...globalConfig }
-
-  // H2: Periodic cleanup of expired rate limit entries
-  setInterval(() => {
+  const cleanupTimer = setInterval(() => {
     const cutoff = Date.now() - WINDOW_MS
-    try { db.prepare('DELETE FROM rate_limits WHERE window_start < ?').run(cutoff) } catch { /* ignore */ }
+    try {
+      db.prepare('DELETE FROM rate_limits WHERE window_start < ?').run(cutoff)
+    } catch {
+      // ignore cleanup errors
+    }
   }, 300_000)
+  cleanupTimer.unref?.()
 
   return async (c, next) => {
-    const sender = c.req.header('x-beam-sender')
+    const envelope = await parseIntentEnvelope(c.req.raw)
+    const sender = c.req.header('x-beam-sender') ?? envelope.sender
 
-    // No sender = not agent-to-agent → pass through
     if (!sender) {
       await next()
       return
     }
 
-    // Find recipient's shield config
-    const recipient = resolveRecipient(c)
-    let shield: ShieldConfig
+    const recipient = c.req.header('x-beam-recipient') ?? envelope.recipient
+    const intentType = envelope.intentType ?? 'http.intent.send'
+    const ip = getClientIp(c.req.raw)
 
+    let shield: ShieldConfig
     if (recipient) {
       const row = db.prepare('SELECT shield_config FROM agents WHERE beam_id = ?').get(recipient) as { shield_config: string | null } | undefined
       shield = parseShieldConfig(row?.shield_config)
     } else {
-      // No recipient identifiable → use global defaults
       shield = {
         mode: 'open',
         allowlist: [],
@@ -104,8 +166,19 @@ export function createTrustGateMiddleware(
       }
     }
 
-    // === CLOSED MODE: reject everything ===
+    const senderTrust = (db.prepare('SELECT trust_score FROM agents WHERE beam_id = ?').get(sender) as { trust_score: number } | undefined)?.trust_score ?? 0
+
     if (shield.mode === 'closed') {
+      logShieldRejection(db, {
+        sender,
+        recipient,
+        senderTrust,
+        intentType,
+        errorCode: 'SHIELD_CLOSED',
+        reason: 'Agent is not accepting intents',
+        ip,
+        payload: envelope.payload,
+      })
       return c.json({
         error: 'Agent is not accepting intents',
         errorCode: 'SHIELD_CLOSED',
@@ -113,8 +186,17 @@ export function createTrustGateMiddleware(
       }, 403)
     }
 
-    // === BLOCKLIST (all modes) ===
-    if (matchesPattern(sender, shield.blocklist)) {
+    if (matchesBeamPattern(sender, shield.blocklist)) {
+      logShieldRejection(db, {
+        sender,
+        recipient,
+        senderTrust,
+        intentType,
+        errorCode: 'SHIELD_BLOCKED',
+        reason: 'Sender matched recipient blocklist',
+        ip,
+        payload: envelope.payload,
+      })
       return c.json({
         error: 'Blocked by Beam Shield',
         errorCode: 'SHIELD_BLOCKED',
@@ -122,14 +204,22 @@ export function createTrustGateMiddleware(
       }, 403)
     }
 
-    // === ALLOWLIST (all modes) ===
-    if (matchesPattern(sender, shield.allowlist)) {
+    if (matchesBeamPattern(sender, shield.allowlist)) {
       await next()
       return
     }
 
-    // === WHITELIST MODE: if not in allowlist → reject ===
     if (shield.mode === 'whitelist') {
+      logShieldRejection(db, {
+        sender,
+        recipient,
+        senderTrust,
+        intentType,
+        errorCode: 'SHIELD_NOT_WHITELISTED',
+        reason: 'Sender was not present in recipient allowlist',
+        ip,
+        payload: envelope.payload,
+      })
       return c.json({
         error: 'Not in allowlist — agent uses whitelist mode',
         errorCode: 'SHIELD_NOT_WHITELISTED',
@@ -138,24 +228,38 @@ export function createTrustGateMiddleware(
       }, 403)
     }
 
-    // === OPEN MODE: trust score check ===
-    const trustRow = db.prepare('SELECT trust_score FROM agents WHERE beam_id = ?').get(sender) as { trust_score: number } | undefined
-    const trust = trustRow?.trust_score ?? 0
-
-    if (trust < shield.minTrust) {
+    if (senderTrust < shield.minTrust) {
+      logShieldRejection(db, {
+        sender,
+        recipient,
+        senderTrust,
+        intentType,
+        errorCode: 'SHIELD_LOW_TRUST',
+        reason: 'Sender trust score is below the recipient minimum',
+        ip,
+        payload: envelope.payload,
+      })
       return c.json({
         error: 'Insufficient trust score',
         errorCode: 'SHIELD_LOW_TRUST',
         required: shield.minTrust,
-        actual: trust,
+        actual: senderTrust,
         sender,
       }, 403)
     }
 
-    // === RATE LIMIT (H2 FIX: persistent in SQLite) ===
     const rateKey = `${sender}→${recipient ?? 'global'}`
-    const allowed = checkAndIncrementRate(db, rateKey, shield.rateLimit)
-    if (!allowed) {
+    if (!checkAndIncrementRate(db, rateKey, shield.rateLimit)) {
+      logShieldRejection(db, {
+        sender,
+        recipient,
+        senderTrust,
+        intentType,
+        errorCode: 'SHIELD_RATE_LIMITED',
+        reason: 'Sender exceeded recipient shield rate limit',
+        ip,
+        payload: envelope.payload,
+      })
       return c.json({
         error: 'Rate limited by Beam Shield',
         errorCode: 'SHIELD_RATE_LIMITED',

--- a/packages/directory/src/routes/agents.ts
+++ b/packages/directory/src/routes/agents.ts
@@ -13,6 +13,7 @@ import {
   getAgent,
   getAgentDirectoryStats,
   getAgentIntentStats,
+  listAgentKeys,
   registerAgent,
   countSearchAgents,
   searchAgents,
@@ -375,11 +376,15 @@ export function agentsRouter(db: Database): Hono {
 
       seedAclsFromCatalog(db)
       return c.json({
-        ...serializeAgent(agent),
+        ...serializeAgent(agent, { keys: listAgentKeys(db, request.beamId) }),
         apiKey,
         verification_email_sent: verificationEmailSent,
       }, 201)
     } catch (err) {
+      const knownError = err as { code?: string; message?: string } | undefined
+      if (knownError?.code === 'KEY_ALREADY_REVOKED') {
+        return c.json({ error: knownError.message ?? 'Key is already revoked', errorCode: 'KEY_ALREADY_REVOKED' }, 409)
+      }
       console.error('Registration error:', err)
       return c.json({ error: 'Failed to register agent', errorCode: 'DB_ERROR' }, 500)
     }
@@ -599,7 +604,7 @@ export function agentsRouter(db: Database): Hono {
       }
 
       return c.json({
-        ...serializeAgent(agent),
+        ...serializeAgent(agent, { keys: listAgentKeys(db, beamId) }),
         intentStats: getAgentIntentStats(db, beamId),
       })
     } catch (err) {

--- a/packages/directory/src/routes/did.ts
+++ b/packages/directory/src/routes/did.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
-import { findAgentByHandle, getAgent, getDIDDocument } from '../db.js'
+import { findAgentByHandle, getAgent, getDIDDocument, listAgentKeys } from '../db.js'
 import { configureDIDResolver, generateDirectoryDIDDocument, resolveDIDWithFallbacks } from '../did.js'
 
 export function didRouter(db: Database): Hono {
@@ -8,6 +8,7 @@ export function didRouter(db: Database): Hono {
     getStoredDocument: (did) => getDIDDocument(db, did),
     getAgentByBeamId: (beamId) => getAgent(db, beamId),
     findAgentByHandle: (handle) => findAgentByHandle(db, handle),
+    listAgentKeysByBeamId: (beamId) => listAgentKeys(db, beamId),
   })
 
   const router = new Hono()

--- a/packages/directory/src/routes/keys.ts
+++ b/packages/directory/src/routes/keys.ts
@@ -1,24 +1,104 @@
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
-import type { AgentKeyRow } from '../types.js'
-import { getAgent, listRevokedAgentKeys, rotateAgentKey } from '../db.js'
+import type { AgentKeyRow, AgentRow } from '../types.js'
+import {
+  getAgent,
+  listAgentKeys,
+  listRevokedAgentKeys,
+  revokeAgentKey,
+  rotateAgentKey,
+} from '../db.js'
 import { verifyPayload } from '../crypto.js'
 import { BEAM_ID_RE } from '../validation.js'
 import { agentApiKeyMatches, getSuppliedApiKey } from '../api-key.js'
-import { serializeAgent } from '../utils/serialize.js'
+import { serializeAgent, serializeAgentKey, serializeAgentKeyState } from '../utils/serialize.js'
 
-function serializeKey(row: AgentKeyRow): object {
+type KeyLifecycleErrorResponse = {
+  error: string
+  errorCode: string
+  status: 404 | 409 | 500
+}
+
+function jsonError(error: string, errorCode: string, status: KeyLifecycleErrorResponse['status']): KeyLifecycleErrorResponse {
+  return { error, errorCode, status }
+}
+
+function getKeyState(db: Database, beamId: string) {
+  return serializeAgentKeyState(listAgentKeys(db, beamId))
+}
+
+function buildAuthPayload(
+  action: 'keys.rotate' | 'keys.revoke',
+  beamId: string,
+  fields: Record<string, unknown>,
+): Record<string, unknown> {
   return {
-    id: row.id,
-    beamId: row.beam_id,
-    publicKey: row.public_key,
-    createdAt: row.created_at,
-    revokedAt: row.revoked_at,
+    action,
+    beamId,
+    ...fields,
+  }
+}
+
+function canManageKeys(
+  agent: AgentRow,
+  request: Request,
+  payload: Record<string, unknown>,
+  signature?: string,
+  legacyProof?: { newPublicKey: string; rotationProof?: string },
+): boolean {
+  const suppliedApiKey = getSuppliedApiKey(request)
+  if (agentApiKeyMatches(agent, suppliedApiKey)) {
+    return true
+  }
+
+  if (signature?.trim() && verifyPayload(payload, signature.trim(), agent.public_key)) {
+    return true
+  }
+
+  if (
+    legacyProof?.rotationProof
+    && legacyProof.newPublicKey
+    && verifyPayload(legacyProof.newPublicKey, legacyProof.rotationProof, agent.public_key)
+  ) {
+    return true
+  }
+
+  return false
+}
+
+function keyLifecycleErrorResponse(error: unknown): KeyLifecycleErrorResponse {
+  const code = typeof error === 'object' && error !== null && 'code' in error ? String((error as { code?: string }).code ?? '') : ''
+  switch (code) {
+    case 'ACTIVE_KEY_REQUIRED':
+      return jsonError('Active key must be rotated before it can be revoked', 'ACTIVE_KEY_REQUIRED', 409)
+    case 'KEY_ALREADY_REVOKED':
+      return jsonError((error as Error).message, 'KEY_ALREADY_REVOKED', 409)
+    case 'KEY_NOT_FOUND':
+      return jsonError((error as Error).message, 'KEY_NOT_FOUND', 404)
+    default:
+      return jsonError('Failed to manage agent keys', 'KEY_MANAGEMENT_ERROR', 500)
   }
 }
 
 export function agentKeysRouter(db: Database): Hono {
   const router = new Hono()
+
+  router.get('/:beamId/keys', (c) => {
+    const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
+    if (!BEAM_ID_RE.test(beamId)) {
+      return c.json({ error: 'Invalid beamId format', errorCode: 'INVALID_BEAM_ID' }, 400)
+    }
+
+    const agent = getAgent(db, beamId)
+    if (!agent) {
+      return c.json({ error: `Agent ${beamId} not found`, errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    return c.json({
+      beamId,
+      keyState: getKeyState(db, beamId),
+    })
+  })
 
   router.post('/:beamId/keys/rotate', async (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
@@ -45,6 +125,8 @@ export function agentKeysRouter(db: Database): Hono {
     const raw = body as Record<string, unknown>
     const newPublicKey = String(raw.new_public_key ?? raw.publicKey ?? raw.public_key ?? '').trim()
     const rotationProof = String(raw.rotation_proof ?? '').trim()
+    const timestamp = typeof raw.timestamp === 'string' ? raw.timestamp : new Date().toISOString()
+    const signature = typeof raw.signature === 'string' ? raw.signature : undefined
 
     if (!newPublicKey) {
       return c.json({ error: 'new_public_key is required', errorCode: 'INVALID_ROTATION' }, 400)
@@ -54,22 +136,92 @@ export function agentKeysRouter(db: Database): Hono {
       return c.json({ error: 'new_public_key must differ from the current key', errorCode: 'NOOP_ROTATION' }, 400)
     }
 
-    const suppliedApiKey = getSuppliedApiKey(c.req.raw)
-    const hasApiKey = agentApiKeyMatches(agent, suppliedApiKey)
-    if (!hasApiKey && (!rotationProof || !verifyPayload(newPublicKey, rotationProof, agent.public_key))) {
-      return c.json({ error: 'rotation_proof is invalid', errorCode: 'INVALID_ROTATION_PROOF' }, 400)
+    const authPayload = buildAuthPayload('keys.rotate', beamId, {
+      newPublicKey,
+      timestamp,
+    })
+    if (!canManageKeys(agent, c.req.raw, authPayload, signature, { newPublicKey, rotationProof })) {
+      return c.json({ error: 'rotation proof or signature is invalid', errorCode: 'INVALID_ROTATION_PROOF' }, 400)
     }
 
-    const updated = rotateAgentKey(db, beamId, newPublicKey)
-    if (!updated) {
+    try {
+      const previousKey = agent.public_key
+      const updated = rotateAgentKey(db, beamId, newPublicKey)
+      if (!updated) {
+        return c.json({ error: `Agent ${beamId} not found`, errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      return c.json({
+        beamId,
+        rotated: true,
+        previousKey,
+        agent: serializeAgent(updated, { keys: listAgentKeys(db, beamId) }),
+        keyState: getKeyState(db, beamId),
+      })
+    } catch (error) {
+      const response = keyLifecycleErrorResponse(error)
+      return c.json({ error: response.error, errorCode: response.errorCode }, response.status)
+    }
+  })
+
+  router.post('/:beamId/keys/revoke', async (c) => {
+    const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
+    if (!BEAM_ID_RE.test(beamId)) {
+      return c.json({ error: 'Invalid beamId format', errorCode: 'INVALID_BEAM_ID' }, 400)
+    }
+
+    const agent = getAgent(db, beamId)
+    if (!agent) {
       return c.json({ error: `Agent ${beamId} not found`, errorCode: 'NOT_FOUND' }, 404)
     }
 
-    return c.json({
-      beamId,
-      rotated: true,
-      agent: serializeAgent(updated),
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const publicKey = String(raw.public_key ?? raw.publicKey ?? '').trim()
+    const timestamp = typeof raw.timestamp === 'string' ? raw.timestamp : new Date().toISOString()
+    const signature = typeof raw.signature === 'string' ? raw.signature : undefined
+
+    if (!publicKey) {
+      return c.json({ error: 'public_key is required', errorCode: 'INVALID_REVOCATION' }, 400)
+    }
+
+    const authPayload = buildAuthPayload('keys.revoke', beamId, {
+      publicKey,
+      timestamp,
     })
+    if (!canManageKeys(agent, c.req.raw, authPayload, signature)) {
+      return c.json({ error: 'signature is invalid', errorCode: 'INVALID_SIGNATURE' }, 400)
+    }
+
+    try {
+      const updated = revokeAgentKey(db, beamId, publicKey)
+      if (!updated) {
+        return c.json({ error: `Agent ${beamId} not found`, errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      const keys = listAgentKeys(db, beamId)
+      const revokedKey = keys.find((row) => row.public_key === publicKey) ?? null
+      return c.json({
+        beamId,
+        revoked: true,
+        revokedKey: revokedKey ? serializeAgentKey(revokedKey) : null,
+        agent: serializeAgent(updated, { keys }),
+        keyState: serializeAgentKeyState(keys),
+      })
+    } catch (error) {
+      const response = keyLifecycleErrorResponse(error)
+      return c.json({ error: response.error, errorCode: response.errorCode }, response.status)
+    }
   })
 
   return router
@@ -81,7 +233,7 @@ export function revokedKeysRouter(db: Database): Hono {
   router.get('/revoked', (c) => {
     const rows = listRevokedAgentKeys(db)
     return c.json({
-      keys: rows.map(serializeKey),
+      keys: rows.map((row: AgentKeyRow) => serializeAgentKey(row)),
       total: rows.length,
     })
   })

--- a/packages/directory/src/routes/shield.ts
+++ b/packages/directory/src/routes/shield.ts
@@ -1,94 +1,72 @@
 /**
  * Beam Shield — Routes
- * Per-agent shield config, audit log, and anomaly detection endpoints.
+ * Per-agent shield config, public endpoint policy, audit log, and anomaly endpoints.
  */
 
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
 import { getAdminSessionFromRequest, requireAdminRole, roleSatisfies } from '../admin-auth.js'
-import { logAuditEvent } from '../db.js'
+import {
+  getPublicEndpointShieldPolicy,
+  logAuditEvent,
+  recordNonce,
+  updatePublicEndpointShieldPolicy,
+} from '../db.js'
+import { verifyPayload } from '../crypto.js'
 import { getRecentEvents, getAuditStats } from '../shield/audit.js'
-
-export interface ShieldConfig {
-  mode: 'whitelist' | 'open' | 'closed'
-  allowlist: string[]
-  blocklist: string[]
-  minTrust: number
-  rateLimit: number
-}
-
-const DEFAULT_SHIELD_CONFIG: ShieldConfig = {
-  mode: 'open',
-  allowlist: [],
-  blocklist: [],
-  minTrust: 0.3,
-  rateLimit: 20,
-}
-
-export function parseShieldConfig(raw: string | null | undefined): ShieldConfig {
-  if (!raw) return { ...DEFAULT_SHIELD_CONFIG }
-  try {
-    const parsed = JSON.parse(raw) as Partial<ShieldConfig>
-    return {
-      mode: parsed.mode === 'whitelist' || parsed.mode === 'closed' ? parsed.mode : 'open',
-      allowlist: Array.isArray(parsed.allowlist) ? parsed.allowlist : [],
-      blocklist: Array.isArray(parsed.blocklist) ? parsed.blocklist : [],
-      minTrust: typeof parsed.minTrust === 'number' ? Math.max(0, Math.min(1, parsed.minTrust)) : 0.3,
-      rateLimit: typeof parsed.rateLimit === 'number' ? Math.max(1, Math.min(1000, parsed.rateLimit)) : 20,
-    }
-  } catch {
-    return { ...DEFAULT_SHIELD_CONFIG }
-  }
-}
+import {
+  parseShieldConfig,
+  type PublicEndpointShieldPolicy,
+  type ShieldConfig,
+} from '../shield/policies.js'
 
 export function shieldRouter(db: Database): Hono {
   const router = new Hono()
 
-  // GET /shield/config/:beamId — Get shield config for an agent
   router.get('/config/:beamId', (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
     const row = db.prepare('SELECT shield_config FROM agents WHERE beam_id = ?').get(beamId) as { shield_config: string | null } | undefined
 
-    if (!row) return c.json({ error: 'Agent not found' }, 404)
+    if (!row) {
+      return c.json({ error: 'Agent not found' }, 404)
+    }
 
-    const config = parseShieldConfig(row.shield_config)
-    return c.json({ beamId, shield: config })
+    return c.json({ beamId, shield: parseShieldConfig(row.shield_config) })
   })
 
-  // PATCH /shield/config/:beamId — Update shield config (admin-key or Ed25519 required)
   router.patch('/config/:beamId', async (c) => {
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
 
     const adminSession = getAdminSessionFromRequest(db, c.req.raw)
     const isAdmin = Boolean(adminSession && roleSatisfies(adminSession.role, 'admin'))
     if (!isAdmin) {
-      // Check Ed25519 signature auth
       const sigHeader = c.req.header('x-beam-signature')
       const nonceHeader = c.req.header('x-beam-nonce')
       if (!sigHeader || !nonceHeader) {
         return c.json({ error: 'Admin session or Ed25519 signature required', errorCode: 'UNAUTHORIZED' }, 401)
       }
 
-      // Verify signature over beamId + nonce
-      const { verifyPayload } = await import('../crypto.js')
       const agentRow = db.prepare('SELECT public_key FROM agents WHERE beam_id = ?').get(beamId) as { public_key: string } | undefined
-      if (!agentRow?.public_key) return c.json({ error: 'Agent not found or no key' }, 404)
+      if (!agentRow?.public_key) {
+        return c.json({ error: 'Agent not found or no key' }, 404)
+      }
 
       const payload = { action: 'shield', beamId, nonce: nonceHeader }
       const valid = verifyPayload(payload, sigHeader, agentRow.public_key)
-      if (!valid) return c.json({ error: 'Invalid signature', errorCode: 'INVALID_SIGNATURE' }, 403)
+      if (!valid) {
+        return c.json({ error: 'Invalid signature', errorCode: 'INVALID_SIGNATURE' }, 403)
+      }
 
-      // K1 FIX: Record nonce to prevent replay attacks
-      const existingNonce = db.prepare('SELECT nonce FROM nonces WHERE nonce = ?').get(nonceHeader)
-      if (existingNonce) return c.json({ error: 'Nonce already used', errorCode: 'NONCE_REPLAY' }, 409)
-      db.prepare('INSERT INTO nonces (nonce, beam_id, created_at) VALUES (?, ?, ?)').run(nonceHeader, beamId, new Date().toISOString())
+      if (!recordNonce(db, nonceHeader)) {
+        return c.json({ error: 'Nonce already used', errorCode: 'NONCE_REPLAY' }, 409)
+      }
     }
 
-    // Validate agent exists
     const agent = db.prepare('SELECT beam_id FROM agents WHERE beam_id = ?').get(beamId) as { beam_id: string } | undefined
-    if (!agent) return c.json({ error: 'Agent not found' }, 404)
+    if (!agent) {
+      return c.json({ error: 'Agent not found' }, 404)
+    }
 
-    // Parse and validate body
     let body: Record<string, unknown>
     try {
       body = await c.req.json() as Record<string, unknown>
@@ -96,14 +74,13 @@ export function shieldRouter(db: Database): Hono {
       return c.json({ error: 'Invalid JSON' }, 400)
     }
 
-    // Build config
     const currentRaw = (db.prepare('SELECT shield_config FROM agents WHERE beam_id = ?').get(beamId) as { shield_config: string | null } | undefined)?.shield_config
     const current = parseShieldConfig(currentRaw)
 
     const updated: ShieldConfig = {
       mode: body.mode === 'whitelist' || body.mode === 'open' || body.mode === 'closed' ? body.mode : current.mode,
-      allowlist: Array.isArray(body.allowlist) ? (body.allowlist as string[]).filter(s => typeof s === 'string') : current.allowlist,
-      blocklist: Array.isArray(body.blocklist) ? (body.blocklist as string[]).filter(s => typeof s === 'string') : current.blocklist,
+      allowlist: Array.isArray(body.allowlist) ? (body.allowlist as unknown[]).filter((value): value is string => typeof value === 'string') : current.allowlist,
+      blocklist: Array.isArray(body.blocklist) ? (body.blocklist as unknown[]).filter((value): value is string => typeof value === 'string') : current.blocklist,
       minTrust: typeof body.minTrust === 'number' ? Math.max(0, Math.min(1, body.minTrust)) : current.minTrust,
       rateLimit: typeof body.rateLimit === 'number' ? Math.max(1, Math.min(1000, body.rateLimit)) : current.rateLimit,
     }
@@ -127,7 +104,42 @@ export function shieldRouter(db: Database): Hono {
     return c.json({ beamId, shield: updated, updated: true })
   })
 
-  // GET /shield/audit/:beamId — Recent audit events for a sender
+  router.get('/policies/public-endpoints', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const { policy, updatedAt } = getPublicEndpointShieldPolicy(db)
+    return c.json({ policy, updatedAt })
+  })
+
+  router.patch('/policies/public-endpoints', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: Partial<PublicEndpointShieldPolicy>
+    try {
+      body = await c.req.json() as Partial<PublicEndpointShieldPolicy>
+    } catch {
+      return c.json({ error: 'Invalid JSON', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    const { policy, updatedAt } = updatePublicEndpointShieldPolicy(db, body)
+    logAuditEvent(db, {
+      action: 'shield.public_policy.updated',
+      actor: auth.session.email,
+      target: 'public-endpoints',
+      details: {
+        role: auth.session.role,
+        policy,
+      },
+    })
+    return c.json({ policy, updatedAt, updated: true })
+  })
+
   router.get('/audit/:beamId', (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
@@ -135,7 +147,7 @@ export function shieldRouter(db: Database): Hono {
     }
 
     const beamId = decodeURIComponent(c.req.param('beamId') ?? '')
-    const hours = parseInt(c.req.query('hours') ?? '24', 10)
+    const hours = Number.parseInt(c.req.query('hours') ?? '24', 10)
 
     try {
       const events = getRecentEvents(db, beamId, hours)
@@ -146,14 +158,13 @@ export function shieldRouter(db: Database): Hono {
     }
   })
 
-  // GET /shield/stats — Aggregate shield statistics
   router.get('/stats', (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
       return auth
     }
 
-    const hours = parseInt(c.req.query('hours') ?? '24', 10)
+    const hours = Number.parseInt(c.req.query('hours') ?? '24', 10)
 
     try {
       const stats = getAuditStats(db, hours)

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -35,7 +35,7 @@ import {
 } from './websocket.js'
 import { createAcl, deleteAcl, listAclsForBeam, seedAclsFromCatalog } from './acl.js'
 import { getAdminSessionFromRequest, requireAdminRole } from './admin-auth.js'
-import { assignDirectoryRole, deleteDirectoryRole, listDirectoryRoles, listAuditLog, listRecentIntentLogs, listTrustScores, logAuditEvent, getDIDDocument, getAgent, upsertDIDDocument } from './db.js'
+import { assignDirectoryRole, deleteDirectoryRole, getAgent, getDIDDocument, listAgentKeys, listAuditLog, listDirectoryRoles, listRecentIntentLogs, listTrustScores, logAuditEvent, upsertDIDDocument } from './db.js'
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import type { AgentRow, IntentFrame } from './types.js'
@@ -576,7 +576,7 @@ export function createApp(db: Database): Hono {
     credentials: true,
   }))
 
-  app.use('*', createRateLimitMiddleware())
+  app.use('*', createRateLimitMiddleware(db))
 
   // Beam Shield — Wall 1: Body size limit (64KB)
   app.use('*', async (c, next) => {
@@ -794,12 +794,12 @@ export function createApp(db: Database): Hono {
     if (stored) return c.json(stored)
 
     // On-demand generation: convert DID → beam_id → lookup agent → generate
-    const { toBeamDID, generateDIDDocument, didToBeamId } = await import('./did.js')
+    const { generateDIDDocumentWithKeys, didToBeamId } = await import('./did.js')
     const beamId = didToBeamId(didString)
     if (beamId) {
       const agent = getAgent(db, beamId)
       if (agent) {
-        const newDoc = generateDIDDocument(agent)
+        const newDoc = generateDIDDocumentWithKeys(agent, listAgentKeys(db, beamId))
         upsertDIDDocument(db, newDoc)
         return c.json(newDoc)
       }

--- a/packages/directory/src/shield/policies.ts
+++ b/packages/directory/src/shield/policies.ts
@@ -1,0 +1,126 @@
+export interface ShieldConfig {
+  mode: 'whitelist' | 'open' | 'closed'
+  allowlist: string[]
+  blocklist: string[]
+  minTrust: number
+  rateLimit: number
+}
+
+export interface PublicEndpointShieldPolicy {
+  trustedIps: string[]
+  trustedBeamIds: string[]
+  registrationPerMinute: number
+  searchPerMinute: number
+  browsePerMinute: number
+  lookupPerMinute: number
+  didResolutionPerMinute: number
+  intentSendPerIpPerMinute: number
+  intentSendPerSenderPerMinute: number
+  adminAuthPerMinute: number
+  keyMutationPerMinute: number
+}
+
+export const DEFAULT_SHIELD_CONFIG: ShieldConfig = {
+  mode: 'open',
+  allowlist: [],
+  blocklist: [],
+  minTrust: 0.3,
+  rateLimit: 20,
+}
+
+export const DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY: PublicEndpointShieldPolicy = {
+  trustedIps: [],
+  trustedBeamIds: [],
+  registrationPerMinute: 10,
+  searchPerMinute: 30,
+  browsePerMinute: 30,
+  lookupPerMinute: 120,
+  didResolutionPerMinute: 120,
+  intentSendPerIpPerMinute: 30,
+  intentSendPerSenderPerMinute: Number.parseInt(process.env['BEAM_RATE_LIMIT_PER_MIN'] ?? '20', 10) || 20,
+  adminAuthPerMinute: 6,
+  keyMutationPerMinute: 10,
+}
+
+function sanitizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return [...new Set(
+    value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )]
+}
+
+function clamp(value: unknown, minimum: number, maximum: number, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback
+  }
+
+  return Math.max(minimum, Math.min(maximum, Math.trunc(value)))
+}
+
+export function matchesBeamPattern(beamId: string, patterns: string[]): boolean {
+  return patterns.some((pattern) => {
+    if (pattern === beamId) {
+      return true
+    }
+
+    if (pattern.startsWith('*@')) {
+      return beamId.endsWith(pattern.slice(1))
+    }
+
+    if (pattern.startsWith('*.')) {
+      return beamId.includes(pattern.slice(1))
+    }
+
+    return false
+  })
+}
+
+export function parseShieldConfig(raw: string | null | undefined): ShieldConfig {
+  if (!raw) {
+    return { ...DEFAULT_SHIELD_CONFIG }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<ShieldConfig>
+    return {
+      mode: parsed.mode === 'whitelist' || parsed.mode === 'closed' ? parsed.mode : 'open',
+      allowlist: sanitizeStringList(parsed.allowlist),
+      blocklist: sanitizeStringList(parsed.blocklist),
+      minTrust: clamp(parsed.minTrust, 0, 1, DEFAULT_SHIELD_CONFIG.minTrust),
+      rateLimit: clamp(parsed.rateLimit, 1, 1_000, DEFAULT_SHIELD_CONFIG.rateLimit),
+    }
+  } catch {
+    return { ...DEFAULT_SHIELD_CONFIG }
+  }
+}
+
+export function parsePublicEndpointShieldPolicy(raw: string | null | undefined): PublicEndpointShieldPolicy {
+  if (!raw) {
+    return { ...DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<PublicEndpointShieldPolicy>
+    return {
+      trustedIps: sanitizeStringList(parsed.trustedIps),
+      trustedBeamIds: sanitizeStringList(parsed.trustedBeamIds),
+      registrationPerMinute: clamp(parsed.registrationPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.registrationPerMinute),
+      searchPerMinute: clamp(parsed.searchPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.searchPerMinute),
+      browsePerMinute: clamp(parsed.browsePerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.browsePerMinute),
+      lookupPerMinute: clamp(parsed.lookupPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.lookupPerMinute),
+      didResolutionPerMinute: clamp(parsed.didResolutionPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.didResolutionPerMinute),
+      intentSendPerIpPerMinute: clamp(parsed.intentSendPerIpPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.intentSendPerIpPerMinute),
+      intentSendPerSenderPerMinute: clamp(parsed.intentSendPerSenderPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.intentSendPerSenderPerMinute),
+      adminAuthPerMinute: clamp(parsed.adminAuthPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.adminAuthPerMinute),
+      keyMutationPerMinute: clamp(parsed.keyMutationPerMinute, 1, 10_000, DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY.keyMutationPerMinute),
+    }
+  } catch {
+    return { ...DEFAULT_PUBLIC_ENDPOINT_SHIELD_POLICY }
+  }
+}

--- a/packages/directory/src/utils/serialize.ts
+++ b/packages/directory/src/utils/serialize.ts
@@ -1,7 +1,31 @@
-import type { AgentRow } from '../types.js'
+import type { AgentKeyRow, AgentRow } from '../types.js'
 import { toBeamDID } from '../did.js'
 
-export function serializeAgent(row: AgentRow, options: { connected?: boolean } = {}): object {
+export function serializeAgentKey(row: AgentKeyRow): object {
+  return {
+    id: row.id,
+    beamId: row.beam_id,
+    publicKey: row.public_key,
+    createdAt: row.created_at,
+    revokedAt: row.revoked_at,
+    status: row.revoked_at === null ? 'active' : 'revoked',
+  }
+}
+
+export function serializeAgentKeyState(rows: AgentKeyRow[]): object {
+  const active = rows.find((row) => row.revoked_at === null) ?? null
+  return {
+    active: active ? serializeAgentKey(active) : null,
+    revoked: rows.filter((row) => row.revoked_at !== null).map(serializeAgentKey),
+    keys: rows.map(serializeAgentKey),
+    total: rows.length,
+  }
+}
+
+export function serializeAgent(
+  row: AgentRow,
+  options: { connected?: boolean; keys?: AgentKeyRow[] } = {},
+): object {
   const { email_token: _emailToken, api_key_hash: _apiKeyHash, ...agent } = row
 
   return {
@@ -14,5 +38,6 @@ export function serializeAgent(row: AgentRow, options: { connected?: boolean } =
     flagged: row.flagged === 1,
     verificationTier: row.verification_tier,
     ...(options.connected === undefined ? {} : { connected: options.connected }),
+    ...(options.keys ? { keyState: serializeAgentKeyState(options.keys) } : {}),
   }
 }

--- a/packages/directory/src/websocket.test.ts
+++ b/packages/directory/src/websocket.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { WebSocket } from 'ws'
 import { createAcl } from './acl.js'
-import { createDatabase, getIntentLogByNonce, listIntentTraceEvents, registerAgent } from './db.js'
+import { createDatabase, getIntentLogByNonce, listIntentTraceEvents, registerAgent, rotateAgentKey } from './db.js'
 import {
   createWebSocketServer,
   expireRecoveredIntentTimeouts,
@@ -231,6 +231,52 @@ test('relayIntentFromHttp caches direct HTTP results by nonce and suppresses dup
     })
 
     assert.equal(directCalls, 1)
+  } finally {
+    db.close()
+  }
+})
+
+test('relayIntentFromHttp rejects intents signed by a rotated-out key', async () => {
+  const db = createDatabase(':memory:')
+  const sender = createFixtureAgent('sender@local.beam.directory')
+  const rotatedSender = createFixtureAgent('sender@local.beam.directory')
+  const receiver = createFixtureAgent('receiver@local.beam.directory')
+
+  try {
+    registerFixtureAgent(db, sender, { displayName: 'Sender' })
+    registerFixtureAgent(db, receiver, {
+      displayName: 'Receiver',
+      httpEndpoint: 'https://direct.example/beam',
+    })
+    createAcl(db, {
+      targetBeamId: receiver.beamId,
+      intentType: TEST_INTENT,
+      allowedFrom: sender.beamId,
+    })
+
+    rotateAgentKey(db, sender.beamId, rotatedSender.publicKeyBase64)
+
+    const staleFrame = createSignedFrame(sender, receiver.beamId)
+    await withFetchStub(async () => {
+      throw new Error('stale key should fail before delivery')
+    }, async () => {
+      await assert.rejects(
+        relayIntentFromHttp(db, staleFrame, 1_000),
+        (error: unknown) => error instanceof RelayError && error.code === 'BAD_REQUEST',
+      )
+    })
+
+    const freshFrame = createSignedFrame(rotatedSender, receiver.beamId)
+    await withFetchStub(async () => new Response(JSON.stringify({
+      success: true,
+      payload: { rotated: true },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }), async () => {
+      const result = await relayIntentFromHttp(db, freshFrame, 1_000)
+      assert.equal(result.success, true)
+    })
   } finally {
     db.close()
   }

--- a/packages/directory/tests/identity-systems.test.ts
+++ b/packages/directory/tests/identity-systems.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Hono } from 'hono'
 import { createAdminSession } from '../src/admin-auth.js'
 import { createDatabase, getAgent, registerAgent, assignDirectoryRole } from '../src/db.js'
+import { canonicalizeJson } from '../src/crypto.js'
 import { getLocalDirectoryUrl } from '../src/federation.js'
+import { agentsRouter } from '../src/routes/agents.js'
+import { didRouter } from '../src/routes/did.js'
 import { agentKeysRouter, revokedKeysRouter } from '../src/routes/keys.js'
 import { verificationRouter } from '../src/routes/verify.js'
 import { delegationsRouter } from '../src/routes/delegations.js'
@@ -22,12 +25,21 @@ function signPayload(privateKey: ReturnType<typeof generateIdentity>['privateKey
   return sign(null, Buffer.from(payload, 'utf8'), privateKey).toString('base64')
 }
 
+function signCanonicalPayload(
+  privateKey: ReturnType<typeof generateIdentity>['privateKey'],
+  payload: Record<string, unknown>,
+): string {
+  return sign(null, Buffer.from(canonicalizeJson(payload), 'utf8'), privateKey).toString('base64')
+}
+
 function createTestApp(db: ReturnType<typeof createDatabase>, resolver?: (hostname: string) => Promise<string[][]>) {
   const app = new Hono()
+  app.route('/agents', agentsRouter(db))
   app.route('/agents', verificationRouter(db, resolver as never))
   app.route('/agents', agentKeysRouter(db))
   app.route('/agents', delegationsRouter(db))
   app.route('/agents', reportsRouter(db))
+  app.route('/agents', didRouter(db))
   app.route('/keys', revokedKeysRouter(db))
   return app
 }
@@ -81,7 +93,7 @@ describe('directory identity and verification routes', () => {
     expect(checked.body.agent.trust_score).toBe(1)
   })
 
-  it('rotates agent keys and exposes revoked keys', async () => {
+  it('rotates agent keys, exposes key state, and keeps revoked keys in DID resolution', async () => {
     const oldIdentity = generateIdentity()
     const newIdentity = generateIdentity()
     const beamId = 'rotator@acme.beam.directory'
@@ -107,6 +119,42 @@ describe('directory identity and verification routes', () => {
 
     expect(rotated.response.status).toBe(200)
     expect(rotated.body.agent.public_key).toBe(newIdentity.publicKey)
+    expect(rotated.body.keyState.active.publicKey).toBe(newIdentity.publicKey)
+    expect(rotated.body.keyState.revoked[0].publicKey).toBe(oldIdentity.publicKey)
+
+    const listed = await jsonRequest(app, `/agents/${encodeURIComponent(beamId)}/keys`)
+    expect(listed.response.status).toBe(200)
+    expect(listed.body.keyState.active.publicKey).toBe(newIdentity.publicKey)
+    expect(listed.body.keyState.revoked).toHaveLength(1)
+
+    const lookup = await jsonRequest(app, `/agents/${encodeURIComponent(beamId)}`)
+    expect(lookup.response.status).toBe(200)
+    expect(lookup.body.keyState.active.publicKey).toBe(newIdentity.publicKey)
+    expect(lookup.body.keyState.revoked[0].publicKey).toBe(oldIdentity.publicKey)
+
+    const revokePayload = {
+      action: 'keys.revoke',
+      beamId,
+      publicKey: oldIdentity.publicKey,
+      timestamp: new Date().toISOString(),
+    }
+    const revokedResponse = await jsonRequest(app, `/agents/${encodeURIComponent(beamId)}/keys/revoke`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        public_key: oldIdentity.publicKey,
+        timestamp: revokePayload.timestamp,
+        signature: signCanonicalPayload(newIdentity.privateKey, revokePayload),
+      }),
+    })
+    expect(revokedResponse.response.status).toBe(409)
+
+    const did = await app.request(`http://localhost/agents/did/${encodeURIComponent('did:beam:acme:rotator')}`)
+    const didBody = await did.json() as { verificationMethod: Array<{ publicKeyMultibase: string; beamStatus?: string }> }
+    expect(did.status).toBe(200)
+    expect(didBody.verificationMethod).toHaveLength(2)
+    expect(didBody.verificationMethod.some((entry) => entry.beamStatus === 'active')).toBe(true)
+    expect(didBody.verificationMethod.some((entry) => entry.beamStatus === 'revoked')).toBe(true)
 
     const revoked = await jsonRequest(app, '/keys/revoked')
     expect(revoked.response.status).toBe(200)

--- a/packages/directory/tests/security-controls.test.ts
+++ b/packages/directory/tests/security-controls.test.ts
@@ -1,0 +1,243 @@
+import { generateKeyPairSync, randomUUID, sign } from 'node:crypto'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAdminSession } from '../src/admin-auth.js'
+import {
+  assignDirectoryRole,
+  createDatabase,
+  listAuditLog,
+  listShieldAuditLog,
+  updatePublicEndpointShieldPolicy,
+} from '../src/db.js'
+import { getLocalDirectoryUrl } from '../src/federation.js'
+import { createApp } from '../src/server.js'
+import type { IntentFrame } from '../src/types.js'
+
+function generateIdentity() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519')
+  return {
+    publicKey: publicKey.export({ type: 'spki', format: 'der' }).toString('base64'),
+    privateKey,
+  }
+}
+
+function buildRegisterBody(beamId: string, publicKey: string) {
+  return {
+    beamId,
+    displayName: beamId.split('@')[0],
+    capabilities: ['agent.ping'],
+    publicKey,
+    visibility: 'public',
+  }
+}
+
+function buildSignedIntent(frame: Omit<IntentFrame, 'signature'>, privateKey: ReturnType<typeof generateIdentity>['privateKey']): IntentFrame {
+  const payload = JSON.stringify({
+    type: 'intent',
+    from: frame.from,
+    to: frame.to,
+    intent: frame.intent,
+    payload: frame.payload,
+    timestamp: frame.timestamp,
+    nonce: frame.nonce,
+  })
+
+  return {
+    ...frame,
+    signature: sign(null, Buffer.from(payload, 'utf8'), privateKey).toString('base64'),
+  }
+}
+
+describe('public endpoint abuse controls', () => {
+  let db: ReturnType<typeof createDatabase>
+
+  beforeEach(() => {
+    vi.stubEnv('JWT_SECRET', 'secret-admin-jwt')
+    db = createDatabase(':memory:')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    db.close()
+  })
+
+  it('updates public endpoint policy and throttles registration bursts by IP', async () => {
+    assignDirectoryRole(db, {
+      userId: 'ops@example.com',
+      role: 'admin',
+      directoryUrl: getLocalDirectoryUrl(),
+    })
+    const adminSession = createAdminSession(db, {
+      email: 'ops@example.com',
+      role: 'admin',
+    })
+    const app = createApp(db)
+
+    const patchResponse = await app.request(new Request('http://localhost/shield/policies/public-endpoints', {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${adminSession.token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ registrationPerMinute: 2 }),
+    }))
+    expect(patchResponse.status).toBe(200)
+
+    const identity = generateIdentity()
+    const headers = {
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.5',
+    }
+
+    const first = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildRegisterBody('alpha@beam.directory', identity.publicKey)),
+    }))
+    const second = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildRegisterBody('beta@beam.directory', identity.publicKey)),
+    }))
+    const third = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildRegisterBody('gamma@beam.directory', identity.publicKey)),
+    }))
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+    expect(third.status).toBe(429)
+
+    const audit = listAuditLog(db, { action: 'public.rate_limit.throttled' })
+    expect(audit[0]?.actor).toBe('ip:203.0.113.5')
+    const shieldAudit = listShieldAuditLog(db, { senderBeamId: 'ip:203.0.113.5' })
+    expect(shieldAudit.length).toBeGreaterThan(0)
+  })
+
+  it('allows trusted IPs to bypass public endpoint throttles', async () => {
+    updatePublicEndpointShieldPolicy(db, {
+      registrationPerMinute: 1,
+      trustedIps: ['203.0.113.44'],
+    })
+
+    const app = createApp(db)
+    const identity = generateIdentity()
+    const headers = {
+      'content-type': 'application/json',
+      'x-forwarded-for': '203.0.113.44',
+    }
+
+    const first = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildRegisterBody('trusted-1@beam.directory', identity.publicKey)),
+    }))
+    const second = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildRegisterBody('trusted-2@beam.directory', identity.publicKey)),
+    }))
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+  })
+
+  it('degrades malformed registration bursts gracefully', async () => {
+    updatePublicEndpointShieldPolicy(db, { registrationPerMinute: 2 })
+    const app = createApp(db)
+
+    const headers = {
+      'content-type': 'application/json',
+      'x-forwarded-for': '198.51.100.10',
+    }
+
+    const first = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: '{"beamId"',
+    }))
+    const second = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: '{"beamId"',
+    }))
+    const third = await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers,
+      body: '{"beamId"',
+    }))
+
+    expect(first.status).toBe(400)
+    expect(second.status).toBe(400)
+    expect(third.status).toBe(429)
+  })
+
+  it('rate limits /intents/send by sender identity across IPs and logs shield blocks', async () => {
+    updatePublicEndpointShieldPolicy(db, {
+      intentSendPerIpPerMinute: 10,
+      intentSendPerSenderPerMinute: 1,
+    })
+    const senderIdentity = generateIdentity()
+    const receiverIdentity = generateIdentity()
+    const app = createApp(db)
+
+    await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(buildRegisterBody('sender@beam.directory', senderIdentity.publicKey)),
+    }))
+    await app.request(new Request('http://localhost/agents/register', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(buildRegisterBody('receiver@beam.directory', receiverIdentity.publicKey)),
+    }))
+
+    db.prepare(`UPDATE agents SET shield_config = ? WHERE beam_id = ?`).run(JSON.stringify({
+      mode: 'closed',
+      allowlist: [],
+      blocklist: [],
+      minTrust: 0.3,
+      rateLimit: 20,
+    }), 'receiver@beam.directory')
+
+    const firstFrame = buildSignedIntent({
+      v: '1',
+      from: 'sender@beam.directory',
+      to: 'receiver@beam.directory',
+      intent: 'agent.ping',
+      payload: { message: 'one' },
+      nonce: randomUUID(),
+      timestamp: new Date().toISOString(),
+    }, senderIdentity.privateKey)
+    const secondFrame = buildSignedIntent({
+      ...firstFrame,
+      payload: { message: 'two' },
+      nonce: randomUUID(),
+      timestamp: new Date(Date.now() + 1_000).toISOString(),
+    }, senderIdentity.privateKey)
+
+    const first = await app.request(new Request('http://localhost/intents/send', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.11',
+      },
+      body: JSON.stringify(firstFrame),
+    }))
+    const second = await app.request(new Request('http://localhost/intents/send', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.12',
+      },
+      body: JSON.stringify(secondFrame),
+    }))
+
+    expect(first.status).toBe(403)
+    expect(second.status).toBe(429)
+
+    const shieldLogs = listShieldAuditLog(db, { senderBeamId: 'sender@beam.directory' })
+    expect(shieldLogs.length).toBeGreaterThan(0)
+    expect(shieldLogs.some((entry) => entry.decision === 'reject')).toBe(true)
+  })
+})

--- a/packages/sdk-python/beam_directory/__init__.py
+++ b/packages/sdk-python/beam_directory/__init__.py
@@ -11,6 +11,8 @@ from .directory import BeamDirectory, BeamDirectoryError
 from .client import BeamClient
 from .frames import create_intent_frame, create_result_frame, validate_intent_frame, validate_result_frame
 from .types import (
+    AgentKeyRecord,
+    AgentKeyState,
     AgentProfile,
     AgentRecord,
     AgentRegistration,
@@ -25,6 +27,7 @@ from .types import (
     DirectoryStats,
     DomainVerification,
     IntentFrame,
+    KeyRevocationResult,
     KeyRotationResult,
     Report,
     ResultFrame,
@@ -42,6 +45,8 @@ __all__ = [
     "validate_intent_frame",
     "validate_result_frame",
     "AgentProfile",
+    "AgentKeyRecord",
+    "AgentKeyState",
     "AgentRecord",
     "AgentRegistration",
     "AgentSearchQuery",
@@ -55,6 +60,7 @@ __all__ = [
     "DirectoryStats",
     "DomainVerification",
     "IntentFrame",
+    "KeyRevocationResult",
     "KeyRotationResult",
     "Report",
     "ResultFrame",

--- a/packages/sdk-python/beam_directory/client.py
+++ b/packages/sdk-python/beam_directory/client.py
@@ -16,6 +16,7 @@ from .frames import create_intent_frame, create_result_frame, validate_intent_fr
 from .identity import BeamIdentity
 from .types import (
     AgentProfile,
+    AgentKeyState,
     AgentRecord,
     BeamClientConfig,
     BeamIdString,
@@ -26,6 +27,7 @@ from .types import (
     DirectoryStats,
     DomainVerification,
     IntentFrame,
+    KeyRevocationResult,
     KeyRotationResult,
     Report,
     ResultFrame,
@@ -33,6 +35,18 @@ from .types import (
 )
 
 IntentHandler = Callable[[IntentFrame], Coroutine[Any, Any, ResultFrame]]
+
+
+def _sort_json(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_sort_json(entry) for entry in value]
+    if isinstance(value, dict):
+        return {key: _sort_json(value[key]) for key in sorted(value.keys())}
+    return value
+
+
+def _canonicalize_json(value: dict[str, Any]) -> str:
+    return json.dumps(_sort_json(value), separators=(",", ":"))
 
 
 class BeamClient:
@@ -102,10 +116,24 @@ class BeamClient:
             if isinstance(new_key_pair, BeamIdentity)
             else BeamIdentity.from_data(new_key_pair)
         )
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime())
+        signature_payload = _canonicalize_json(
+            {
+                "action": "keys.rotate",
+                "beamId": self._identity.beam_id,
+                "newPublicKey": identity.public_key_base64,
+                "timestamp": timestamp,
+            }
+        )
         data = await self._request(
             "POST",
             f"/agents/{self._identity.beam_id}/keys/rotate",
-            json={"publicKey": identity.public_key_base64},
+            json={
+                "new_public_key": identity.public_key_base64,
+                "rotation_proof": self._identity.sign(json.dumps(identity.public_key_base64)),
+                "signature": self._identity.sign(signature_payload),
+                "timestamp": timestamp,
+            },
         )
         self._identity = identity
         return KeyRotationResult.from_dict(
@@ -113,6 +141,34 @@ class BeamClient:
             beam_id=self._identity.beam_id,
             public_key=self._identity.public_key_base64,
         )
+
+    async def list_keys(self) -> AgentKeyState:
+        data = await self._request(
+            "GET",
+            f"/agents/{self._identity.beam_id}/keys",
+        )
+        return AgentKeyState.from_dict(data.get("keyState"))
+
+    async def revoke_key(self, public_key: str) -> KeyRevocationResult:
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime())
+        signature_payload = _canonicalize_json(
+            {
+                "action": "keys.revoke",
+                "beamId": self._identity.beam_id,
+                "publicKey": public_key,
+                "timestamp": timestamp,
+            }
+        )
+        data = await self._request(
+            "POST",
+            f"/agents/{self._identity.beam_id}/keys/revoke",
+            json={
+                "public_key": public_key,
+                "signature": self._identity.sign(signature_payload),
+                "timestamp": timestamp,
+            },
+        )
+        return KeyRevocationResult.from_dict(data, beam_id=self._identity.beam_id)
 
     async def browse(
         self,

--- a/packages/sdk-python/beam_directory/directory.py
+++ b/packages/sdk-python/beam_directory/directory.py
@@ -7,11 +7,14 @@ from typing import Any, Optional
 import httpx
 
 from .types import (
+    AgentKeyState,
     AgentRecord,
     AgentRegistration,
     AgentSearchQuery,
     BeamIdString,
     DirectoryConfig,
+    KeyRevocationResult,
+    KeyRotationResult,
 )
 
 
@@ -102,6 +105,68 @@ class BeamDirectory:
             )
         if res.status_code not in (200, 204, 404):
             self._raise_for_status(res, "Heartbeat failed")
+
+    async def list_keys(self, beam_id: BeamIdString) -> AgentKeyState:
+        async with httpx.AsyncClient() as client:
+            res = await client.get(
+                f"{self._base_url}/agents/{beam_id}/keys",
+                headers=self._headers,
+                timeout=10.0,
+            )
+        self._raise_for_status(res, "List keys failed")
+        body: Any = res.json()
+        return AgentKeyState.from_dict(body.get("keyState") if isinstance(body, dict) else None)
+
+    async def rotate_keys(
+        self,
+        beam_id: BeamIdString,
+        public_key: str,
+        *,
+        rotation_proof: Optional[str] = None,
+        signature: Optional[str] = None,
+        timestamp: Optional[str] = None,
+    ) -> KeyRotationResult:
+        payload: dict[str, Any] = {"new_public_key": public_key}
+        if rotation_proof:
+            payload["rotation_proof"] = rotation_proof
+        if signature:
+            payload["signature"] = signature
+        if timestamp:
+            payload["timestamp"] = timestamp
+
+        async with httpx.AsyncClient() as client:
+            res = await client.post(
+                f"{self._base_url}/agents/{beam_id}/keys/rotate",
+                json=payload,
+                headers=self._headers,
+                timeout=30.0,
+            )
+        self._raise_for_status(res, "Key rotation failed")
+        return KeyRotationResult.from_dict(res.json(), beam_id=beam_id, public_key=public_key)
+
+    async def revoke_key(
+        self,
+        beam_id: BeamIdString,
+        public_key: str,
+        *,
+        signature: Optional[str] = None,
+        timestamp: Optional[str] = None,
+    ) -> KeyRevocationResult:
+        payload: dict[str, Any] = {"public_key": public_key}
+        if signature:
+            payload["signature"] = signature
+        if timestamp:
+            payload["timestamp"] = timestamp
+
+        async with httpx.AsyncClient() as client:
+            res = await client.post(
+                f"{self._base_url}/agents/{beam_id}/keys/revoke",
+                json=payload,
+                headers=self._headers,
+                timeout=30.0,
+            )
+        self._raise_for_status(res, "Key revocation failed")
+        return KeyRevocationResult.from_dict(res.json(), beam_id=beam_id)
 
     # ── Private helpers ────────────────────────────────────────────────────────
 

--- a/packages/sdk-python/beam_directory/types.py
+++ b/packages/sdk-python/beam_directory/types.py
@@ -153,6 +153,7 @@ class AgentRecord(AgentRegistration):
     verified: bool = False
     created_at: str = ""
     last_seen: str = ""
+    key_state: Optional["AgentKeyState"] = None
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "AgentRecord":
@@ -166,6 +167,7 @@ class AgentRecord(AgentRegistration):
             verified=data.get("verified", False),
             created_at=data.get("createdAt", data.get("created_at", "")),
             last_seen=data.get("lastSeen", data.get("last_seen", "")),
+            key_state=AgentKeyState.from_dict(data.get("keyState")) if isinstance(data.get("keyState"), dict) else None,
         )
 
 
@@ -319,6 +321,7 @@ class KeyRotationResult:
     public_key: str
     rotated_at: Optional[str] = None
     previous_key: Optional[str] = None
+    key_state: Optional["AgentKeyState"] = None
 
     @classmethod
     def from_dict(
@@ -332,6 +335,70 @@ class KeyRotationResult:
             public_key=data.get("publicKey", data.get("public_key", public_key)),
             rotated_at=data.get("rotatedAt", data.get("rotated_at")),
             previous_key=data.get("previousKey", data.get("previous_key")),
+            key_state=AgentKeyState.from_dict(data["keyState"]) if isinstance(data.get("keyState"), dict) else None,
+        )
+
+
+@dataclass
+class AgentKeyRecord:
+    beam_id: BeamIdString
+    public_key: str
+    created_at: int
+    revoked_at: Optional[int]
+    status: Literal["active", "revoked"]
+    id: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AgentKeyRecord":
+        return cls(
+            id=data.get("id"),
+            beam_id=data.get("beamId", data.get("beam_id", "")),
+            public_key=data.get("publicKey", data.get("public_key", "")),
+            created_at=data.get("createdAt", data.get("created_at", 0)),
+            revoked_at=data.get("revokedAt", data.get("revoked_at")),
+            status="revoked" if data.get("status") == "revoked" else "active",
+        )
+
+
+@dataclass
+class AgentKeyState:
+    active: Optional[AgentKeyRecord]
+    revoked: list[AgentKeyRecord]
+    keys: list[AgentKeyRecord]
+    total: int
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict[str, Any]]) -> "AgentKeyState":
+        if not isinstance(data, dict):
+            return cls(active=None, revoked=[], keys=[], total=0)
+
+        keys = [AgentKeyRecord.from_dict(entry) for entry in data.get("keys", []) if isinstance(entry, dict)]
+        revoked = [AgentKeyRecord.from_dict(entry) for entry in data.get("revoked", []) if isinstance(entry, dict)]
+        active_raw = data.get("active")
+        active = AgentKeyRecord.from_dict(active_raw) if isinstance(active_raw, dict) else None
+        return cls(
+            active=active,
+            revoked=revoked,
+            keys=keys,
+            total=data.get("total", len(keys)),
+        )
+
+
+@dataclass
+class KeyRevocationResult:
+    beam_id: BeamIdString
+    revoked: bool
+    revoked_key: Optional[AgentKeyRecord]
+    key_state: AgentKeyState
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], beam_id: BeamIdString) -> "KeyRevocationResult":
+        revoked_key = data.get("revokedKey", data.get("revoked_key"))
+        return cls(
+            beam_id=data.get("beamId", data.get("beam_id", beam_id)),
+            revoked=bool(data.get("revoked", False)),
+            revoked_key=AgentKeyRecord.from_dict(revoked_key) if isinstance(revoked_key, dict) else None,
+            key_state=AgentKeyState.from_dict(data.get("keyState")),
         )
 
 

--- a/packages/sdk-python/tests/test_key_lifecycle.py
+++ b/packages/sdk-python/tests/test_key_lifecycle.py
@@ -1,0 +1,151 @@
+import json
+
+import pytest
+
+from beam_directory.client import BeamClient, _canonicalize_json
+from beam_directory.identity import BeamIdentity
+
+
+@pytest.mark.asyncio
+async def test_rotate_keys_signs_canonical_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    current_identity = BeamIdentity.generate("rotator", "acme")
+    next_identity = BeamIdentity.generate("rotator", "acme")
+    client = BeamClient(identity=current_identity, directory_url="https://api.beam.directory")
+    captured: dict[str, object] = {}
+
+    async def fake_request(method: str, path: str, *, params=None, json=None):  # type: ignore[no-untyped-def]
+        captured["method"] = method
+        captured["path"] = path
+        captured["json"] = json
+        return {
+            "beamId": current_identity.beam_id,
+            "publicKey": next_identity.public_key_base64,
+            "keyState": {
+                "active": {
+                    "beamId": current_identity.beam_id,
+                    "publicKey": next_identity.public_key_base64,
+                    "createdAt": 1,
+                    "revokedAt": None,
+                    "status": "active",
+                },
+                "revoked": [],
+                "keys": [],
+                "total": 1,
+            },
+        }
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.rotate_keys(next_identity)
+
+    payload = captured["json"]
+    assert isinstance(payload, dict)
+    assert payload["new_public_key"] == next_identity.public_key_base64
+    assert BeamIdentity.verify(
+        _canonicalize_json(
+            {
+                "action": "keys.rotate",
+                "beamId": current_identity.beam_id,
+                "newPublicKey": next_identity.public_key_base64,
+                "timestamp": payload["timestamp"],
+            }
+        ),
+        str(payload["signature"]),
+        current_identity.public_key_base64,
+    )
+    assert result.key_state is not None
+    assert result.key_state.active is not None
+    assert result.key_state.active.public_key == next_identity.public_key_base64
+
+
+@pytest.mark.asyncio
+async def test_list_and_revoke_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    identity = BeamIdentity.generate("guardian", "acme")
+    retired_identity = BeamIdentity.generate("guardian", "acme")
+    client = BeamClient(identity=identity, directory_url="https://api.beam.directory")
+    responses = iter(
+        [
+            {
+                "keyState": {
+                    "active": {
+                        "beamId": identity.beam_id,
+                        "publicKey": identity.public_key_base64,
+                        "createdAt": 1,
+                        "revokedAt": None,
+                        "status": "active",
+                    },
+                    "revoked": [
+                        {
+                            "beamId": identity.beam_id,
+                            "publicKey": retired_identity.public_key_base64,
+                            "createdAt": 0,
+                            "revokedAt": 2,
+                            "status": "revoked",
+                        }
+                    ],
+                    "keys": [],
+                    "total": 2,
+                }
+            },
+            {
+                "beamId": identity.beam_id,
+                "revoked": True,
+                "revokedKey": {
+                    "beamId": identity.beam_id,
+                    "publicKey": retired_identity.public_key_base64,
+                    "createdAt": 0,
+                    "revokedAt": 2,
+                    "status": "revoked",
+                },
+                "keyState": {
+                    "active": {
+                        "beamId": identity.beam_id,
+                        "publicKey": identity.public_key_base64,
+                        "createdAt": 1,
+                        "revokedAt": None,
+                        "status": "active",
+                    },
+                    "revoked": [
+                        {
+                            "beamId": identity.beam_id,
+                            "publicKey": retired_identity.public_key_base64,
+                            "createdAt": 0,
+                            "revokedAt": 2,
+                            "status": "revoked",
+                        }
+                    ],
+                    "keys": [],
+                    "total": 2,
+                },
+            },
+        ]
+    )
+    captured: list[dict[str, object]] = []
+
+    async def fake_request(method: str, path: str, *, params=None, json=None):  # type: ignore[no-untyped-def]
+        captured.append({"method": method, "path": path, "json": json})
+        return next(responses)
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    key_state = await client.list_keys()
+    result = await client.revoke_key(retired_identity.public_key_base64)
+
+    assert key_state.revoked[0].public_key == retired_identity.public_key_base64
+    revoke_payload = captured[1]["json"]
+    assert isinstance(revoke_payload, dict)
+    assert BeamIdentity.verify(
+        _canonicalize_json(
+            {
+                "action": "keys.revoke",
+                "beamId": identity.beam_id,
+                "publicKey": retired_identity.public_key_base64,
+                "timestamp": revoke_payload["timestamp"],
+            }
+        ),
+        str(revoke_payload["signature"]),
+        identity.public_key_base64,
+    )
+    assert result.revoked is True
+    assert result.revoked_key is not None
+    assert result.revoked_key.public_key == retired_identity.public_key_base64

--- a/packages/sdk-typescript/src/client.ts
+++ b/packages/sdk-typescript/src/client.ts
@@ -1,10 +1,11 @@
 import { BeamIdentity } from './identity.js'
 import { BeamDirectory } from './directory.js'
 import { BeamCredentialsClient, BeamDID } from './did.js'
-import { createIntentFrame, createResultFrame, signFrame, validateIntentFrame } from './frames.js'
+import { canonicalizeFrame, createIntentFrame, createResultFrame, signFrame, validateIntentFrame } from './frames.js'
 import { beamIdFromApiKey } from './api-key.js'
 import type {
   AgentProfile,
+  AgentKeyState,
   AgentRecord,
   BeamClientConfig,
   BeamIdString,
@@ -15,6 +16,7 @@ import type {
   DomainVerification,
   IntentFrame,
   KeyRotationResult,
+  KeyRevocationResult,
   Report,
   ResultFrame,
   BeamIdentityData,
@@ -140,10 +142,42 @@ export class BeamClient {
     }
 
     const identity = newKeyPair instanceof BeamIdentity ? newKeyPair : BeamIdentity.fromData(newKeyPair)
+    const timestamp = new Date().toISOString()
+    const signaturePayload = canonicalizeFrame({
+      action: 'keys.rotate',
+      beamId: this._beamId,
+      newPublicKey: identity.publicKeyBase64,
+      timestamp,
+    })
     const rotationProof = this._identity ? this._identity.sign(JSON.stringify(identity.publicKeyBase64)) : undefined
-    const result = await this._directory.rotateKeys(this._beamId, identity.publicKeyBase64, rotationProof)
+    const signature = this._identity ? this._identity.sign(signaturePayload) : undefined
+    const result = await this._directory.rotateKeys(this._beamId, identity.publicKeyBase64, {
+      rotationProof,
+      signature,
+      timestamp,
+    })
     this._identity = identity
     return result
+  }
+
+  async listKeys(): Promise<AgentKeyState> {
+    return this._directory.listKeys(this._beamId)
+  }
+
+  async revokeKey(publicKey: string): Promise<KeyRevocationResult> {
+    if (!this._identity && !this._apiKey) {
+      throw new Error('revokeKey() requires identity or apiKey auth')
+    }
+
+    const timestamp = new Date().toISOString()
+    const signaturePayload = canonicalizeFrame({
+      action: 'keys.revoke',
+      beamId: this._beamId,
+      publicKey,
+      timestamp,
+    })
+    const signature = this._identity ? this._identity.sign(signaturePayload) : undefined
+    return this._directory.revokeKey(this._beamId, publicKey, { signature, timestamp })
   }
 
   async browse(page = 1, filters: BrowseFilters = {}): Promise<BrowseResult> {

--- a/packages/sdk-typescript/src/directory.ts
+++ b/packages/sdk-typescript/src/directory.ts
@@ -1,5 +1,7 @@
 import type {
   AgentProfile,
+  AgentKeyRecord,
+  AgentKeyState,
   AgentRecord,
   AgentRegistration,
   AgentSearchQuery,
@@ -10,6 +12,7 @@ import type {
   DirectoryStats,
   DomainVerification,
   KeyRotationResult,
+  KeyRevocationResult,
   Delegation,
   Report,
   VerificationTier,
@@ -68,6 +71,7 @@ function normalizeAgent(raw: Record<string, unknown>): AgentRecord {
     verified: (raw.verified ?? false) as boolean,
     createdAt: (raw.createdAt ?? raw.created_at ?? '') as string,
     lastSeen: (raw.lastSeen ?? raw.last_seen ?? '') as string,
+    keyState: normalizeKeyState(raw['keyState']),
   }
 }
 
@@ -116,6 +120,59 @@ function normalizeRotation(raw: Record<string, unknown>, beamId: BeamIdString, p
     publicKey: getString(raw, 'publicKey', 'public_key') ?? publicKey,
     rotatedAt: getString(raw, 'rotatedAt', 'rotated_at'),
     previousKey: getString(raw, 'previousKey', 'previous_key'),
+    keyState: normalizeKeyState(raw['keyState']) ?? normalizeKeyState((raw['agent'] as Record<string, unknown> | undefined)?.['keyState']),
+  }
+}
+
+function normalizeKey(raw: unknown): AgentKeyRecord | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+
+  const value = raw as Record<string, unknown>
+  return {
+    id: getNumber(value, 'id'),
+    beamId: ((getString(value, 'beamId', 'beam_id') ?? '') || 'unknown@beam.directory') as BeamIdString,
+    publicKey: getString(value, 'publicKey', 'public_key') ?? '',
+    createdAt: getNumber(value, 'createdAt', 'created_at') ?? 0,
+    revokedAt: getNumber(value, 'revokedAt', 'revoked_at') ?? null,
+    status: (getString(value, 'status') === 'revoked' ? 'revoked' : 'active'),
+  }
+}
+
+function normalizeKeyState(raw: unknown): AgentKeyState | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined
+  }
+
+  const value = raw as Record<string, unknown>
+  const keys = Array.isArray(value['keys'])
+    ? value['keys'].map(normalizeKey).filter((entry): entry is AgentKeyRecord => entry !== null)
+    : []
+  const revoked = Array.isArray(value['revoked'])
+    ? value['revoked'].map(normalizeKey).filter((entry): entry is AgentKeyRecord => entry !== null)
+    : []
+  const active = normalizeKey(value['active'])
+
+  return {
+    active,
+    revoked,
+    keys,
+    total: getNumber(value, 'total') ?? keys.length,
+  }
+}
+
+function normalizeRevocation(raw: Record<string, unknown>, beamId: BeamIdString): KeyRevocationResult {
+  return {
+    beamId: (getString(raw, 'beamId', 'beam_id') as BeamIdString | undefined) ?? beamId,
+    revoked: getBoolean(raw, 'revoked') ?? false,
+    revokedKey: normalizeKey(raw['revokedKey'] ?? raw['revoked_key']),
+    keyState: normalizeKeyState(raw['keyState']) ?? {
+      active: null,
+      revoked: [],
+      keys: [],
+      total: 0,
+    },
   }
 }
 
@@ -285,15 +342,47 @@ export class BeamDirectory {
     return normalizeVerification(body)
   }
 
-  async rotateKeys(beamId: BeamIdString, publicKey: string, rotationProof?: string): Promise<KeyRotationResult> {
+  async listKeys(beamId: BeamIdString): Promise<AgentKeyState> {
+    const body = await this.request<Record<string, unknown>>(`/agents/${encodeURIComponent(beamId)}/keys`)
+    return normalizeKeyState(body['keyState']) ?? {
+      active: null,
+      revoked: [],
+      keys: [],
+      total: 0,
+    }
+  }
+
+  async rotateKeys(
+    beamId: BeamIdString,
+    publicKey: string,
+    options: { rotationProof?: string; signature?: string; timestamp?: string } = {},
+  ): Promise<KeyRotationResult> {
     const body = await this.request<Record<string, unknown>>(`/agents/${encodeURIComponent(beamId)}/keys/rotate`, {
       method: 'POST',
       body: JSON.stringify({
         new_public_key: publicKey,
-        ...(rotationProof ? { rotation_proof: rotationProof } : {}),
+        ...(options.rotationProof ? { rotation_proof: options.rotationProof } : {}),
+        ...(options.signature ? { signature: options.signature } : {}),
+        ...(options.timestamp ? { timestamp: options.timestamp } : {}),
       }),
     })
     return normalizeRotation(body, beamId, publicKey)
+  }
+
+  async revokeKey(
+    beamId: BeamIdString,
+    publicKey: string,
+    options: { signature?: string; timestamp?: string } = {},
+  ): Promise<KeyRevocationResult> {
+    const body = await this.request<Record<string, unknown>>(`/agents/${encodeURIComponent(beamId)}/keys/revoke`, {
+      method: 'POST',
+      body: JSON.stringify({
+        public_key: publicKey,
+        ...(options.signature ? { signature: options.signature } : {}),
+        ...(options.timestamp ? { timestamp: options.timestamp } : {}),
+      }),
+    })
+    return normalizeRevocation(body, beamId)
   }
 
   async delegate(sourceBeamId: BeamIdString, targetBeamId: BeamIdString, scope: string, expiresIn?: number): Promise<Delegation> {

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -15,6 +15,8 @@ export {
 } from './frames.js'
 export type {
   AgentProfile,
+  AgentKeyRecord,
+  AgentKeyState,
   AgentRegistration,
   AgentRecord,
   AgentSearchQuery,
@@ -30,6 +32,7 @@ export type {
   DomainVerification,
   IntentFrame,
   KeyRotationResult,
+  KeyRevocationResult,
   Report,
   ResultFrame,
   VerificationTier,

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -51,6 +51,7 @@ export interface AgentRecord extends AgentRegistration {
   verified: boolean
   createdAt: string
   lastSeen: string
+  keyState?: AgentKeyState
 }
 
 export interface AgentProfile extends AgentRecord {
@@ -122,6 +123,30 @@ export interface KeyRotationResult {
   publicKey: string
   rotatedAt?: string
   previousKey?: string
+  keyState?: AgentKeyState
+}
+
+export interface AgentKeyRecord {
+  id?: number
+  beamId: BeamIdString
+  publicKey: string
+  createdAt: number
+  revokedAt: number | null
+  status: 'active' | 'revoked'
+}
+
+export interface AgentKeyState {
+  active: AgentKeyRecord | null
+  revoked: AgentKeyRecord[]
+  keys: AgentKeyRecord[]
+  total: number
+}
+
+export interface KeyRevocationResult {
+  beamId: BeamIdString
+  revoked: boolean
+  revokedKey: AgentKeyRecord | null
+  keyState: AgentKeyState
 }
 
 export interface DirectoryConfig {

--- a/packages/sdk-typescript/tests/key-lifecycle.test.ts
+++ b/packages/sdk-typescript/tests/key-lifecycle.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { BeamClient, BeamDirectory, BeamIdentity, canonicalizeFrame } from '../src/index.js'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('SDK key lifecycle', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('signs key rotation payloads and normalizes returned key state', async () => {
+    const currentIdentity = BeamIdentity.generate({ agentName: 'rotator', orgName: 'acme' })
+    const nextIdentity = BeamIdentity.generate({ agentName: 'rotator', orgName: 'acme' })
+
+    const fetchMock = vi.fn(async () => jsonResponse({
+      beamId: currentIdentity.beamId,
+      previousKey: currentIdentity.publicKeyBase64,
+      keyState: {
+        active: {
+          beamId: currentIdentity.beamId,
+          publicKey: nextIdentity.publicKeyBase64,
+          createdAt: Date.now(),
+          revokedAt: null,
+          status: 'active',
+        },
+        revoked: [{
+          beamId: currentIdentity.beamId,
+          publicKey: currentIdentity.publicKeyBase64,
+          createdAt: Date.now() - 1_000,
+          revokedAt: Date.now(),
+          status: 'revoked',
+        }],
+        keys: [],
+        total: 1,
+      },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const client = new BeamClient({
+      identity: currentIdentity.export(),
+      directoryUrl: 'https://api.beam.directory',
+    })
+
+    const result = await client.rotateKeys(nextIdentity.export())
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as Record<string, string>
+    expect(body['new_public_key']).toBe(nextIdentity.publicKeyBase64)
+    expect(body['rotation_proof']).toBeTypeOf('string')
+    expect(body['signature']).toBeTypeOf('string')
+    expect(body['timestamp']).toBeTypeOf('string')
+    expect(BeamIdentity.verify(
+      canonicalizeFrame({
+        action: 'keys.rotate',
+        beamId: currentIdentity.beamId,
+        newPublicKey: nextIdentity.publicKeyBase64,
+        timestamp: body['timestamp'],
+      }),
+      body['signature'] ?? '',
+      currentIdentity.publicKeyBase64,
+    )).toBe(true)
+    expect(result.keyState?.active?.publicKey).toBe(nextIdentity.publicKeyBase64)
+  })
+
+  it('lists keys and signs revocation payloads', async () => {
+    const identity = BeamIdentity.generate({ agentName: 'guardian', orgName: 'acme' })
+    const retiredIdentity = BeamIdentity.generate({ agentName: 'guardian', orgName: 'acme' })
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/keys')) {
+        return jsonResponse({
+          keyState: {
+            active: {
+              beamId: identity.beamId,
+              publicKey: identity.publicKeyBase64,
+              createdAt: Date.now(),
+              revokedAt: null,
+              status: 'active',
+            },
+            revoked: [{
+              beamId: identity.beamId,
+              publicKey: retiredIdentity.publicKeyBase64,
+              createdAt: Date.now() - 1_000,
+              revokedAt: Date.now(),
+              status: 'revoked',
+            }],
+            keys: [{
+              beamId: identity.beamId,
+              publicKey: identity.publicKeyBase64,
+              createdAt: Date.now(),
+              revokedAt: null,
+              status: 'active',
+            }],
+            total: 2,
+          },
+        })
+      }
+
+      return jsonResponse({
+        beamId: identity.beamId,
+        revoked: true,
+        revokedKey: {
+          beamId: identity.beamId,
+          publicKey: retiredIdentity.publicKeyBase64,
+          createdAt: Date.now() - 1_000,
+          revokedAt: Date.now(),
+          status: 'revoked',
+        },
+        keyState: {
+          active: {
+            beamId: identity.beamId,
+            publicKey: identity.publicKeyBase64,
+            createdAt: Date.now(),
+            revokedAt: null,
+            status: 'active',
+          },
+          revoked: [{
+            beamId: identity.beamId,
+            publicKey: retiredIdentity.publicKeyBase64,
+            createdAt: Date.now() - 1_000,
+            revokedAt: Date.now(),
+            status: 'revoked',
+          }],
+          keys: [],
+          total: 2,
+        },
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const directory = new BeamDirectory({
+      baseUrl: 'https://api.beam.directory',
+    })
+    const keyState = await directory.listKeys(identity.beamId)
+    expect(keyState.revoked[0]?.publicKey).toBe(retiredIdentity.publicKeyBase64)
+
+    const client = new BeamClient({
+      identity: identity.export(),
+      directoryUrl: 'https://api.beam.directory',
+    })
+    const result = await client.revokeKey(retiredIdentity.publicKeyBase64)
+
+    const [, init] = fetchMock.mock.calls[1] as [string, RequestInit]
+    const body = JSON.parse(String(init.body)) as Record<string, string>
+    expect(BeamIdentity.verify(
+      canonicalizeFrame({
+        action: 'keys.revoke',
+        beamId: identity.beamId,
+        publicKey: retiredIdentity.publicKeyBase64,
+        timestamp: body['timestamp'],
+      }),
+      body['signature'] ?? '',
+      identity.publicKeyBase64,
+    )).toBe(true)
+    expect(result.revoked).toBe(true)
+    expect(result.revokedKey?.publicKey).toBe(retiredIdentity.publicKeyBase64)
+  })
+})


### PR DESCRIPTION
## Summary
- add agent key rotation, revocation, DID key inventories, and CLI/SDK support for key lifecycle flows
- add configurable public Beam Shield endpoint policies with IP and sender throttling plus audit/shield logging
- document the new key-state and abuse-control APIs and cover them with directory, SDK, Python, and E2E tests

## Verification
- npm run build
- npm test
- npm run test:e2e
- python3 -m venv /tmp/beam-sdk-venv && source /tmp/beam-sdk-venv/bin/activate && python -m pip install -q --upgrade pip && python -m pip install -q -e 'packages/sdk-python[dev]' && python -m pytest packages/sdk-python/tests
- cd docs && npm run build

Closes #10
Closes #11