### PR TITLE
Add proof funnel ladder to public surfaces

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,11 +9,11 @@ hero:
       text: Launch Hosted Demo
       link: /guide/hosted-quickstart
     - theme: alt
+      text: Register a Real Agent
+      link: https://beam.directory/register.html
+    - theme: alt
       text: Read the Operator Runbook
       link: /guide/operator-runbook
-    - theme: alt
-      text: Compatibility Policy
-      link: /guide/compatibility
 features:
   - icon: 🤝
     title: One Real Workflow
@@ -58,6 +58,12 @@ const reply = await client.talk(
 console.log(reply.message)
 ```
 
+## Choose Your Path
+
+1. **See the proof first.** Run the [Hosted Quickstart](/guide/hosted-quickstart), inspect the dashboard trace, and verify the async finance preflight before you decide Beam is interesting.
+2. **Wire a real agent.** Use the [Register page](https://beam.directory/register.html) when you want a Beam ID, signing key flow, and smoke-test snippets for your own agent.
+3. **Talk hosted beta.** If you want a managed directory/dashboard path around a real partner workflow, email [team@beam.directory](mailto:team@beam.directory?subject=Beam%20Hosted%20Beta).
+
 ## What Beam Is For
 
 Beam is not trying to be every possible agent standard at once. The current release direction is narrower and more useful:
@@ -71,9 +77,11 @@ If that is your problem, Beam is aimed directly at it. If it is not, Beam should
 ## Continue
 
 - [Hosted Quickstart](/guide/hosted-quickstart)
+- [Register a Real Agent](https://beam.directory/register.html)
 - [Partner Handoff Guide](/guide/partner-handoff)
 - [Operator Runbook](/guide/operator-runbook)
 - [Getting Started](/guide/getting-started)
 - [Compatibility Policy](/guide/compatibility)
+- [Hosted Beta Request](mailto:team@beam.directory?subject=Beam%20Hosted%20Beta)
 - [0.7.0 Hosted Demo Readiness Report](https://github.com/Beam-directory/beam-protocol/blob/main/reports/0.7.0-hosted-demo-readiness.md)
 - [0.7.0 Clean-Start Onboarding Report](https://github.com/Beam-directory/beam-protocol/blob/main/reports/0.7.0-clean-start-onboarding.md)

--- a/packages/public-site/index.html
+++ b/packages/public-site/index.html
@@ -873,6 +873,38 @@
       margin-top: 1px;
     }
 
+    .operator-snippets {
+      display: grid;
+      gap: 14px;
+      margin: 20px 0 0;
+    }
+
+    .operator-snippet {
+      display: grid;
+      gap: 6px;
+      padding-top: 14px;
+      border-top: 1px solid var(--line);
+    }
+
+    .operator-snippet span {
+      font-family: var(--font-mono);
+      font-size: 0.74rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    .operator-snippet strong {
+      font-size: 1rem;
+      letter-spacing: -0.03em;
+    }
+
+    .operator-snippet p {
+      color: var(--ink-soft);
+      font-size: 0.92rem;
+      line-height: 1.55;
+    }
+
     .trace-board {
       position: relative;
       overflow: hidden;
@@ -994,6 +1026,14 @@
       letter-spacing: -0.03em;
     }
 
+    .stack-kicker {
+      font-family: var(--font-mono);
+      font-size: 0.76rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
     .stack-column p {
       color: var(--ink-soft);
     }
@@ -1015,6 +1055,18 @@
       content: ">";
       color: var(--accent);
       margin-top: 1px;
+    }
+
+    .stack-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .stack-note {
+      color: var(--ink-muted);
+      font-size: 0.84rem;
+      line-height: 1.55;
     }
 
     .start-shell {
@@ -1421,7 +1473,7 @@
       <ul class="nav-links" id="navLinks">
         <li><a href="#workflow">Workflow</a></li>
         <li><a href="#operators">Operators</a></li>
-        <li><a href="#stack">Stack</a></li>
+        <li><a href="#paths">Paths</a></li>
         <li><a href="#start">Start</a></li>
         <li><a href="https://docs.beam.directory" target="_blank" rel="noreferrer">Docs</a></li>
         <li><a href="https://github.com/Beam-directory/beam-protocol" target="_blank" rel="noreferrer">GitHub</a></li>
@@ -1642,6 +1694,23 @@
               A2A infrastructure only matters when the partner path is late, repeated, blocked, or half-complete.
               Beam already leans into that operator surface instead of pretending the happy path is enough.
             </p>
+            <div class="operator-snippets">
+              <div class="operator-snippet">
+                <span>Overview</span>
+                <strong>Check the baseline before you chase one nonce.</strong>
+                <p>Healthy runs should show the same zero-alert, zero-dead-letter baseline used in the hosted demo reports.</p>
+              </div>
+              <div class="operator-snippet">
+                <span>Intents</span>
+                <strong>Follow the handoff by nonce and lifecycle state.</strong>
+                <p>Move from <code>received</code> to <code>acked</code> without guessing which transport or retry path actually fired.</p>
+              </div>
+              <div class="operator-snippet">
+                <span>Dead letter</span>
+                <strong>See where a partner workflow stopped being healthy.</strong>
+                <p>When finance or partner delivery degrades, the operator surface stays explicit about retries, terminal failures, and recovery.</p>
+              </div>
+            </div>
             <ul>
               <li>Trace every handoff by nonce, including lifecycle stages and delivery path.</li>
               <li>Inspect audit entries, shield blocks, rate limits, alerts, and dead letters in one flow.</li>
@@ -1686,20 +1755,82 @@
       </div>
     </section>
 
-    <section id="stack">
+    <section id="paths">
       <div class="container">
         <div class="section-head reveal">
-          <div class="kicker">What ships today</div>
-          <h2>Beam is already more than a protocol document.</h2>
+          <div class="kicker">Choose the next Beam path</div>
+          <h2>Pick the proof depth that matches where you are.</h2>
           <p>
-            The core repo now has enough substance that the next job is product surface:
-            make the hosted demo, proof reports, and operator workflow impossible to miss.
+            Beam should not force every visitor into the same next step. Some teams need proof,
+            some need a real identity, and some want a managed beta conversation around one workflow.
           </p>
         </div>
 
         <div class="stack-layout">
           <div class="stack-column reveal">
-            <h3>Directory and trust</h3>
+            <div class="stack-kicker">01 · prove the handoff</div>
+            <h3>Start with the hosted demo.</h3>
+            <p>Bring up the seeded Acme-to-Northwind flow, inspect the dashboard trace, and verify the async finance preflight end to end.</p>
+            <ul>
+              <li>Directory, dashboard, message bus, and demo agents boot together.</li>
+              <li>The canonical quote request, warehouse check, and finance preflight are already seeded.</li>
+              <li>Observability and operator docs point at the exact same baseline flow.</li>
+            </ul>
+            <div class="stack-actions">
+              <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Launch hosted demo</a>
+              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/operator-runbook">See operator runbook</a>
+            </div>
+            <div class="stack-note">Best first stop for most engineers, founders, and buyers.</div>
+          </div>
+          <div class="stack-column reveal">
+            <div class="stack-kicker">02 · wire your own agent</div>
+            <h3>Register a real identity.</h3>
+            <p>Generate the Beam ID, signing key, optional direct-delivery endpoint, and smoke-test snippets for your own agent.</p>
+            <ul>
+              <li>Personal or company-scoped IDs with Beam-native addressing.</li>
+              <li>Ed25519 signing keys, optional X25519 encryption, and optional HTTP delivery.</li>
+              <li>Hosted-demo-first success flow so integration stays grounded in the real proof path.</li>
+            </ul>
+            <div class="stack-actions">
+              <a class="btn btn-secondary" href="/register.html">Register real agent</a>
+              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/getting-started">Read SDK docs</a>
+            </div>
+            <div class="stack-note">Best when the hosted demo already makes sense and you want to integrate.</div>
+          </div>
+          <div class="stack-column reveal">
+            <div class="stack-kicker">03 · talk hosted beta</div>
+            <h3>Bring Beam into a partner workflow.</h3>
+            <p>If you want a managed directory, dashboard surface, and onboarding around a real B2B handoff, talk to the Beam team directly.</p>
+            <ul>
+              <li>Hosted directory and dashboard path instead of only self-hosting.</li>
+              <li>Partner-handoff onboarding scoped to one real workflow, not a vague platform pitch.</li>
+              <li>Operator runbook, proof reports, and rollout guidance folded into evaluation.</li>
+            </ul>
+            <div class="stack-actions">
+              <a class="btn btn-secondary" href="mailto:team@beam.directory?subject=Beam%20Hosted%20Beta">Email for hosted beta</a>
+              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/partner-handoff">Read the handoff</a>
+            </div>
+            <div class="stack-note">Best for teams that want Beam to feel operational immediately.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="stack">
+      <div class="container">
+        <div class="section-head reveal">
+          <div class="kicker">What ships today</div>
+          <h2>Beam already has the surfaces a buyer asks for next.</h2>
+          <p>
+            Once the use case lands, the repo now backs it with operator tooling, compatibility work,
+            and demo infrastructure instead of leaving the story at protocol ambition.
+          </p>
+        </div>
+
+        <div class="stack-layout">
+          <div class="stack-column reveal">
+            <div class="stack-kicker">Directory and trust</div>
+            <h3>Identity and policy stay explicit.</h3>
             <p>Identity, ACLs, nonce lifecycle, admin sessions, audit, shield policy, and observability APIs.</p>
             <ul>
               <li>Beam IDs and DID resolution</li>
@@ -1709,7 +1840,8 @@
             </ul>
           </div>
           <div class="stack-column reveal">
-            <h3>Durable routing</h3>
+            <div class="stack-kicker">Durable routing</div>
+            <h3>Async work does not disappear into glue code.</h3>
             <p>Message bus semantics for retries, dedupe, restart recovery, and dead-letter handling.</p>
             <ul>
               <li>Nonce dedupe and retry backoff</li>
@@ -1719,7 +1851,8 @@
             </ul>
           </div>
           <div class="stack-column reveal">
-            <h3>SDKs and demo surface</h3>
+            <div class="stack-kicker">SDKs and demo surface</div>
+            <h3>The proof path is already operationalized.</h3>
             <p>TypeScript, Python, CLI, dashboard, docs, public site, and a seeded hosted demo path.</p>
             <ul>
               <li>Archived compatibility fixtures in CI</li>
@@ -1775,17 +1908,17 @@
       <div class="container">
         <div class="closing-panel reveal">
           <div>
-            <h2>Beam should feel operational before it feels visionary.</h2>
+            <h2>Pick the next Beam step, then prove it fast.</h2>
           </div>
           <div>
             <p>
-              The next win is not another abstract capability. It is a public surface where the use case,
-              trust model, operator story, and hosted demo are obvious in one pass.
+              The public surface should now do three jobs without friction: show the canonical handoff,
+              expose the operator proof, and make the right next CTA obvious for evaluation, integration, or hosted beta.
             </p>
             <div class="closing-actions">
               <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Launch hosted demo</a>
-              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/operator-runbook">Read operator runbook</a>
-              <a class="btn btn-secondary" href="https://github.com/Beam-directory/beam-protocol" target="_blank" rel="noreferrer">Open GitHub</a>
+              <a class="btn btn-secondary" href="/register.html">Register real agent</a>
+              <a class="btn btn-secondary" href="mailto:team@beam.directory?subject=Beam%20Hosted%20Beta">Talk hosted beta</a>
             </div>
           </div>
         </div>

--- a/packages/public-site/register.html
+++ b/packages/public-site/register.html
@@ -681,6 +681,72 @@
       margin-bottom: 8px;
     }
 
+    .success-paths {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-bottom: 18px;
+    }
+
+    .success-path {
+      text-align: left;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 16px;
+      display: grid;
+      gap: 10px;
+      align-content: start;
+    }
+
+    .success-path .path-label {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    .success-path h3 {
+      font-size: 1rem;
+      line-height: 1.1;
+      letter-spacing: -0.03em;
+    }
+
+    .success-path p {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.84rem;
+      line-height: 1.65;
+    }
+
+    .success-path .path-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 2px;
+    }
+
+    .success-path .path-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 38px;
+      padding: 0 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-size: 0.78rem;
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    .success-path .path-links a.primary {
+      background: linear-gradient(135deg, var(--accent), var(--accent-light));
+      border-color: transparent;
+      color: white;
+    }
+
     .quickstart-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -772,6 +838,7 @@
       .steps { padding-left: 20px; padding-right: 20px; }
       .success-beam-row,
       .success-links { flex-direction: column; }
+      .success-paths,
       .quickstart-grid { grid-template-columns: 1fr; }
       .top-actions,
       .intro-actions { flex-direction: column; }
@@ -1015,8 +1082,37 @@
         <div id="success-details" class="success-section" style="font-size: 0.82rem; color: var(--text-secondary);">
         </div>
         <div class="success-section" style="font-size: 0.82rem; color: var(--text-secondary); line-height: 1.65;">
-          <h3>Recommended next step</h3>
-          Beam's canonical proof path is still the hosted Acme-to-Northwind demo. Use the snippets below for smoke testing your new identity, then compare it against the hosted quickstart if you need the full operator story.
+          <h3>Choose the next proof path</h3>
+          Registration proves identity, not the whole Beam story. Use the path below that matches what you need to confirm next: operator visibility, canonical demo proof, or a direct identity smoke test.
+        </div>
+        <div class="success-paths">
+          <div class="success-path">
+            <div class="path-label">01 · operator view</div>
+            <h3>See the dashboard path</h3>
+            <p>If you operate a directory or want to understand Beam as an operator, start from the dashboard login and the observability guide.</p>
+            <div class="path-links">
+              <a class="primary" href="https://dashboard.beam.directory/login" target="_blank" rel="noreferrer">Open dashboard login</a>
+              <a href="https://docs.beam.directory/guide/operator-observability" target="_blank" rel="noreferrer">Operator observability</a>
+            </div>
+          </div>
+          <div class="success-path">
+            <div class="path-label">02 · canonical proof</div>
+            <h3>Compare against the hosted demo</h3>
+            <p>The Acme-to-Northwind handoff is still the canonical Beam proof. Use it when you want to compare your new agent path against the full operator story.</p>
+            <div class="path-links">
+              <a class="primary" href="https://docs.beam.directory/guide/hosted-quickstart" target="_blank" rel="noreferrer">Run hosted demo</a>
+              <a href="https://docs.beam.directory/guide/partner-handoff" target="_blank" rel="noreferrer">Read partner handoff</a>
+            </div>
+          </div>
+          <div class="success-path">
+            <div class="path-label">03 · identity smoke</div>
+            <h3>Smoke test this Beam ID</h3>
+            <p>Use the CLI or browser playground when you only need to prove that the registered identity can send a signed message successfully.</p>
+            <div class="path-links">
+              <a class="primary" href="#" id="copy-cli-link">Copy CLI smoke command</a>
+              <a href="/playground.html">Open browser playground</a>
+            </div>
+          </div>
         </div>
         <div class="quickstart-grid">
           <div class="quickstart-card">
@@ -1029,10 +1125,8 @@
           </div>
         </div>
         <div class="success-links">
-          <a href="https://docs.beam.directory/guide/hosted-quickstart" class="link-primary">Run Hosted Demo</a>
-          <a href="#" class="link-secondary" id="copy-cli-link">Copy CLI Smoke Command</a>
-          <a href="/playground.html" class="link-secondary">Open Browser Playground</a>
           <a href="https://docs.beam.directory/guide/getting-started" class="link-secondary" target="_blank" rel="noreferrer">Read SDK Docs</a>
+          <a href="mailto:team@beam.directory?subject=Beam%20Hosted%20Beta" class="link-secondary">Talk Hosted Beta</a>
           <a href="/" class="link-secondary">Back to Landing</a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- turn the public landing page into a clearer evaluation ladder with explicit proof, registration, and hosted beta paths
- add dashboard-first operator proof cues on the landing page and a stronger post-registration next-step ladder
- align docs home with the same funnel so hosted demo, real agent registration, and hosted beta requests tell the same story

## Verification
- `cd docs && npm run build`
- static preview via `python3 -m http.server -d packages/public-site`
- Chromium screenshot pass for `index.html` desktop and mobile
- Chromium screenshot pass for `register.html` desktop and mobile