### PR TITLE
Ship operator-ready observability UX

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         { text: 'Federation', link: '/guide/federation' },
         { text: 'Intent Lifecycle', link: '/guide/intent-lifecycle' },
         { text: 'Restart Recovery', link: '/guide/restart-recovery' },
+        { text: 'Operator Observability', link: '/guide/operator-observability' },
         { text: 'Consumer IDs', link: '/guide/consumer-ids' },
         { text: 'Core Concepts', link: '/guide/concepts' },
         { text: 'Self-Hosting', link: '/guide/self-hosting' }

--- a/docs/guide/hosted-quickstart.md
+++ b/docs/guide/hosted-quickstart.md
@@ -124,6 +124,8 @@ If you want Dead Letter operations in the dashboard, open `Settings` and paste:
 - Bus URL: `http://localhost:8420`
 - Bus API key: the `BEAM_BUS_API_KEY` value from `ops/quickstart/.env`
 
+For the full operator workflow after login, including alert investigation, exports, and prune safeguards, continue with the [Operator Observability](/guide/operator-observability) guide.
+
 ## 7. Tear Down
 
 ```bash

--- a/docs/guide/operator-observability.md
+++ b/docs/guide/operator-observability.md
@@ -1,0 +1,183 @@
+# Operator Observability
+
+This guide is for Beam operators who need to respond to incidents without reading the source code first.
+
+It covers:
+
+- admin setup and login
+- the alert -> trace -> audit workflow
+- exports and retention controls
+- expected operational guardrails
+
+## Roles
+
+Beam uses short-lived admin sessions for the dashboard and observability APIs.
+
+- `admin`: full read/write access, including prune
+- `operator`: read-only observability access
+- `viewer`: read-only access for audits, traces, and dashboards
+
+Bootstrap roles with environment variables on the directory:
+
+```bash
+BEAM_ADMIN_EMAILS=ops@example.com
+BEAM_OPERATOR_EMAILS=incident@example.com
+BEAM_VIEWER_EMAILS=stakeholder@example.com
+```
+
+## Required Admin Setup
+
+The directory must know how to issue and verify admin sessions:
+
+```bash
+JWT_SECRET=replace-me
+BEAM_DASHBOARD_URL=https://dashboard.example.com
+```
+
+For production magic-link delivery, configure either SMTP or Resend:
+
+```bash
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=beam
+SMTP_PASS=replace-me
+SMTP_FROM=beam@example.com
+```
+
+or:
+
+```bash
+RESEND_API_KEY=re_xxx
+```
+
+Local development can skip SMTP and Resend. On `localhost`, the directory returns the dev callback URL directly after a magic-link request.
+
+## Sign In
+
+Open the dashboard login page and request a magic link for an authorized email:
+
+```bash
+POST /admin/auth/magic-link
+```
+
+The dashboard exchanges the token through:
+
+```bash
+POST /admin/auth/verify
+GET /admin/auth/session
+POST /admin/auth/logout
+```
+
+The browser stores only the short-lived session token. The old static pasted admin key flow is no longer used.
+
+## Incident Workflow
+
+### 1. Start From Alerts
+
+Use the `Alerts` page first. Each card now shows:
+
+- current metric value
+- threshold value
+- why Beam raised the alert
+- why the current severity is `warning` or `critical`
+- direct investigation links
+
+### 2. Jump Into A Trace
+
+Every alert exposes at least one investigation path inside the dashboard:
+
+- filtered intent feed
+- direct sample trace
+- matching audit history
+- specialized dashboards such as `Errors` or `Federation`
+
+The trace page is the fastest way to answer:
+
+- what happened to this nonce
+- which lifecycle stage it reached
+- whether Shield intervened
+- whether related audit events exist
+
+### 3. Confirm With Audit History
+
+Use the `Audit` page when you need control-plane context:
+
+- federation relay actions
+- admin and operator actions
+- prune history
+- role or control changes
+
+Deep links from alerts and traces open the audit view with the relevant nonce, target, or query already applied.
+
+## Exports
+
+Exports are read-only snapshots. Use them when you need to:
+
+- hand off an incident to another team
+- preserve evidence before cleanup
+- compare windows offline
+
+Available datasets:
+
+- `intents`
+- `audit`
+- `errors`
+- `federation`
+- `alerts`
+
+Formats:
+
+- `json`
+- `csv`
+- `ndjson`
+
+Exports respect the selected alert window and never mutate retained data.
+
+## Retention And Prune
+
+Retention is controlled from the `Alerts` page.
+
+Prune is intentionally guarded:
+
+1. choose the dataset
+2. choose the day threshold
+3. run an admin-only preview
+4. type the dataset name
+5. type the exact confirmation phrase
+6. prune
+
+The API enforces the confirmation fields server-side, not just in the browser UI.
+
+Important behavior:
+
+- pruning `intents` also removes matching `traces`
+- prune is irreversible
+- export first if you need a handoff artifact
+- every successful prune is written to the audit log as `observability.prune`
+
+## Message Bus Dead Letters
+
+If you want dead-letter operations in the dashboard, configure the message bus in `Settings`:
+
+- Bus URL
+- `BEAM_BUS_API_KEY`
+
+This enables:
+
+- dead-letter inspection
+- requeue actions
+- queue health visibility
+
+## Operational Expectations
+
+Use Beam observability as a triage surface, not just a chart wall.
+
+The normal operator loop is:
+
+1. open alert
+2. inspect trace
+3. confirm audit history
+4. export if needed
+5. prune only after evidence is preserved
+
+If you need a full local environment, start with the [Hosted Quickstart](/guide/hosted-quickstart).

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -20,6 +20,10 @@ npm run dev --workspace=packages/dashboard
 
 For a full local operator stack, use the hosted quickstart in [`ops/quickstart`](../../ops/quickstart) and then open `http://localhost:5173/login`.
 
+Admin setup, login flow, exports, and prune safety are documented in the operator guide:
+
+- [docs.beam.directory/guide/operator-observability](https://docs.beam.directory/guide/operator-observability)
+
 ## Pages
 
 - `/` overview with live stats from `GET /agents/stats`

--- a/packages/dashboard/src/components/AlertCard.tsx
+++ b/packages/dashboard/src/components/AlertCard.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router-dom'
+import type { AlertItem } from '../lib/api'
+import { formatIntentLifecycleLabel } from '../lib/intent-lifecycle'
+import {
+  alertSeverityColor,
+  cn,
+  formatDateTime,
+  formatLatency,
+  formatNumber,
+  formatPercent,
+  truncateBeamId,
+} from '../lib/utils'
+import { StatusPill } from './Observability'
+
+function formatAlertMetric(alert: AlertItem, value: number) {
+  switch (alert.valueUnit) {
+    case 'ratio':
+      return formatPercent(value, 0)
+    case 'ms':
+      return formatLatency(value)
+    default:
+      return formatNumber(value)
+  }
+}
+
+export default function AlertCard({
+  alert,
+  compact = false,
+}: {
+  alert: AlertItem
+  compact?: boolean
+}) {
+  const visibleLinks = alert.links.slice(0, compact ? 2 : 3)
+  const visibleSamples = alert.sampleTraces.slice(0, compact ? 1 : 3)
+
+  return (
+    <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
+          {alert.severity}
+        </span>
+        <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
+        <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(alert.startedAt)}</span>
+      </div>
+
+      <div className="mt-2 text-sm font-medium">{alert.title}</div>
+      <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{alert.message}</div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-xl bg-slate-50 px-3 py-3 dark:bg-slate-950">
+          <div className="text-[11px] uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">Current value</div>
+          <div className="mt-1 text-lg font-semibold">{formatAlertMetric(alert, alert.value)}</div>
+        </div>
+        <div className="rounded-xl bg-slate-50 px-3 py-3 dark:bg-slate-950">
+          <div className="text-[11px] uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">Threshold</div>
+          <div className="mt-1 text-lg font-semibold">{formatAlertMetric(alert, alert.threshold)}</div>
+        </div>
+      </div>
+
+      <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">{alert.thresholdExplanation}</div>
+      <div className="mt-1 text-xs font-medium text-slate-700 dark:text-slate-200">{alert.severityReason}</div>
+
+      {visibleSamples.length > 0 ? (
+        <div className="mt-4">
+          <div className="text-[11px] uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">Recent traces</div>
+          <div className="mt-2 space-y-2">
+            {visibleSamples.map((sample) => (
+              <div key={sample.nonce} className="rounded-xl border border-slate-200 px-3 py-3 dark:border-slate-800">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Link className="font-mono text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/intents/${encodeURIComponent(sample.nonce)}?alert=${encodeURIComponent(alert.id)}`}>
+                    {truncateBeamId(sample.nonce, compact ? 22 : 28)}
+                  </Link>
+                  <StatusPill label={formatIntentLifecycleLabel(sample.status)} />
+                  {sample.errorCode ? <StatusPill label={sample.errorCode} tone="critical" /> : null}
+                </div>
+                {!compact ? (
+                  <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                    {sample.intentType} · {truncateBeamId(sample.from, 26)} → {truncateBeamId(sample.to, 26)} · {formatDateTime(sample.requestedAt)}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {visibleLinks.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {visibleLinks.map((link) => (
+            <Link
+              key={`${alert.id}-${link.label}-${link.href}`}
+              className={cn(
+                'rounded-full border px-3 py-1.5 text-sm transition-colors',
+                link.surface === 'trace' && 'border-orange-200 text-orange-700 hover:border-orange-300 hover:bg-orange-50 dark:border-orange-500/30 dark:text-orange-300 dark:hover:bg-orange-500/10',
+                link.surface !== 'trace' && 'border-slate-200 text-slate-700 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900',
+              )}
+              to={link.href}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -3,6 +3,8 @@ export type AlertSeverity = 'info' | 'warning' | 'critical'
 export type ExportDataset = 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
 export type ExportFormat = 'json' | 'csv' | 'ndjson'
 export type IntentLifecycleStatus = 'received' | 'validated' | 'queued' | 'dispatched' | 'delivered' | 'acked' | 'failed' | 'dead_letter'
+export type AlertMetricUnit = 'ratio' | 'ms' | 'count'
+export type AlertLinkSurface = 'trace' | 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
 
 export interface DirectoryAgent {
   beamId: string
@@ -168,7 +170,28 @@ export interface AlertItem {
   metric: string
   value: number
   threshold: number
+  valueUnit: AlertMetricUnit
   startedAt: string
+  thresholdExplanation: string
+  severityReason: string
+  links: AlertLink[]
+  sampleTraces: AlertTraceSample[]
+}
+
+export interface AlertLink {
+  label: string
+  href: string
+  surface: AlertLinkSurface
+}
+
+export interface AlertTraceSample {
+  nonce: string
+  from: string
+  to: string
+  intentType: string
+  requestedAt: string
+  status: IntentLifecycleStatus
+  errorCode: string | null
 }
 
 export interface OverviewTimelinePoint {
@@ -349,17 +372,20 @@ export interface AlertsResponse {
   alerts: AlertItem[]
   retention: {
     defaultDays: number
+    minimumDays: number
+    confirmPhrasePrefix: string
     datasets: string[]
+    details: ObservabilityDatasetInfo[]
   }
-  exports: Array<{
-    dataset: string
-    formats: string[]
-  }>
+  exports: ExportCatalogEntry[]
 }
 
 export interface RetentionResponse {
   defaultDays: number
+  minimumDays: number
+  confirmPhrasePrefix: string
   datasets: string[]
+  details: ObservabilityDatasetInfo[]
 }
 
 export interface PruneResponse {
@@ -368,6 +394,26 @@ export interface PruneResponse {
   deleted: number
   intents?: number
   traces?: number
+}
+
+export interface PrunePreviewResponse {
+  dataset: string
+  olderThanDays: number
+  wouldDelete: number
+  intents?: number
+  traces?: number
+}
+
+export interface ObservabilityDatasetInfo {
+  name: string
+  description: string
+  cascadesTo?: string[]
+}
+
+export interface ExportCatalogEntry {
+  dataset: string
+  formats: string[]
+  description: string
 }
 
 export interface RegisterAgentInput {
@@ -833,9 +879,17 @@ export const directoryApi = {
   getErrorAnalytics: (hours = 24 * 7) => request<ErrorAnalyticsResponse>(`/observability/errors?hours=${hours}`, undefined, { admin: true }),
   getAlerts: (hours = 24) => request<AlertsResponse>(`/observability/alerts?hours=${hours}`, undefined, { admin: true }),
   getRetention: () => request<RetentionResponse>('/observability/retention', undefined, { admin: true }),
-  pruneObservability: (dataset: string, olderThanDays: number) => request<PruneResponse>('/observability/prune', {
+  previewPruneObservability: (dataset: string, olderThanDays: number) => request<PrunePreviewResponse>(`/observability/prune-preview${buildQuery({
+    dataset,
+    olderThanDays,
+  })}`, undefined, { admin: true }),
+  pruneObservability: (
+    dataset: string,
+    olderThanDays: number,
+    confirmation: { confirmDataset: string; confirmPhrase: string },
+  ) => request<PruneResponse>('/observability/prune', {
     method: 'POST',
-    body: JSON.stringify({ dataset, olderThanDays }),
+    body: JSON.stringify({ dataset, olderThanDays, ...confirmation }),
   }, { admin: true }),
   downloadObservabilityExport: async (dataset: ExportDataset, format: ExportFormat, params?: {
     hours?: number

--- a/packages/dashboard/src/pages/AlertsPage.tsx
+++ b/packages/dashboard/src/pages/AlertsPage.tsx
@@ -1,8 +1,17 @@
-import { useEffect, useState } from 'react'
-import { ApiError, directoryApi, type AlertsResponse, type ExportDataset, type ExportFormat } from '../lib/api'
+import { useEffect, useMemo, useState } from 'react'
+import AlertCard from '../components/AlertCard'
+import {
+  ApiError,
+  directoryApi,
+  type AlertsResponse,
+  type ExportDataset,
+  type ExportFormat,
+  type ObservabilityDatasetInfo,
+  type PrunePreviewResponse,
+} from '../lib/api'
 import { EmptyPanel, PageHeader } from '../components/Observability'
 import { useAdminAuth } from '../lib/admin-auth'
-import { alertSeverityColor, cn, downloadBlob, formatDateTime } from '../lib/utils'
+import { downloadBlob, formatDateTime, formatNumber } from '../lib/utils'
 
 const EXPORT_FORMATS: ExportFormat[] = ['json', 'csv', 'ndjson']
 
@@ -14,6 +23,10 @@ export default function AlertsPage() {
   const [error, setError] = useState<string | null>(null)
   const [pruneDataset, setPruneDataset] = useState('intents')
   const [pruneDays, setPruneDays] = useState(30)
+  const [prunePreview, setPrunePreview] = useState<PrunePreviewResponse | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [confirmDataset, setConfirmDataset] = useState('')
+  const [confirmPhrase, setConfirmPhrase] = useState('')
   const [actionState, setActionState] = useState<string | null>(null)
 
   async function load(currentHours: number) {
@@ -22,6 +35,11 @@ export default function AlertsPage() {
       const response = await directoryApi.getAlerts(currentHours)
       setData(response)
       setPruneDays(response.retention.defaultDays)
+      setPruneDataset((current) => (
+        response.retention.datasets.includes(current)
+          ? current
+          : response.retention.datasets[0] ?? 'intents'
+      ))
       setError(null)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load alerts')
@@ -34,6 +52,23 @@ export default function AlertsPage() {
     void load(hours)
   }, [hours])
 
+  useEffect(() => {
+    setPrunePreview(null)
+    setConfirmDataset('')
+    setConfirmPhrase('')
+  }, [pruneDataset, pruneDays])
+
+  const retentionMeta = useMemo<ObservabilityDatasetInfo | null>(() => {
+    return data?.retention.details.find((entry) => entry.name === pruneDataset) ?? null
+  }, [data, pruneDataset])
+
+  const expectedPhrase = `${data?.retention.confirmPhrasePrefix ?? 'prune'} ${pruneDataset}`
+  const pruneReady = session?.role === 'admin'
+    && prunePreview?.dataset === pruneDataset
+    && prunePreview.olderThanDays === pruneDays
+    && confirmDataset === pruneDataset
+    && confirmPhrase === expectedPhrase
+
   async function handleExport(dataset: ExportDataset, format: ExportFormat) {
     try {
       setActionState(`Exporting ${dataset}.${format}…`)
@@ -45,16 +80,40 @@ export default function AlertsPage() {
     }
   }
 
-  async function handlePrune() {
+  async function handlePrunePreview() {
     if (session?.role !== 'admin') {
-      setActionState('Only admins can prune observability datasets.')
+      setActionState('Only admins can preview or prune observability datasets.')
+      return
+    }
+
+    try {
+      setPreviewLoading(true)
+      setActionState(`Previewing ${pruneDataset} older than ${pruneDays} days…`)
+      const result = await directoryApi.previewPruneObservability(pruneDataset, pruneDays)
+      setPrunePreview(result)
+      setActionState(`Preview ready for ${pruneDataset}.`)
+    } catch (err) {
+      setPrunePreview(null)
+      setActionState(err instanceof ApiError ? err.message : 'Preview failed')
+    } finally {
+      setPreviewLoading(false)
+    }
+  }
+
+  async function handlePrune() {
+    if (!pruneReady) {
+      setActionState(`Preview the dataset and type "${expectedPhrase}" before pruning.`)
       return
     }
 
     try {
       setActionState(`Pruning ${pruneDataset} older than ${pruneDays} days…`)
-      const result = await directoryApi.pruneObservability(pruneDataset, pruneDays)
+      const result = await directoryApi.pruneObservability(pruneDataset, pruneDays, {
+        confirmDataset,
+        confirmPhrase,
+      })
       setActionState(`Deleted ${result.deleted} records from ${result.dataset}`)
+      setPrunePreview(null)
       await load(hours)
     } catch (err) {
       setActionState(err instanceof ApiError ? err.message : 'Prune failed')
@@ -85,6 +144,16 @@ export default function AlertsPage() {
           {actionState}
         </div>
       ) : null}
+      <div className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950/80 dark:text-slate-300">
+        <div className="font-medium text-slate-900 dark:text-slate-100">Operator flow</div>
+        <div className="mt-1">
+          Alert cards now carry threshold reasoning plus investigation links into filtered intents, trace detail, and audit history.
+          Exports are read-only snapshots. Prune is irreversible, so the dashboard requires an admin preview and typed confirmation phrase first.
+        </div>
+        <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Generated {formatDateTime(data?.generatedAt)} for the last {hours} hours.
+        </div>
+      </div>
 
       <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
         <div className="panel">
@@ -95,22 +164,7 @@ export default function AlertsPage() {
             ) : !data || data.alerts.length === 0 ? (
               <EmptyPanel label="No active alerts for the selected window." />
             ) : (
-              data.alerts.map((alert) => (
-                <div key={alert.id} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
-                      {alert.severity}
-                    </span>
-                    <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
-                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(alert.startedAt)}</span>
-                  </div>
-                  <div className="mt-2 text-sm font-medium">{alert.title}</div>
-                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{alert.message}</div>
-                  <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-                    {alert.metric}: {alert.value} (threshold {alert.threshold})
-                  </div>
-                </div>
-              ))
+              data.alerts.map((alert) => <AlertCard key={alert.id} alert={alert} />)
             )}
           </div>
         </div>
@@ -127,6 +181,10 @@ export default function AlertsPage() {
                 data.exports.map((entry) => (
                   <div key={entry.dataset} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
                     <div className="text-sm font-medium capitalize">{entry.dataset}</div>
+                    <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">{entry.description}</div>
+                    <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                      Export snapshots honor the current time window and can be shared without mutating state.
+                    </div>
                     <div className="mt-3 flex flex-wrap gap-2">
                       {EXPORT_FORMATS.filter((format) => entry.formats.includes(format)).map((format) => (
                         <button
@@ -163,6 +221,16 @@ export default function AlertsPage() {
                   </>
                 )}
               </select>
+              {retentionMeta ? (
+                <div className="rounded-xl bg-slate-50 px-3 py-3 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                  <div>{retentionMeta.description}</div>
+                  {retentionMeta.cascadesTo?.length ? (
+                    <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      Also removes: {retentionMeta.cascadesTo.join(', ')}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
               <input
                 className="input-field"
                 min={1}
@@ -172,13 +240,55 @@ export default function AlertsPage() {
                 onChange={(event) => setPruneDays(Number(event.target.value))}
               />
               <button
+                className="btn-secondary w-full disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={session?.role !== 'admin' || previewLoading}
+                onClick={() => void handlePrunePreview()}
+                type="button"
+              >
+                {previewLoading ? 'Previewing…' : 'Preview prune impact'}
+              </button>
+              {prunePreview ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-100">
+                  <div className="font-medium">Preview result</div>
+                  <div className="mt-1">
+                    Beam would delete {formatNumber(prunePreview.wouldDelete)} records older than {prunePreview.olderThanDays} days from {prunePreview.dataset}.
+                  </div>
+                  {typeof prunePreview.intents === 'number' || typeof prunePreview.traces === 'number' ? (
+                    <div className="mt-2 text-xs text-amber-800 dark:text-amber-200">
+                      intents: {formatNumber(prunePreview.intents ?? 0)} · traces: {formatNumber(prunePreview.traces ?? 0)}
+                    </div>
+                  ) : null}
+                </div>
+              ) : (
+                <div className="rounded-xl border border-dashed border-slate-200 px-3 py-3 text-sm text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                  Run a preview before pruning. The dashboard does not enable destructive actions without a fresh preview for the current dataset and day threshold.
+                </div>
+              )}
+              <input
+                className="input-field"
+                placeholder={`Type dataset: ${pruneDataset}`}
+                type="text"
+                value={confirmDataset}
+                onChange={(event) => setConfirmDataset(event.target.value)}
+              />
+              <input
+                className="input-field"
+                placeholder={`Type phrase: ${expectedPhrase}`}
+                type="text"
+                value={confirmPhrase}
+                onChange={(event) => setConfirmPhrase(event.target.value)}
+              />
+              <button
                 className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={session?.role !== 'admin'}
+                disabled={!pruneReady}
                 onClick={() => void handlePrune()}
                 type="button"
               >
-                {session?.role === 'admin' ? 'Prune Dataset' : 'Admin role required'}
+                {session?.role === 'admin' ? 'Prune dataset' : 'Admin role required'}
               </button>
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                Prune is irreversible. Use export first if you need a handoff snapshot, then preview, then type the dataset and phrase exactly.
+              </div>
             </div>
           </div>
         </div>

--- a/packages/dashboard/src/pages/AuditPage.tsx
+++ b/packages/dashboard/src/pages/AuditPage.tsx
@@ -1,15 +1,36 @@
 import { useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { Search } from 'lucide-react'
 import { ApiError, directoryApi, type AuditEntry } from '../lib/api'
 import { EmptyPanel, PageHeader, StatusPill } from '../components/Observability'
 import { formatDateTime } from '../lib/utils'
 
 export default function AuditPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [entries, setEntries] = useState<AuditEntry[]>([])
-  const [query, setQuery] = useState('')
-  const [hours, setHours] = useState(24 * 7)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const query = searchParams.get('q') ?? ''
+  const action = searchParams.get('action') ?? ''
+  const actor = searchParams.get('actor') ?? ''
+  const target = searchParams.get('target') ?? ''
+  const hours = Number.parseInt(searchParams.get('hours') ?? String(24 * 7), 10) || 24 * 7
+  const alertId = searchParams.get('alert')
+  const hasDeepLinkFilters = Boolean(alertId || query || action || actor || target || hours !== 24 * 7)
+
+  function updateSearchParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams)
+    if (!value || (key === 'hours' && value === String(24 * 7))) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  function clearFilters() {
+    setSearchParams({}, { replace: true })
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -19,6 +40,9 @@ export default function AuditPage() {
         setLoading(true)
         const response = await directoryApi.getAuditLog({
           q: query || undefined,
+          action: action || undefined,
+          actor: actor || undefined,
+          target: target || undefined,
           hours,
           limit: 120,
         })
@@ -43,6 +67,19 @@ export default function AuditPage() {
     <div className="space-y-6">
       <PageHeader title="Audit" description="Administrative and federation control-plane events across the directory." />
 
+      {hasDeepLinkFilters ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300">
+          {alertId ? (
+            <span>Showing the filtered audit slice linked from alert <span className="font-mono">{alertId}</span>.</span>
+          ) : (
+            <span>Showing a filtered audit slice.</span>
+          )}
+          <button className="ml-2 text-orange-600 hover:text-orange-700 dark:text-orange-300" onClick={clearFilters} type="button">
+            Clear filters
+          </button>
+        </div>
+      ) : null}
+
       <section className="panel">
         <div className="grid gap-3 lg:grid-cols-[1.5fr,0.5fr]">
           <label className="relative block">
@@ -51,15 +88,22 @@ export default function AuditPage() {
               className="input-field pl-10"
               placeholder="Search action, actor, target, details"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => updateSearchParam('q', event.target.value)}
             />
           </label>
-          <select className="input-field" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+          <select className="input-field" value={hours} onChange={(event) => updateSearchParam('hours', event.target.value)}>
             <option value={24}>24h</option>
             <option value={24 * 7}>7d</option>
             <option value={24 * 30}>30d</option>
           </select>
         </div>
+        {(action || actor || target) ? (
+          <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            {action ? <StatusPill label={`action:${action}`} /> : null}
+            {actor ? <StatusPill label={`actor:${actor}`} /> : null}
+            {target ? <StatusPill label={`target:${target}`} /> : null}
+          </div>
+        ) : null}
       </section>
 
       {error ? (
@@ -77,25 +121,52 @@ export default function AuditPage() {
           </div>
         ) : (
           <div className="divide-y divide-slate-200 dark:divide-slate-800">
-            {entries.map((entry) => (
-              <div key={entry.id} className="p-5">
-                <div className="flex flex-wrap items-center gap-2">
-                  <StatusPill label={entry.action} />
-                  <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(entry.timestamp)}</span>
+            {entries.map((entry) => {
+              const relatedNonce = extractAuditNonce(entry)
+
+              return (
+                <div key={entry.id} className="p-5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill label={entry.action} />
+                    <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(entry.timestamp)}</span>
+                  </div>
+                  <div className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                    {entry.actor} → {entry.target}
+                  </div>
+                  {relatedNonce ? (
+                    <div className="mt-2">
+                      <Link
+                        className="text-xs font-medium text-orange-600 hover:text-orange-700 dark:text-orange-300"
+                        to={`/intents/${encodeURIComponent(relatedNonce)}?alert=${encodeURIComponent(alertId ?? entry.action)}`}
+                      >
+                        Open related trace
+                      </Link>
+                    </div>
+                  ) : null}
+                  {entry.details ? (
+                    <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                      {JSON.stringify(entry.details, null, 2)}
+                    </pre>
+                  ) : null}
                 </div>
-                <div className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-                  {entry.actor} → {entry.target}
-                </div>
-                {entry.details ? (
-                  <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
-                    {JSON.stringify(entry.details, null, 2)}
-                  </pre>
-                ) : null}
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </section>
     </div>
   )
+}
+
+function extractAuditNonce(entry: AuditEntry): string | null {
+  const detailsNonce = typeof entry.details?.['nonce'] === 'string' ? entry.details['nonce'] : null
+  if (detailsNonce) {
+    return detailsNonce
+  }
+
+  if (entry.target && !entry.target.includes('@') && !entry.target.includes('://') && !entry.target.includes(' ')) {
+    return entry.target
+  }
+
+  return null
 }

--- a/packages/dashboard/src/pages/IntentsPage.tsx
+++ b/packages/dashboard/src/pages/IntentsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { Radio, Search } from 'lucide-react'
 import { ApiError, connectIntentFeed, directoryApi, type RecentIntent } from '../lib/api'
 import { PageHeader, StatusPill } from '../components/Observability'
@@ -13,6 +13,8 @@ const WINDOW_OPTIONS = [
 
 const STATUS_OPTIONS = [
   { value: 'all', label: 'All lifecycle states' },
+  { value: 'error', label: 'Failed or dead letter' },
+  { value: 'success', label: 'Acked' },
   { value: 'in_flight', label: 'In flight' },
   { value: 'received', label: 'Received' },
   { value: 'validated', label: 'Validated' },
@@ -29,8 +31,12 @@ function matchesFilters(intent: RecentIntent, filters: {
   status: string
   hours: number
 }) {
+  const lifecycleClass = classifyIntentLifecycle(intent.status)
   const matchesStatus = filters.status === 'all'
-    || (filters.status === 'in_flight' ? classifyIntentLifecycle(intent.status) === 'in_flight' : intent.status === filters.status)
+    || (filters.status === 'in_flight' ? lifecycleClass === 'in_flight' : false)
+    || (filters.status === 'error' ? lifecycleClass === 'error' : false)
+    || (filters.status === 'success' ? lifecycleClass === 'success' : false)
+    || intent.status === filters.status
   const matchesQuery = !filters.query || [
     intent.nonce,
     intent.from,
@@ -48,14 +54,31 @@ function matchesFilters(intent: RecentIntent, filters: {
 }
 
 export default function IntentsPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [intents, setIntents] = useState<RecentIntent[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [socketState, setSocketState] = useState<'connecting' | 'live' | 'offline'>('connecting')
-  const [query, setQuery] = useState('')
-  const [status, setStatus] = useState('all')
-  const [hours, setHours] = useState(24)
   const socketRef = useRef<WebSocket | null>(null)
+  const query = searchParams.get('q') ?? ''
+  const status = searchParams.get('status') ?? 'all'
+  const hours = Number.parseInt(searchParams.get('hours') ?? '24', 10) || 24
+  const alertId = searchParams.get('alert')
+  const hasDeepLinkFilters = Boolean(alertId || query || status !== 'all' || hours !== 24)
+
+  function updateSearchParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams)
+    if (!value || (key === 'status' && value === 'all') || (key === 'hours' && value === '24')) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  function clearFilters() {
+    setSearchParams({}, { replace: true })
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -143,6 +166,19 @@ export default function IntentsPage() {
         )}
       />
 
+      {hasDeepLinkFilters ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300">
+          {alertId ? (
+            <span>Showing the filtered intent slice linked from alert <span className="font-mono">{alertId}</span>.</span>
+          ) : (
+            <span>Showing a filtered intent slice.</span>
+          )}
+          <button className="ml-2 text-orange-600 hover:text-orange-700 dark:text-orange-300" onClick={clearFilters} type="button">
+            Clear filters
+          </button>
+        </div>
+      ) : null}
+
       <section className="panel">
         <div className="grid gap-3 lg:grid-cols-[1.6fr,0.8fr,0.8fr]">
           <label className="relative block">
@@ -151,15 +187,15 @@ export default function IntentsPage() {
               className="input-field pl-10"
               placeholder="Search nonce, Beam ID, intent type, error code"
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => updateSearchParam('q', event.target.value)}
             />
           </label>
-          <select className="input-field" value={status} onChange={(event) => setStatus(event.target.value)}>
+          <select className="input-field" value={status} onChange={(event) => updateSearchParam('status', event.target.value)}>
             {STATUS_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>{option.label}</option>
             ))}
           </select>
-          <select className="input-field" value={hours} onChange={(event) => setHours(Number(event.target.value))}>
+          <select className="input-field" value={hours} onChange={(event) => updateSearchParam('hours', event.target.value)}>
             {WINDOW_OPTIONS.map((option) => (
               <option key={option.value} value={option.value}>{option.label}</option>
             ))}

--- a/packages/dashboard/src/pages/LoginPage.tsx
+++ b/packages/dashboard/src/pages/LoginPage.tsx
@@ -163,6 +163,14 @@ export default function LoginPage() {
               ? 'Authorized admins receive a magic link by email.'
               : 'Without SMTP or Resend, localhost returns the dev magic link directly.'}
           </p>
+          <a
+            href="https://docs.beam.directory/guide/operator-observability"
+            rel="noreferrer"
+            style={{ display: 'inline-block', marginTop: '10px', fontSize: '0.82rem', color: '#F75C03', textDecoration: 'underline' }}
+            target="_blank"
+          >
+            Operator setup guide
+          </a>
         </div>
       </div>
     </div>

--- a/packages/dashboard/src/pages/OverviewPage.tsx
+++ b/packages/dashboard/src/pages/OverviewPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import AlertCard from '../components/AlertCard'
 import { ApiError, directoryApi, type ObservabilityOverview } from '../lib/api'
-import { alertSeverityColor, cn, formatLatency, formatNumber, formatPercent } from '../lib/utils'
+import { formatLatency, formatNumber, formatPercent } from '../lib/utils'
 import { BarList, EmptyPanel, MetricCard, PageHeader, StatusPill, TimeSeriesChart } from '../components/Observability'
 
 const WINDOW_OPTIONS = [
@@ -164,16 +165,7 @@ export default function OverviewPage() {
               <EmptyPanel label="No active alerts in the selected window." />
             ) : (
               overview.alerts.map((alert) => (
-                <div key={alert.id} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
-                      {alert.severity}
-                    </span>
-                    <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
-                  </div>
-                  <div className="mt-2 text-sm font-medium">{alert.title}</div>
-                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{alert.message}</div>
-                </div>
+                <AlertCard key={alert.id} alert={alert} compact />
               ))
             )}
           </div>

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -201,7 +201,19 @@ export default function SettingsPage() {
           <div className="panel-title">Observability retention</div>
           <InfoRow label="Default days" value={retention ? String(retention.defaultDays) : '—'} />
           <InfoRow label="Datasets" value={retention?.datasets.join(', ') ?? '—'} />
-          <p className="text-sm text-slate-500 dark:text-slate-400">Retention controls in the Alerts page call the prune endpoint directly and do not rely on local cache.</p>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Retention controls in the Alerts page now require an admin-only preview plus a typed confirmation phrase before prune is allowed.
+          </p>
+          {retention?.details?.length ? (
+            <div className="space-y-2 rounded-xl bg-slate-50 p-3 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+              {retention.details.map((entry) => (
+                <div key={entry.name}>
+                  <span className="font-medium">{entry.name}:</span> {entry.description}
+                  {entry.cascadesTo?.length ? ` Also removes ${entry.cascadesTo.join(', ')}.` : ''}
+                </div>
+              ))}
+            </div>
+          ) : null}
         </div>
 
         <div className="panel space-y-3">
@@ -212,6 +224,21 @@ export default function SettingsPage() {
           <InfoRow label="Bus URL" value={getStoredBusUrl() || BUS_DEFAULT_URL} />
           <p className="text-sm text-slate-500 dark:text-slate-400">Private keys generated on the Register page stay in `localStorage` for this browser profile only.</p>
         </div>
+      </section>
+
+      <section className="panel space-y-3">
+        <div className="panel-title">Operator docs</div>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Admin setup, alert triage, exports, and prune safety are documented end to end in the operator guide.
+        </p>
+        <a
+          className="inline-flex w-fit rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
+          href="https://docs.beam.directory/guide/operator-observability"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Open operator guide
+        </a>
       </section>
     </div>
   )

--- a/packages/dashboard/src/pages/TraceDetailPage.tsx
+++ b/packages/dashboard/src/pages/TraceDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { ApiError, directoryApi, type IntentTraceResponse } from '../lib/api'
 import { EmptyPanel, PageHeader, StatusPill } from '../components/Observability'
 import { alertSeverityColor, cn, formatDateTime, formatLatency, intentStatusColor, truncateBeamId } from '../lib/utils'
@@ -7,10 +7,12 @@ import { formatIntentLifecycleLabel, intentLifecycleDotColor, intentLifecycleTon
 
 export default function TraceDetailPage() {
   const { nonce } = useParams<{ nonce: string }>()
+  const [searchParams] = useSearchParams()
   const resolvedNonce = nonce ? decodeURIComponent(nonce) : null
   const [trace, setTrace] = useState<IntentTraceResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const alertId = searchParams.get('alert')
 
   useEffect(() => {
     if (!resolvedNonce) return
@@ -55,8 +57,21 @@ export default function TraceDetailPage() {
       <PageHeader
         title="Trace"
         description={`Nonce ${trace.intent.nonce}`}
-        actions={<Link className="btn-secondary" to="/intents">Back to intents</Link>}
+        actions={(
+          <div className="flex flex-wrap gap-2">
+            <Link className="btn-secondary" to="/intents">Back to intents</Link>
+            <Link className="btn-secondary" to={`/audit?target=${encodeURIComponent(trace.intent.nonce)}${alertId ? `&alert=${encodeURIComponent(alertId)}` : ''}`}>
+              Open audit log
+            </Link>
+          </div>
+        )}
       />
+
+      {alertId ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300">
+          This trace was opened from alert <span className="font-mono">{alertId}</span>. Use the audit button above for the matching control-plane history.
+        </div>
+      ) : null}
 
       <section className="grid gap-4 xl:grid-cols-[1.1fr,0.9fr]">
         <div className="panel space-y-3">

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -100,6 +100,10 @@ Production:
 - configure `SMTP_*` or `RESEND_API_KEY` for magic-link delivery
 - the dashboard and admin APIs use `/admin/auth/*` plus a short-lived signed session
 
+For the full operator workflow, including alerts, traces, audit history, exports, and prune confirmation, see:
+
+- [docs.beam.directory/guide/operator-observability](https://docs.beam.directory/guide/operator-observability)
+
 ## Fly.io
 
 The repo includes [`fly.toml`](./fly.toml):

--- a/packages/directory/src/observability.test.ts
+++ b/packages/directory/src/observability.test.ts
@@ -185,10 +185,63 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
     }))
 
     assert.equal(response.status, 200)
-    const payload = await response.json() as { alerts: Array<{ id: string }> }
+    const payload = await response.json() as {
+      alerts: Array<{
+        id: string
+        thresholdExplanation: string
+        links: Array<{ href: string }>
+        sampleTraces: Array<{ nonce: string }>
+      }>
+    }
 
-    assert.ok(payload.alerts.some((alert) => alert.id === 'network-error-rate'))
-    assert.ok(payload.alerts.some((alert) => alert.id === 'error-hotspot-timeout'))
+    const errorRateAlert = payload.alerts.find((alert) => alert.id === 'network-error-rate')
+    const hotspotAlert = payload.alerts.find((alert) => alert.id === 'error-hotspot-timeout')
+
+    assert.ok(errorRateAlert)
+    if (!errorRateAlert) {
+      throw new Error('Expected network-error-rate alert to exist')
+    }
+    assert.match(errorRateAlert.thresholdExplanation, /10%/)
+    assert.ok(errorRateAlert.links.some((link) => link.href.includes('/intents?')))
+    assert.equal(errorRateAlert.sampleTraces[0]?.nonce, 'error-9')
+
+    assert.ok(hotspotAlert)
+    if (!hotspotAlert) {
+      throw new Error('Expected error-hotspot-timeout alert to exist')
+    }
+    assert.ok(hotspotAlert.links.some((link) => link.href.includes('/audit?')))
+  } finally {
+    db.close()
+  }
+})
+
+test('prune preview returns dataset impact before destructive action', async () => {
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const oldTimestamp = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
+    const frame = createFrame('preview-intent', oldTimestamp)
+
+    logIntentStart(db, frame)
+    appendIntentTraceEvent(db, {
+      nonce: frame.nonce,
+      fromBeamId: frame.from,
+      toBeamId: frame.to,
+      intentType: frame.intent,
+      stage: 'received',
+      timestamp: oldTimestamp,
+    })
+
+    const app = createApp(db)
+    const response = await app.request(new Request('http://localhost/observability/prune-preview?dataset=intents&olderThanDays=30', {
+      headers: createAdminHeaders(db),
+    }))
+
+    assert.equal(response.status, 200)
+    const payload = await response.json() as { wouldDelete: number; intents: number; traces: number }
+    assert.equal(payload.intents, 1)
+    assert.equal(payload.traces, 1)
+    assert.equal(payload.wouldDelete, 2)
   } finally {
     db.close()
   }
@@ -218,7 +271,12 @@ test('prune endpoint removes aged intents and trace records', async () => {
         'content-type': 'application/json',
         ...createAdminHeaders(db),
       },
-      body: JSON.stringify({ dataset: 'intents', olderThanDays: 30 }),
+      body: JSON.stringify({
+        dataset: 'intents',
+        olderThanDays: 30,
+        confirmDataset: 'intents',
+        confirmPhrase: 'prune intents',
+      }),
     }))
 
     assert.equal(response.status, 200)
@@ -267,12 +325,44 @@ test('prune endpoint rejects read-only sessions', async () => {
         'content-type': 'application/json',
         ...createAdminHeaders(db, 'viewer@example.com', 'viewer'),
       },
-      body: JSON.stringify({ dataset: 'intents', olderThanDays: 30 }),
+      body: JSON.stringify({
+        dataset: 'intents',
+        olderThanDays: 30,
+        confirmDataset: 'intents',
+        confirmPhrase: 'prune intents',
+      }),
     }))
 
     assert.equal(response.status, 403)
     const payload = await response.json() as { errorCode: string }
     assert.equal(payload.errorCode, 'FORBIDDEN')
+  } finally {
+    db.close()
+  }
+})
+
+test('prune endpoint rejects missing confirmation phrase', async () => {
+  const db = createDatabase(':memory:')
+  try {
+    registerFixtureAgents(db)
+    const app = createApp(db)
+    const response = await app.request(new Request('http://localhost/observability/prune', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...createAdminHeaders(db),
+      },
+      body: JSON.stringify({
+        dataset: 'intents',
+        olderThanDays: 30,
+        confirmDataset: 'intents',
+        confirmPhrase: 'delete intents',
+      }),
+    }))
+
+    assert.equal(response.status, 400)
+    const payload = await response.json() as { errorCode: string }
+    assert.equal(payload.errorCode, 'PRUNE_CONFIRMATION_REQUIRED')
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -20,6 +20,30 @@ import type {
 
 type BindValue = string | number | null
 type AlertSeverity = 'info' | 'warning' | 'critical'
+type AlertMetricUnit = 'ratio' | 'ms' | 'count'
+type AlertLinkSurface = 'trace' | 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
+
+type ObservabilityDatasetInfo = {
+  name: string
+  description: string
+  cascadesTo?: string[]
+}
+
+type AlertLink = {
+  label: string
+  href: string
+  surface: AlertLinkSurface
+}
+
+type AlertTraceSample = {
+  nonce: string
+  from: string
+  to: string
+  intentType: string
+  requestedAt: string
+  status: IntentLifecycleStatus
+  errorCode: string | null
+}
 
 type AlertItem = {
   id: string
@@ -30,7 +54,12 @@ type AlertItem = {
   metric: string
   value: number
   threshold: number
+  valueUnit: AlertMetricUnit
   startedAt: string
+  thresholdExplanation: string
+  severityReason: string
+  links: AlertLink[]
+  sampleTraces: AlertTraceSample[]
 }
 
 type IntentQuery = {
@@ -45,6 +74,53 @@ type IntentQuery = {
 }
 
 const DEFAULT_RETENTION_DAYS = Math.max(1, Number.parseInt(process.env['BEAM_OBSERVABILITY_RETENTION_DAYS'] ?? '30', 10) || 30)
+const OBSERVABILITY_DATASETS: ObservabilityDatasetInfo[] = [
+  {
+    name: 'intents',
+    description: 'Intent log rows with lifecycle status, latency, and error summary fields.',
+    cascadesTo: ['traces'],
+  },
+  {
+    name: 'traces',
+    description: 'Per-stage lifecycle events used to reconstruct nonce timelines.',
+  },
+  {
+    name: 'audit',
+    description: 'Administrative and federation control-plane events recorded by operators and services.',
+  },
+  {
+    name: 'shield',
+    description: 'Beam Shield hold and reject decisions with anomaly context.',
+  },
+]
+
+const EXPORT_DATASETS = [
+  {
+    dataset: 'intents',
+    formats: ['json', 'csv', 'ndjson'],
+    description: 'Snapshot filtered intent rows for incident review or handoff.',
+  },
+  {
+    dataset: 'audit',
+    formats: ['json', 'csv', 'ndjson'],
+    description: 'Export control-plane activity, role changes, and prune history.',
+  },
+  {
+    dataset: 'errors',
+    formats: ['json', 'csv', 'ndjson'],
+    description: 'Download aggregated error hotspots and affected routes.',
+  },
+  {
+    dataset: 'federation',
+    formats: ['json', 'csv', 'ndjson'],
+    description: 'Capture peer status, cache age, and trust assertions.',
+  },
+  {
+    dataset: 'alerts',
+    formats: ['json', 'csv', 'ndjson'],
+    description: 'Store the current heuristic alert set with threshold reasoning.',
+  },
+] as const
 
 function parseLimit(value: string | undefined, fallback: number, max = 500): number {
   const parsed = Number.parseInt(value ?? '', 10)
@@ -96,6 +172,21 @@ function parseJson<T>(value: string | null | undefined, fallback: T): T {
   } catch {
     return fallback
   }
+}
+
+function buildDashboardSearch(params: Record<string, string | number | undefined | null>): string {
+  const query = new URLSearchParams()
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === '') {
+      continue
+    }
+
+    query.set(key, String(value))
+  }
+
+  const serialized = query.toString()
+  return serialized ? `?${serialized}` : ''
 }
 
 function percentile(values: number[], pct: number): number | null {
@@ -162,6 +253,18 @@ function serializeTraceEvent(row: IntentTraceEventRow) {
     status: lifecycleStatus,
     timestamp: row.timestamp,
     details: parseJson<Record<string, unknown> | null>(row.details, null),
+  }
+}
+
+function serializeAlertTraceSample(row: IntentLogRow): AlertTraceSample {
+  return {
+    nonce: row.nonce,
+    from: row.from_beam_id,
+    to: row.to_beam_id,
+    intentType: row.intent_type,
+    requestedAt: row.requested_at,
+    status: normalizeIntentLifecycleStatus(row.status) ?? 'received',
+    errorCode: row.error_code ?? null,
   }
 }
 
@@ -846,15 +949,70 @@ function buildErrorsPayload(db: Database, windowHours: number) {
   }
 }
 
+function recentIntentSamples(
+  db: Database,
+  whereClause: string,
+  params: BindValue[],
+  limit = 3,
+): AlertTraceSample[] {
+  if (!whereClause.trim()) {
+    return []
+  }
+
+  const rows = db.prepare(`
+    SELECT *
+    FROM intent_log
+    ${whereClause}
+    ORDER BY requested_at DESC, id DESC
+    LIMIT ${limit}
+  `).all(...params) as IntentLogRow[]
+
+  return rows.map(serializeAlertTraceSample)
+}
+
+function buildAlertLinks(
+  alertId: string,
+  primaryPath: string,
+  primaryLabel: string,
+  primarySurface: AlertLinkSurface,
+  primaryParams: Record<string, string | number | undefined | null>,
+  extra: Array<{
+    path: string
+    label: string
+    surface: AlertLinkSurface
+    params?: Record<string, string | number | undefined | null>
+  }> = [],
+): AlertLink[] {
+  return [
+    {
+      label: primaryLabel,
+      href: `${primaryPath}${buildDashboardSearch({ alert: alertId, ...primaryParams })}`,
+      surface: primarySurface,
+    },
+    ...extra.map((entry) => ({
+      label: entry.label,
+      href: `${entry.path}${buildDashboardSearch({ alert: alertId, ...entry.params })}`,
+      surface: entry.surface,
+    })),
+  ]
+}
+
 function buildAlerts(db: Database, windowHours: number): AlertItem[] {
   const overview = buildOverviewPayload(db, windowHours)
   const errors = buildErrorsPayload(db, windowHours)
   const federation = buildFederationPayload(db)
   const alerts: AlertItem[] = []
+  const since = nowMinusHours(windowHours)
 
   const completedCount = overview.summary.successCount + overview.summary.errorCount
   const errorRate = completedCount > 0 ? overview.summary.errorCount / completedCount : 0
   if (completedCount >= 10 && errorRate >= 0.1) {
+    const sampleTraces = recentIntentSamples(
+      db,
+      "WHERE requested_at >= ? AND status IN ('failed', 'dead_letter')",
+      [since],
+    )
+    const latestNonce = sampleTraces[0]?.nonce
     alerts.push({
       id: 'network-error-rate',
       severity: errorRate >= 0.25 ? 'critical' : 'warning',
@@ -864,11 +1022,53 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'error_rate',
       value: round(errorRate, 4),
       threshold: 0.1,
-      startedAt: new Date().toISOString(),
+      valueUnit: 'ratio',
+      startedAt: sampleTraces[0]?.requestedAt ?? new Date().toISOString(),
+      thresholdExplanation: 'Beam raises this alert once completed intent failures cross 10% of the selected window.',
+      severityReason: errorRate >= 0.25
+        ? 'Critical because the network error rate is at or above the 25% escalation threshold.'
+        : 'Warning because the network error rate is above the 10% investigation threshold.',
+      links: buildAlertLinks(
+        'network-error-rate',
+        '/intents',
+        'Open failing intents',
+        'intents',
+        { status: 'error', hours: windowHours },
+        [
+          latestNonce
+            ? {
+              path: `/intents/${encodeURIComponent(latestNonce)}`,
+              label: 'Open latest failing trace',
+              surface: 'trace' as const,
+            }
+            : null,
+          latestNonce
+            ? {
+              path: '/audit',
+              label: 'Open audit for latest failing trace',
+              surface: 'audit' as const,
+              params: { target: latestNonce, hours: windowHours },
+            }
+            : null,
+          {
+            path: '/errors',
+            label: 'Open error dashboard',
+            surface: 'errors' as const,
+            params: { alert: 'network-error-rate' },
+          },
+        ].filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+      ),
+      sampleTraces,
     })
   }
 
   if ((overview.summary.p95LatencyMs ?? 0) >= 2000) {
+    const sampleTraces = recentIntentSamples(
+      db,
+      'WHERE requested_at >= ? AND round_trip_latency_ms >= ?',
+      [since, 2000],
+    )
+    const latestNonce = sampleTraces[0]?.nonce
     alerts.push({
       id: 'network-latency-p95',
       severity: (overview.summary.p95LatencyMs ?? 0) >= 5000 ? 'critical' : 'warning',
@@ -878,11 +1078,47 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'p95_latency_ms',
       value: overview.summary.p95LatencyMs ?? 0,
       threshold: 2000,
-      startedAt: new Date().toISOString(),
+      valueUnit: 'ms',
+      startedAt: sampleTraces[0]?.requestedAt ?? new Date().toISOString(),
+      thresholdExplanation: 'Beam raises this alert once p95 round-trip latency crosses 2 seconds in the selected window.',
+      severityReason: (overview.summary.p95LatencyMs ?? 0) >= 5000
+        ? 'Critical because p95 latency crossed the 5 second escalation threshold.'
+        : 'Warning because p95 latency crossed the 2 second investigation threshold.',
+      links: buildAlertLinks(
+        'network-latency-p95',
+        '/intents',
+        'Open recent intents',
+        'intents',
+        { hours: windowHours },
+        [
+          latestNonce
+            ? {
+              path: `/intents/${encodeURIComponent(latestNonce)}`,
+              label: 'Open slowest recent trace',
+              surface: 'trace' as const,
+            }
+            : null,
+          latestNonce
+            ? {
+              path: '/audit',
+              label: 'Open audit for latest slow trace',
+              surface: 'audit' as const,
+              params: { target: latestNonce, hours: windowHours },
+            }
+            : null,
+        ].filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+      ),
+      sampleTraces,
     })
   }
 
   if (overview.summary.inFlightOlderThan15m > 0) {
+    const sampleTraces = recentIntentSamples(
+      db,
+      "WHERE status NOT IN ('acked', 'failed', 'dead_letter') AND requested_at < ?",
+      [new Date(Date.now() - 15 * 60 * 1000).toISOString()],
+    )
+    const latestNonce = sampleTraces[0]?.nonce
     alerts.push({
       id: 'network-in-flight-backlog',
       severity: overview.summary.inFlightOlderThan15m >= 5 ? 'critical' : 'warning',
@@ -892,7 +1128,37 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'in_flight_older_than_15m',
       value: overview.summary.inFlightOlderThan15m,
       threshold: 1,
-      startedAt: new Date().toISOString(),
+      valueUnit: 'count',
+      startedAt: sampleTraces[0]?.requestedAt ?? new Date().toISOString(),
+      thresholdExplanation: 'Beam raises this alert when at least one intent has been in flight for more than 15 minutes.',
+      severityReason: overview.summary.inFlightOlderThan15m >= 5
+        ? 'Critical because five or more in-flight intents exceeded the 15 minute backlog threshold.'
+        : 'Warning because at least one in-flight intent exceeded the 15 minute backlog threshold.',
+      links: buildAlertLinks(
+        'network-in-flight-backlog',
+        '/intents',
+        'Open in-flight intents',
+        'intents',
+        { status: 'in_flight', hours: windowHours },
+        [
+          latestNonce
+            ? {
+              path: `/intents/${encodeURIComponent(latestNonce)}`,
+              label: 'Open oldest in-flight trace',
+              surface: 'trace' as const,
+            }
+            : null,
+          latestNonce
+            ? {
+              path: '/audit',
+              label: 'Open audit for oldest in-flight trace',
+              surface: 'audit' as const,
+              params: { target: latestNonce, hours: windowHours },
+            }
+            : null,
+        ].filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+      ),
+      sampleTraces,
     })
   }
 
@@ -906,7 +1172,28 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'stale_peers',
       value: federation.summary.stalePeers,
       threshold: 1,
+      valueUnit: 'count',
       startedAt: new Date().toISOString(),
+      thresholdExplanation: 'Beam raises this alert when at least one federated peer is stale or has stopped syncing.',
+      severityReason: federation.summary.stalePeers >= 2
+        ? 'Critical because two or more federation peers are stale.'
+        : 'Warning because at least one federation peer is stale.',
+      links: buildAlertLinks(
+        'federation-stale-peers',
+        '/federation',
+        'Open federation health',
+        'federation',
+        {},
+        [
+          {
+            path: '/audit',
+            label: 'Open federation audit history',
+            surface: 'audit' as const,
+            params: { q: 'federation', hours: windowHours },
+          },
+        ],
+      ),
+      sampleTraces: [],
     })
   }
 
@@ -921,6 +1208,18 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
   const rejected = shieldRow?.rejected ?? 0
   const held = shieldRow?.held ?? 0
   if (rejected >= 3 || held >= 5) {
+    const sampleTraces = recentIntentSamples(
+      db,
+      `WHERE nonce IN (
+        SELECT nonce
+        FROM shield_audit_log
+        WHERE created_at >= ? AND decision IN ('reject', 'hold') AND nonce IS NOT NULL
+        ORDER BY created_at DESC, id DESC
+        LIMIT 3
+      )`,
+      [since],
+    )
+    const latestNonce = sampleTraces[0]?.nonce
     alerts.push({
       id: 'shield-review-load',
       severity: rejected >= 5 ? 'critical' : 'warning',
@@ -930,12 +1229,46 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'shield_flagged_events',
       value: rejected + held,
       threshold: 5,
-      startedAt: new Date().toISOString(),
+      valueUnit: 'count',
+      startedAt: sampleTraces[0]?.requestedAt ?? new Date().toISOString(),
+      thresholdExplanation: 'Beam raises this alert when Shield records at least three rejects or five held requests in the selected window.',
+      severityReason: rejected >= 5
+        ? 'Critical because Shield recorded five or more rejected requests.'
+        : 'Warning because Shield review volume crossed the hold and reject thresholds.',
+      links: buildAlertLinks(
+        'shield-review-load',
+        '/audit',
+        'Open Shield audit history',
+        'audit',
+        { q: 'shield', hours: windowHours },
+        [
+          latestNonce
+            ? {
+              path: `/intents/${encodeURIComponent(latestNonce)}`,
+              label: 'Open latest flagged trace',
+              surface: 'trace' as const,
+            }
+            : null,
+          {
+            path: '/alerts',
+            label: 'Open alert feed',
+            surface: 'alerts' as const,
+            params: { hours: windowHours },
+          },
+        ].filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+      ),
+      sampleTraces,
     })
   }
 
   const topError = errors.codes[0]
   if (topError && topError.count >= 5) {
+    const sampleTraces = recentIntentSamples(
+      db,
+      "WHERE requested_at >= ? AND error_code = ? AND status IN ('failed', 'dead_letter')",
+      [since, topError.errorCode],
+    )
+    const latestNonce = sampleTraces[0]?.nonce
     alerts.push({
       id: `error-hotspot-${topError.errorCode.toLowerCase()}`,
       severity: topError.count >= 10 ? 'critical' : 'warning',
@@ -945,7 +1278,43 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
       metric: 'error_code_count',
       value: topError.count,
       threshold: 5,
+      valueUnit: 'count',
       startedAt: topError.lastSeenAt,
+      thresholdExplanation: 'Beam raises this alert when the same error code occurs at least five times in the selected window.',
+      severityReason: topError.count >= 10
+        ? `Critical because ${topError.errorCode} crossed the 10 failure escalation threshold.`
+        : `Warning because ${topError.errorCode} crossed the 5 failure investigation threshold.`,
+      links: buildAlertLinks(
+        `error-hotspot-${topError.errorCode.toLowerCase()}`,
+        '/intents',
+        `Open ${topError.errorCode} intents`,
+        'intents',
+        { status: 'error', q: topError.errorCode, hours: windowHours },
+        [
+          latestNonce
+            ? {
+              path: `/intents/${encodeURIComponent(latestNonce)}`,
+              label: 'Open latest hotspot trace',
+              surface: 'trace' as const,
+            }
+            : null,
+          latestNonce
+            ? {
+              path: '/audit',
+              label: 'Open audit for latest hotspot trace',
+              surface: 'audit' as const,
+              params: { target: latestNonce, hours: windowHours },
+            }
+            : null,
+          {
+            path: '/errors',
+            label: 'Open error analytics',
+            surface: 'errors' as const,
+            params: { alert: `error-hotspot-${topError.errorCode.toLowerCase()}` },
+          },
+        ].filter((entry): entry is NonNullable<typeof entry> => Boolean(entry)),
+      ),
+      sampleTraces,
     })
   }
 
@@ -1045,6 +1414,32 @@ function pruneDataset(db: Database, dataset: string, olderThanDays: number): { d
     case 'shield': {
       const result = db.prepare('DELETE FROM shield_audit_log WHERE created_at < ?').run(cutoff)
       return { deleted: result.changes }
+    }
+    default:
+      throw new Error(`Unsupported dataset: ${dataset}`)
+  }
+}
+
+function previewPruneDataset(db: Database, dataset: string, olderThanDays: number): { deleted: number; extra?: Record<string, number> } {
+  const cutoff = nowMinusDays(olderThanDays)
+
+  switch (dataset) {
+    case 'intents': {
+      const intents = (db.prepare('SELECT COUNT(*) AS count FROM intent_log WHERE requested_at < ?').get(cutoff) as { count: number } | undefined)?.count ?? 0
+      const traces = (db.prepare('SELECT COUNT(*) AS count FROM intent_trace_events WHERE timestamp < ?').get(cutoff) as { count: number } | undefined)?.count ?? 0
+      return { deleted: intents + traces, extra: { intents, traces } }
+    }
+    case 'traces': {
+      const deleted = (db.prepare('SELECT COUNT(*) AS count FROM intent_trace_events WHERE timestamp < ?').get(cutoff) as { count: number } | undefined)?.count ?? 0
+      return { deleted }
+    }
+    case 'audit': {
+      const deleted = (db.prepare('SELECT COUNT(*) AS count FROM audit_log WHERE timestamp < ?').get(cutoff) as { count: number } | undefined)?.count ?? 0
+      return { deleted }
+    }
+    case 'shield': {
+      const deleted = (db.prepare('SELECT COUNT(*) AS count FROM shield_audit_log WHERE created_at < ?').get(cutoff) as { count: number } | undefined)?.count ?? 0
+      return { deleted }
     }
     default:
       throw new Error(`Unsupported dataset: ${dataset}`)
@@ -1188,15 +1583,12 @@ export function observabilityRouter(db: Database): Hono {
       alerts: buildAlerts(db, windowHours),
       retention: {
         defaultDays: DEFAULT_RETENTION_DAYS,
-        datasets: ['intents', 'traces', 'audit', 'shield'],
+        minimumDays: 1,
+        confirmPhrasePrefix: 'prune',
+        datasets: OBSERVABILITY_DATASETS.map((dataset) => dataset.name),
+        details: OBSERVABILITY_DATASETS,
       },
-      exports: [
-        { dataset: 'intents', formats: ['json', 'csv', 'ndjson'] },
-        { dataset: 'audit', formats: ['json', 'csv', 'ndjson'] },
-        { dataset: 'errors', formats: ['json', 'csv', 'ndjson'] },
-        { dataset: 'federation', formats: ['json', 'csv', 'ndjson'] },
-        { dataset: 'alerts', formats: ['json', 'csv', 'ndjson'] },
-      ],
+      exports: EXPORT_DATASETS,
     })
   })
 
@@ -1208,8 +1600,40 @@ export function observabilityRouter(db: Database): Hono {
 
     return c.json({
       defaultDays: DEFAULT_RETENTION_DAYS,
-      datasets: ['intents', 'traces', 'audit', 'shield'],
+      minimumDays: 1,
+      confirmPhrasePrefix: 'prune',
+      datasets: OBSERVABILITY_DATASETS.map((dataset) => dataset.name),
+      details: OBSERVABILITY_DATASETS,
     })
+  })
+
+  router.get('/prune-preview', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const dataset = String(c.req.query('dataset') ?? '').trim()
+    const olderThanDays = parseDays(c.req.query('olderThanDays'), DEFAULT_RETENTION_DAYS)
+
+    if (!dataset) {
+      return c.json({ error: 'dataset is required', errorCode: 'INVALID_PRUNE' }, 400)
+    }
+
+    try {
+      const result = previewPruneDataset(db, dataset, olderThanDays)
+      return c.json({
+        dataset,
+        olderThanDays,
+        wouldDelete: result.deleted,
+        ...result.extra,
+      })
+    } catch (err) {
+      return c.json({
+        error: err instanceof Error ? err.message : 'Failed to preview prune dataset',
+        errorCode: 'PRUNE_PREVIEW_ERROR',
+      }, 400)
+    }
   })
 
   router.get('/export/:dataset', (c) => {
@@ -1303,9 +1727,18 @@ export function observabilityRouter(db: Database): Hono {
       raw.olderThanDays == null ? undefined : String(raw.olderThanDays),
       DEFAULT_RETENTION_DAYS,
     )
+    const confirmDataset = String(raw.confirmDataset ?? '').trim()
+    const confirmPhrase = String(raw.confirmPhrase ?? '').trim()
 
     if (!dataset) {
       return c.json({ error: 'dataset is required', errorCode: 'INVALID_PRUNE' }, 400)
+    }
+
+    if (confirmDataset !== dataset || confirmPhrase !== `prune ${dataset}`) {
+      return c.json({
+        error: 'Prune confirmation is required. Repeat the dataset name and the phrase exactly.',
+        errorCode: 'PRUNE_CONFIRMATION_REQUIRED',
+      }, 400)
     }
 
     try {


### PR DESCRIPTION
Closes #12

## Summary
- add operator-facing alert reasoning, deep links, and trace samples across observability APIs and dashboard views
- add safer prune flows with preview plus server-side confirmation requirements
- document admin setup and the alert -> trace -> audit workflow end to end

## Verification
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build