### PR TITLE
Refresh 0.7.0 hosted beta execution plan

### DIFF
--- a/reports/0.7.0-hosted-beta-plan.md
+++ b/reports/0.7.0-hosted-beta-plan.md
@@ -1,119 +1,146 @@
 # Beam 0.7.0 Hosted Beta Plan
 
-## Goal
+Updated: 2026-03-30
 
-Beam 0.7.0 should turn the current protocol release into an operator-ready hosted beta for one narrow job:
+## Milestone Goal
+
+Beam 0.7.0 should turn the current release into an evaluation-ready hosted beta for one narrow job:
 
 **verified B2B handoffs between two companies' agents**
 
-At the end of this milestone, a new team should be able to:
+At the end of this milestone, a new evaluator should be able to:
 
-1. start from the docs and hosted quickstart,
-2. register two orgs and at least one agent per org,
-3. complete the partner handoff flow end to end,
-4. inspect the trace, audit trail, and alerts in the dashboard,
-5. recover from one simulated delivery failure without guessing.
+1. understand Beam from the public site in under a minute,
+2. get one successful result from the public browser playground in under five minutes,
+3. run the hosted Acme to Northwind handoff from the docs without repo-diving,
+4. inspect the trace, audit trail, and operator path from the dashboard,
+5. request hosted beta and land in a real follow-up workflow instead of a dead-end form.
+
+## What Is Already Done
+
+The milestone is no longer starting from zero. These parts are already in place on `main`:
+
+- release readiness, CI hygiene, docs build, and package publish flow,
+- cross-stack compatibility matrix and archived `0.6.x` fixtures,
+- retries, idempotency, dead-letter handling, restart recovery, and key lifecycle controls,
+- session-based admin auth and operator-facing observability flows,
+- hosted quickstart, seeded demo identities, operator runbook, and dogfood scripts,
+- public-site funnel refocus around the hosted demo,
+- live browser playground fix plus built-in public echo responder,
+- live deployment sync for `beam.directory`, `api.beam.directory`, and `docs.beam.directory`.
+
+## What Is Not Done Yet
+
+The remaining work is now mostly product and operations, not core protocol invention:
+
+- hosted beta intake is still just a waitlist record, not an operator workflow,
+- public truth surfaces drift in places, especially release/version metadata,
+- there is no post-refresh external or buyer-like dogfood report yet,
+- the GitHub `0.7.0` backlog still shows older issues as open even though most of that work landed,
+- there is no final `0.7.0` release-candidate checklist and cut sequence.
 
 ## Non-Goals
 
-The next milestone is not for:
+0.7.0 is not for:
 
-- widening Beam into a generic multi-agent platform,
-- adding broad new integrations before the hosted beta loop is solid,
-- introducing protocol surface area that does not improve reliability, onboarding, or operator control.
+- broadening Beam into a generic "all agents everywhere" platform,
+- adding new protocol families that do not improve the hosted beta loop,
+- shipping wide integrations before the hosted evaluation path is boring,
+- rewriting the dashboard or public site from scratch.
 
-## Current Position
+## Definition Of Done
 
-- `v0.6.1` is released.
-- Monorepo build, tests, e2e matrix, and quickstart are green.
-- The docs deployment path is being stabilized after the CI hygiene pass.
-- The repo currently has no open backlog issues, so the next milestone needs an explicit execution backlog.
+0.7.0 is complete when all of the following are true:
 
-## Success Criteria
+- `beam.directory` explains the product in plain language and points to one clear evaluation path,
+- `beam.directory/playground.html` succeeds end to end against the live public API,
+- the hosted quickstart remains reproducible from a clean checkout and documented clean-start path,
+- hosted beta requests are visible, triageable, and exportable by an operator,
+- `/health`, `/stats`, public status surfaces, and the current release agree on version truth,
+- at least two fresh post-refresh dogfood runs are documented,
+- `main` is green and the remaining milestone issues are all actually current.
 
-0.7.0 is done when all of the following are true:
+## Remaining Workstreams
 
-- GitHub Actions is green on `main`, including docs deployment.
-- Hosted quickstart works from a clean checkout in under 30 minutes.
-- The public docs tell one story only: verified partner handoff.
-- Operators can debug the five common failure modes from the dashboard alone:
-  - registration failure
-  - ACL denial
-  - retry/backoff loop
-  - dead-letter handoff
-  - stale or revoked key
-- Compatibility fixtures for the released `beam/1` surface are archived and tested.
-- At least two real dogfood runs have been completed after the milestone starts and written down as reports.
+### 1. Hosted Beta Intake
 
-## Workstreams
+Turn the current hosted-beta form into an actual operating loop:
 
-### 1. Platform Reliability
+- store beta requests with owner, status, notes, and timestamps,
+- expose that queue in the admin/dashboard surface or a clear export path,
+- distinguish request sources such as landing, playground, register, and hosted-beta page,
+- tighten the success state so evaluators know exactly what happens next.
 
-Lock down the surfaces that make Beam feel stable:
+### 2. Truth And Status Surfaces
 
-- restore and keep docs deployment green,
-- archive signed compatibility fixtures for released versions,
-- define the async acknowledgement pattern for bus-initiated requests,
-- remove duplicate or ambiguous delivery states from traces and summaries.
+Remove the remaining trust leaks:
 
-### 2. Operator Product
+- fix stale version metadata in API and public status surfaces,
+- expose current release, git SHA, and deploy timestamp consistently,
+- make the public status page match the actual hosted stack and demo path.
 
-Make the dashboard good enough for real operators:
+### 3. Dogfood And Validation
 
-- tighten trace detail and dead-letter investigation,
-- make alerts point directly to the failing trace or agent,
-- document retention, export, and recovery behavior,
-- add a concrete operator runbook.
+Use the improved public funnel as a real test, not a self-congratulatory demo:
 
-### 3. Hosted Beta Onboarding
+- run one buyer-like pass starting from the landing page,
+- run one technical operator pass starting from hosted quickstart,
+- write down exactly what confused people, what had to be explained manually, and what still feels too technical.
 
-Turn the current release into something another team can actually start:
+### 4. Release Control
 
-- seed a demo hosted environment and known demo identities,
-- keep the partner handoff as the primary happy path,
-- make the docs and quickstart match the hosted path exactly,
-- document the minimum production env and secrets setup.
+Cut the milestone deliberately:
 
-### 4. Dogfood and Validation
+- close stale issues that are already done,
+- open only the issues that still matter for 0.7.0,
+- define the `0.7.0-rc1` checklist,
+- release only after the remaining dogfood loop is boring.
 
-Prove the wedge with real usage instead of more abstract protocol work:
+## Execution Sequence
 
-- run at least two fresh dogfood handoffs after fixes land,
-- capture what failed, what was confusing, and what had to be explained manually,
-- use that feedback to decide the `0.7.0` cut, not feature appetite.
+### Phase 1. Backlog Cleanup And Truth Fixes
 
-## Sequence
+Goal: make the plan and backlog honest again.
 
-### Phase 1: Stabilize the Release Surface
+- close the stale `0.7.0` issues that were already delivered by PRs `#30` through `#35`,
+- open a fresh issue set for intake workflow, status/version truth, dogfood, and release cut,
+- fix version drift in the public API and status surfaces.
 
-- finish the docs deployment fix,
-- close remaining `0.6.x` hygiene work,
-- open the `0.7.0` milestone with a concrete issue backlog.
+### Phase 2. Make Hosted Beta Operational
 
-### Phase 2: Harden the Operator Loop
+Goal: every hosted-beta request becomes an actionable operator record.
 
-- fix trace and dead-letter investigation gaps,
-- define async acknowledgement semantics,
-- write the operator runbook from the current system, not from theory.
+- extend the server-side waitlist/beta-request model,
+- add admin visibility or export,
+- tighten the public success state and internal follow-up path.
 
-### Phase 3: Make Hosted Beta Real
+### Phase 3. Dogfood The Actual Funnel
 
-- seed the hosted demo environment,
-- align quickstart, public docs, and dashboard with the same partner handoff,
-- run clean-start onboarding from scratch and measure time-to-first-success.
+Goal: validate the real public path, not just the internal happy path.
 
-### Phase 4: Dogfood Before Release
+- run a non-technical evaluation pass from landing to playground to hosted-beta request,
+- run a technical pass from docs to hosted demo to operator investigation,
+- record friction as blockers, not as future ideas.
 
-- run real handoffs,
-- file only the blockers discovered there,
-- cut `0.7.0` after the dogfood loop is boring.
+### Phase 4. Cut 0.7.0
+
+Goal: ship a hosted beta, not another open-ended workstream.
+
+- run the final smoke matrix,
+- update changelog and release notes,
+- tag `0.7.0-rc1` if needed, then `v0.7.0`,
+- leave the next milestone for post-beta expansion.
 
 ## Immediate Next Actions
 
-The next five concrete actions are:
+These are the next five concrete moves:
 
-1. get the docs deployment stable again on the official Pages path,
-2. create the `0.7.0` milestone and backlog issues,
-3. archive compatibility fixtures for `0.6.0` and `0.6.1`,
-4. define the async acknowledgement model for message-bus initiated requests,
-5. seed a hosted demo environment with reusable demo identities.
+1. close stale issues `#25` to `#29` and replace them with current `0.7.0` issues,
+2. implement the hosted-beta request workflow behind the current form,
+3. fix version and deployment truth on `/stats`, status views, and public metadata,
+4. run two fresh post-refresh dogfood passes and write the reports,
+5. prepare the `0.7.0` release checklist and cut sequence.
+
+## One-Sentence Goal Check
+
+If a normal person cannot understand Beam from the landing page, a technical evaluator cannot complete the public demo without guessing, or an operator cannot see what happened after a beta request comes in, then 0.7.0 is not done.


### PR DESCRIPTION
## Summary
- refresh the canonical 0.7.0 hosted beta plan to reflect what is already done on main
- redefine the remaining work around hosted-beta intake, version truth, dogfood, and release control
- sync the GitHub milestone backlog so only the real remaining work stays open

## Testing
- not run (planning/report-only change)