### PR TITLE
Build hosted beta operator workflow

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -142,9 +142,91 @@ PATCH /shield/policies/public-endpoints
 
 The policy covers registration, discovery, DID resolution, `POST /intents/send`, admin auth, and key mutation limits, plus trusted IP / trusted Beam ID overrides.
 
+## Hosted beta intake
+
+Public hosted beta intake stays on the compatibility-safe `POST /waitlist` path.
+
+Example request:
+
+```json
+{
+  "email": "ops@northwind.systems",
+  "source": "hosted-beta-page",
+  "company": "Northwind Systems",
+  "agentCount": 6,
+  "workflowType": "hosted-beta-partner-handoff",
+  "workflowSummary": "Procurement asks partner operations for stock, then finance approves the async quote."
+}
+```
+
+Successful responses return:
+
+- `status`: `registered` or `already_registered`
+- `request`: the canonical hosted beta request record
+- `nextStep`: human-readable operator follow-up guidance
+
+The canonical request payload now includes:
+
+- `id`
+- `email`
+- `source`
+- `company`
+- `agentCount`
+- `workflowType`
+- `workflowSummary`
+- `requestStatus`
+- `owner`
+- `operatorNotes`
+- `createdAt`
+- `updatedAt`
+
+Stable request statuses are:
+
+- `new`
+- `reviewing`
+- `contacted`
+- `scheduled`
+- `active`
+- `closed`
+
+## Admin hosted beta workflow
+
+Operators can work the hosted beta queue through:
+
+```text
+GET   /admin/beta-requests
+GET   /admin/beta-requests/:id
+PATCH /admin/beta-requests/:id
+GET   /admin/beta-requests/export?format=json|csv
+```
+
+List filtering currently supports:
+
+- `q`
+- `status`
+- `owner`
+- `source`
+- `workflowType`
+- `limit`
+
+`PATCH /admin/beta-requests/:id` accepts:
+
+```json
+{
+  "status": "reviewing",
+  "owner": "operator@beam.directory",
+  "operatorNotes": "Intro email sent, follow-up call pending."
+}
+```
+
+All hosted beta admin endpoints require an authenticated admin session and accept either:
+
+- `Authorization: Bearer <admin-session-token>`
+- the dashboard admin session cookie
+
 ## `DELETE /admin/waitlist`
 
-Clears waitlist entries from the admin surface.
+Clears waitlist and hosted beta intake entries from the legacy admin surface.
 
 - Requires an authenticated admin session.
 - Accepts `Authorization: Bearer <admin-session-token>` for API clients or the dashboard session cookie.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import AgentsPage from './pages/AgentsPage'
 import AlertsPage from './pages/AlertsPage'
 import AuthCallbackPage from './pages/AuthCallbackPage'
 import AuditPage from './pages/AuditPage'
+import BetaRequestsPage from './pages/BetaRequestsPage'
 import DeadLetterPage from './pages/DeadLetterPage'
 import ErrorsPage from './pages/ErrorsPage'
 import FederationPage from './pages/FederationPage'
@@ -54,6 +55,7 @@ export default function App() {
             <Route path="federation" element={<FederationPage />} />
             <Route path="errors" element={<ErrorsPage />} />
             <Route path="alerts" element={<AlertsPage />} />
+            <Route path="beta-requests" element={<BetaRequestsPage />} />
             <Route path="dead-letter" element={<DeadLetterPage />} />
             <Route path="register" element={<RegisterPage />} />
             <Route path="settings" element={<SettingsPage />} />

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { Activity, Bot, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
+import { Activity, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
 import { useAdminAuth } from '../lib/admin-auth'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { path: '/federation', label: 'Federation', icon: Globe2 },
   { path: '/errors', label: 'Errors', icon: TriangleAlert },
   { path: '/alerts', label: 'Alerts', icon: Shield },
+  { path: '/beta-requests', label: 'Beta Requests', icon: FileText },
   { path: '/dead-letter', label: 'Dead Letters', icon: Inbox },
   { path: '/register', label: 'Register', icon: UserPlus },
   { path: '/settings', label: 'Settings', icon: Settings },

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -5,6 +5,8 @@ export type ExportFormat = 'json' | 'csv' | 'ndjson'
 export type IntentLifecycleStatus = 'received' | 'validated' | 'queued' | 'dispatched' | 'delivered' | 'acked' | 'failed' | 'dead_letter'
 export type AlertMetricUnit = 'ratio' | 'ms' | 'count'
 export type AlertLinkSurface = 'trace' | 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
+export type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
+export type BetaRequestExportFormat = 'json' | 'csv'
 
 export interface DirectoryAgent {
   beamId: string
@@ -515,25 +517,68 @@ export interface WaitlistSignupInput {
   source?: string
   company?: string
   agentCount?: number
+  workflowType?: string
+  workflowSummary?: string
 }
 
 export interface WaitlistSignupResponse {
   ok: boolean
-  email: string
-  createdAt: string
+  status: 'registered' | 'already_registered'
+  request: BetaRequest
+  nextStep: string
 }
 
-export interface WaitlistEntry {
+export interface BetaRequest {
+  id: number
   email: string
   source: string | null
   company: string | null
   agentCount: number | null
+  workflowType: string | null
+  workflowSummary: string | null
+  requestStatus: BetaRequestStatus
+  owner: string | null
+  operatorNotes: string | null
   createdAt: string
+  updatedAt: string
 }
 
+export type WaitlistEntry = BetaRequest
+
 export interface WaitlistListResponse {
-  waitlist: WaitlistEntry[]
+  waitlist: BetaRequest[]
+  signups?: BetaRequest[]
+  requests?: BetaRequest[]
   total: number
+  summary?: BetaRequestSummary
+}
+
+export interface BetaRequestSummary {
+  total: number
+  active: number
+  unowned: number
+  byStatus: Record<BetaRequestStatus, number>
+}
+
+export interface BetaRequestListResponse {
+  requests: BetaRequest[]
+  total: number
+  summary: BetaRequestSummary
+}
+
+export interface BetaRequestDetailResponse {
+  request: BetaRequest
+}
+
+export interface BetaRequestUpdateInput {
+  status?: BetaRequestStatus
+  owner?: string | null
+  operatorNotes?: string | null
+}
+
+export interface BetaRequestUpdateResponse {
+  ok: boolean
+  request: BetaRequest
 }
 
 export interface IntentFeedMessage {
@@ -825,7 +870,50 @@ export const directoryApi = {
     method: 'POST',
     body: JSON.stringify(input),
   }),
-  listWaitlist: () => request<WaitlistListResponse>('/waitlist'),
+  listWaitlist: () => request<WaitlistListResponse>('/waitlist', undefined, { admin: true }),
+  listBetaRequests: (params?: {
+    q?: string
+    status?: BetaRequestStatus
+    owner?: string
+    source?: string
+    workflowType?: string
+    limit?: number
+  }) => request<BetaRequestListResponse>(`/admin/beta-requests${buildQuery({
+    q: params?.q,
+    status: params?.status,
+    owner: params?.owner,
+    source: params?.source,
+    workflowType: params?.workflowType,
+    limit: params?.limit,
+  })}`, undefined, { admin: true }),
+  getBetaRequest: (id: number) => request<BetaRequestDetailResponse>(`/admin/beta-requests/${id}`, undefined, { admin: true }),
+  updateBetaRequest: (id: number, input: BetaRequestUpdateInput) => request<BetaRequestUpdateResponse>(`/admin/beta-requests/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  downloadBetaRequestsExport: async (format: BetaRequestExportFormat, params?: {
+    q?: string
+    status?: BetaRequestStatus
+    owner?: string
+    source?: string
+    workflowType?: string
+    limit?: number
+  }): Promise<ExportDownload> => {
+    const response = await requestRaw(`/admin/beta-requests/export${buildQuery({
+      format,
+      q: params?.q,
+      status: params?.status,
+      owner: params?.owner,
+      source: params?.source,
+      workflowType: params?.workflowType,
+      limit: params?.limit,
+    })}`, undefined, { admin: true })
+
+    return {
+      blob: await response.blob(),
+      filename: getFilenameFromResponse(response, 'beta-requests', format),
+    }
+  },
   createOrg: (input: OrgRegistrationInput) => request<OrgRegistrationResponse>('/orgs', {
     method: 'POST',
     body: JSON.stringify(input),

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Download, RefreshCw, Search } from 'lucide-react'
+import { useSearchParams } from 'react-router-dom'
+import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import { useAdminAuth } from '../lib/admin-auth'
+import {
+  ApiError,
+  directoryApi,
+  type BetaRequest,
+  type BetaRequestStatus,
+} from '../lib/api'
+import { downloadBlob, formatDateTime, formatRelativeTime } from '../lib/utils'
+
+const STATUS_OPTIONS: Array<{ value: '' | BetaRequestStatus; label: string }> = [
+  { value: '', label: 'All statuses' },
+  { value: 'new', label: 'New' },
+  { value: 'reviewing', label: 'Reviewing' },
+  { value: 'contacted', label: 'Contacted' },
+  { value: 'scheduled', label: 'Scheduled' },
+  { value: 'active', label: 'Active' },
+  { value: 'closed', label: 'Closed' },
+]
+
+export default function BetaRequestsPage() {
+  const { session } = useAdminAuth()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [requests, setRequests] = useState<BetaRequest[]>([])
+  const [total, setTotal] = useState(0)
+  const [summary, setSummary] = useState<{
+    total: number
+    active: number
+    unowned: number
+    byStatus: Record<BetaRequestStatus, number>
+  } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const query = searchParams.get('q') ?? ''
+  const status = (searchParams.get('status') ?? '') as '' | BetaRequestStatus
+  const ownerFilter = searchParams.get('owner') ?? ''
+  const selectedId = Number.parseInt(searchParams.get('id') ?? '', 10)
+  const canEdit = session?.role === 'admin' || session?.role === 'operator'
+
+  const selectedRequest = useMemo(
+    () => requests.find((entry) => entry.id === selectedId) ?? requests[0] ?? null,
+    [requests, selectedId],
+  )
+
+  const [draftStatus, setDraftStatus] = useState<BetaRequestStatus>('new')
+  const [draftOwner, setDraftOwner] = useState('')
+  const [draftNotes, setDraftNotes] = useState('')
+
+  function updateSearchParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams)
+    if (!value) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  useEffect(() => {
+    if (!selectedRequest) {
+      return
+    }
+
+    if (!selectedId || selectedId !== selectedRequest.id) {
+      const next = new URLSearchParams(searchParams)
+      next.set('id', String(selectedRequest.id))
+      setSearchParams(next, { replace: true })
+    }
+  }, [searchParams, selectedId, selectedRequest, setSearchParams])
+
+  useEffect(() => {
+    if (!selectedRequest) {
+      setDraftStatus('new')
+      setDraftOwner('')
+      setDraftNotes('')
+      return
+    }
+
+    setDraftStatus(selectedRequest.requestStatus)
+    setDraftOwner(selectedRequest.owner ?? '')
+    setDraftNotes(selectedRequest.operatorNotes ?? '')
+  }, [selectedRequest])
+
+  async function load() {
+    try {
+      setLoading(true)
+      const response = await directoryApi.listBetaRequests({
+        q: query || undefined,
+        status: status || undefined,
+        owner: ownerFilter || undefined,
+        limit: 200,
+      })
+      setRequests(response.requests)
+      setTotal(response.total)
+      setSummary(response.summary)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load hosted beta requests')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [ownerFilter, query, status])
+
+  async function saveRequest() {
+    if (!selectedRequest || !canEdit) {
+      return
+    }
+
+    try {
+      setSaving(true)
+      setNotice(null)
+      const response = await directoryApi.updateBetaRequest(selectedRequest.id, {
+        status: draftStatus,
+        owner: draftOwner || null,
+        operatorNotes: draftNotes || null,
+      })
+      setRequests((current) => current.map((entry) => (
+        entry.id === response.request.id ? response.request : entry
+      )))
+      setNotice('Operator updates saved.')
+      await load()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to save beta request')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function exportRequests(format: 'json' | 'csv') {
+    try {
+      setNotice(null)
+      const download = await directoryApi.downloadBetaRequestsExport(format, {
+        q: query || undefined,
+        status: status || undefined,
+        owner: ownerFilter || undefined,
+        limit: 5000,
+      })
+      downloadBlob(download.blob, download.filename)
+      setNotice(`Exported hosted beta requests as ${format.toUpperCase()}.`)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to export beta requests')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Hosted Beta Requests"
+        description="Review, assign, and export incoming hosted beta workflows without touching the database."
+        actions={(
+          <div className="flex flex-wrap gap-2">
+            <button className="btn-secondary" onClick={() => void exportRequests('json')} type="button">
+              <Download size={16} />
+              <span>Export JSON</span>
+            </button>
+            <button className="btn-secondary" onClick={() => void exportRequests('csv')} type="button">
+              <Download size={16} />
+              <span>Export CSV</span>
+            </button>
+            <button className="btn-secondary" onClick={() => void load()} type="button">
+              <RefreshCw size={16} />
+              <span>Refresh</span>
+            </button>
+          </div>
+        )}
+      />
+
+      {summary ? (
+        <section className="grid gap-4 md:grid-cols-4">
+          <MetricCard label="Total requests" value={String(summary.total)} hint="All hosted beta requests in the current filter." />
+          <MetricCard label="Active requests" value={String(summary.active)} hint="Everything that is not closed." tone="success" />
+          <MetricCard label="Unowned" value={String(summary.unowned)} hint="Requests without an assigned operator." tone={summary.unowned > 0 ? 'warning' : 'default'} />
+          <MetricCard label="New" value={String(summary.byStatus.new)} hint="Fresh requests that still need first review." tone={summary.byStatus.new > 0 ? 'warning' : 'default'} />
+        </section>
+      ) : null}
+
+      <section className="panel">
+        <div className="grid gap-3 lg:grid-cols-[1.5fr,0.8fr,0.8fr]">
+          <label className="relative block">
+            <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              className="input-field pl-10"
+              placeholder="Search email, company, workflow, notes"
+              value={query}
+              onChange={(event) => updateSearchParam('q', event.target.value)}
+            />
+          </label>
+          <select className="input-field" value={status} onChange={(event) => updateSearchParam('status', event.target.value)}>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <input
+            className="input-field"
+            placeholder="Filter by owner"
+            value={ownerFilter}
+            onChange={(event) => updateSearchParam('owner', event.target.value)}
+          />
+        </div>
+      </section>
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {notice ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+          {notice}
+        </div>
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel overflow-hidden p-0">
+          <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <div className="panel-title">Queue</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{total} request(s) match the current filters.</p>
+          </div>
+
+          {loading ? (
+            <div className="p-5 text-sm text-slate-500 dark:text-slate-400">Loading hosted beta requests…</div>
+          ) : requests.length === 0 ? (
+            <div className="p-5">
+              <EmptyPanel label="No hosted beta requests matched the current filters." />
+            </div>
+          ) : (
+            <div className="divide-y divide-slate-200 dark:divide-slate-800">
+              {requests.map((entry) => {
+                const active = selectedRequest?.id === entry.id
+
+                return (
+                  <button
+                    key={entry.id}
+                    className={`flex w-full flex-col gap-2 px-5 py-4 text-left transition ${active ? 'bg-orange-50 dark:bg-orange-500/10' : 'hover:bg-slate-50 dark:hover:bg-slate-900'}`}
+                    onClick={() => updateSearchParam('id', String(entry.id))}
+                    type="button"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill label={entry.requestStatus} tone={statusTone(entry.requestStatus)} />
+                      <span className="text-sm font-medium text-slate-900 dark:text-slate-100">{entry.company ?? entry.email}</span>
+                      <span className="text-xs text-slate-500 dark:text-slate-400">{entry.email}</span>
+                    </div>
+                    <div className="text-sm text-slate-600 dark:text-slate-300">
+                      {formatWorkflowType(entry.workflowType)}
+                      {entry.agentCount != null ? ` · ${entry.agentCount} agent${entry.agentCount === 1 ? '' : 's'}` : ''}
+                    </div>
+                    <div className="flex flex-wrap gap-3 text-xs text-slate-500 dark:text-slate-400">
+                      <span>Owner: {entry.owner ?? 'unassigned'}</span>
+                      <span>Updated {formatRelativeTime(entry.updatedAt)}</span>
+                      <span>Source: {entry.source ?? 'unknown'}</span>
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <div className="panel space-y-4">
+            <div className="panel-title">Request detail</div>
+            {!selectedRequest ? (
+              <EmptyPanel label="Select a hosted beta request to inspect its workflow summary and assignment state." />
+            ) : (
+              <>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <InfoRow label="Company" value={selectedRequest.company ?? '—'} />
+                  <InfoRow label="Email" value={selectedRequest.email} />
+                  <InfoRow label="Workflow" value={formatWorkflowType(selectedRequest.workflowType)} />
+                  <InfoRow label="Source" value={selectedRequest.source ?? '—'} />
+                  <InfoRow label="Created" value={formatDateTime(selectedRequest.createdAt)} />
+                  <InfoRow label="Updated" value={formatDateTime(selectedRequest.updatedAt)} />
+                </div>
+
+                <div className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                  {selectedRequest.workflowSummary || 'No workflow summary was provided in the intake.'}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="panel space-y-4">
+            <div className="panel-title">Operator assignment</div>
+            {!selectedRequest ? (
+              <EmptyPanel label="Select a request to assign an owner, move the status, and capture follow-up notes." />
+            ) : (
+              <>
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium">Status</span>
+                  <select
+                    className="input-field"
+                    disabled={!canEdit || saving}
+                    value={draftStatus}
+                    onChange={(event) => setDraftStatus(event.target.value as BetaRequestStatus)}
+                  >
+                    {STATUS_OPTIONS.filter((option) => option.value).map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium">Owner</span>
+                  <input
+                    className="input-field"
+                    disabled={!canEdit || saving}
+                    placeholder="operator@beam.directory"
+                    value={draftOwner}
+                    onChange={(event) => setDraftOwner(event.target.value)}
+                  />
+                </label>
+
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium">Operator notes</span>
+                  <textarea
+                    className="input-field min-h-36"
+                    disabled={!canEdit || saving}
+                    placeholder="Capture the next step, missing context, or why the request is blocked."
+                    value={draftNotes}
+                    onChange={(event) => setDraftNotes(event.target.value)}
+                  />
+                </label>
+
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    className="btn-primary disabled:cursor-not-allowed disabled:opacity-60"
+                    disabled={!canEdit || saving}
+                    onClick={() => void saveRequest()}
+                    type="button"
+                  >
+                    {saving ? 'Saving…' : 'Save operator update'}
+                  </button>
+                  {!canEdit ? (
+                    <span className="text-sm text-slate-500 dark:text-slate-400">
+                      Viewer sessions can inspect and export, but not edit.
+                    </span>
+                  ) : null}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function formatWorkflowType(value: string | null): string {
+  if (!value) {
+    return 'No workflow type'
+  }
+
+  return value
+    .replace(/^hosted-beta-/, '')
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function statusTone(status: BetaRequestStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'active':
+      return 'success'
+    case 'closed':
+      return 'default'
+    case 'new':
+    case 'reviewing':
+    case 'contacted':
+    case 'scheduled':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-sm text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-1 break-words text-sm font-medium text-slate-900 dark:text-slate-100">{value}</div>
+    </div>
+  )
+}

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -157,11 +157,23 @@ function initSchema(db: DB): void {
       source TEXT,
       company TEXT,
       agent_count INTEGER,
-      created_at TEXT NOT NULL
+      workflow_type TEXT,
+      workflow_summary TEXT,
+      status TEXT NOT NULL DEFAULT 'new',
+      owner TEXT,
+      operator_notes TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
     );
 
     CREATE INDEX IF NOT EXISTS idx_waitlist_created_at
       ON waitlist(created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_waitlist_status
+      ON waitlist(status, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_waitlist_owner
+      ON waitlist(owner, created_at DESC);
 
     CREATE TABLE IF NOT EXISTS intent_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -460,6 +472,19 @@ function initSchema(db: DB): void {
   // Create indexes that depend on ensureColumn'd columns
   db.exec(`CREATE INDEX IF NOT EXISTS idx_agents_verification_tier ON agents(verification_tier, trust_score DESC)`)
   ensureColumn(db, 'agents', 'personal', 'INTEGER NOT NULL DEFAULT 0')
+  ensureColumn(db, 'waitlist', 'workflow_type', 'TEXT')
+  ensureColumn(db, 'waitlist', 'workflow_summary', 'TEXT')
+  ensureColumn(db, 'waitlist', 'status', "TEXT NOT NULL DEFAULT 'new'")
+  ensureColumn(db, 'waitlist', 'owner', 'TEXT')
+  ensureColumn(db, 'waitlist', 'operator_notes', 'TEXT')
+  ensureColumn(db, 'waitlist', 'updated_at', 'TEXT')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_status ON waitlist(status, created_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_owner ON waitlist(owner, created_at DESC)')
+  db.prepare(`
+    UPDATE waitlist
+    SET status = COALESCE(NULLIF(status, ''), 'new'),
+        updated_at = COALESCE(NULLIF(updated_at, ''), created_at)
+  `).run()
   ensureIntentLogSchema(db)
   ensureColumn(db, 'intent_trace_events', 'nonce', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_intent_trace_nonce ON intent_trace_events(nonce, timestamp ASC, id ASC)')

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -1,7 +1,26 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
-import { createDatabase } from './db.js'
+import { assignDirectoryRole, createDatabase } from './db.js'
+import { getLocalDirectoryUrl } from './federation.js'
+
+function createAdminHeaders(
+  db: ReturnType<typeof createDatabase>,
+  email = 'ops@example.com',
+  role: 'admin' | 'operator' | 'viewer' = 'admin',
+) {
+  process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+  assignDirectoryRole(db, {
+    userId: email,
+    role,
+    directoryUrl: getLocalDirectoryUrl(),
+  })
+  const session = createAdminSession(db, { email, role })
+  return {
+    Authorization: `Bearer ${session.token}`,
+  }
+}
 
 test('cors allows production public-site and loopback dashboard origins', async () => {
   const db = createDatabase(':memory:')
@@ -55,14 +74,18 @@ test('waitlist signups are idempotent by email and preserve the original created
     const first = await firstResponse.json() as {
       ok: boolean
       status: string
-      createdAt: string
-      company: string
-      agentCount: number
+      request: {
+        createdAt: string
+        company: string
+        agentCount: number
+        requestStatus: string
+      }
     }
     assert.equal(first.ok, true)
     assert.equal(first.status, 'registered')
-    assert.equal(first.company, 'Acme')
-    assert.equal(first.agentCount, 8)
+    assert.equal(first.request.company, 'Acme')
+    assert.equal(first.request.agentCount, 8)
+    assert.equal(first.request.requestStatus, 'new')
 
     const secondResponse = await app.request(new Request('http://localhost/waitlist', {
       method: 'POST',
@@ -82,17 +105,19 @@ test('waitlist signups are idempotent by email and preserve the original created
     const second = await secondResponse.json() as {
       ok: boolean
       status: string
-      createdAt: string
-      company: string
-      agentCount: number
-      source: string
+      request: {
+        createdAt: string
+        company: string
+        agentCount: number
+        source: string
+      }
     }
     assert.equal(second.ok, true)
     assert.equal(second.status, 'already_registered')
-    assert.equal(second.company, 'Acme Renewed')
-    assert.equal(second.agentCount, 14)
-    assert.equal(second.source, 'hosted-beta-follow-up')
-    assert.equal(second.createdAt, first.createdAt)
+    assert.equal(second.request.company, 'Acme Renewed')
+    assert.equal(second.request.agentCount, 14)
+    assert.equal(second.request.source, 'hosted-beta-follow-up')
+    assert.equal(second.request.createdAt, first.request.createdAt)
 
     const row = db.prepare(`
       SELECT COUNT(*) AS count, company, agent_count, source, created_at
@@ -110,7 +135,114 @@ test('waitlist signups are idempotent by email and preserve the original created
     assert.equal(row.company, 'Acme Renewed')
     assert.equal(row.agent_count, 14)
     assert.equal(row.source, 'hosted-beta-follow-up')
-    assert.equal(row.created_at, first.createdAt)
+    assert.equal(row.created_at, first.request.createdAt)
+  } finally {
+    db.close()
+  }
+})
+
+test('hosted beta requests can be created publicly, reviewed by operators, and exported', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const app = createApp(db)
+
+    const createResponse = await app.request(new Request('http://localhost/waitlist', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Origin: 'https://beam.directory',
+      },
+      body: JSON.stringify({
+        email: 'buyer@example.com',
+        source: 'hosted-beta-page',
+        company: 'Northwind Systems',
+        agentCount: 6,
+        workflowType: 'hosted-beta-partner-handoff',
+        workflowSummary: 'Procurement asks partner operations for stock, then finance approves the async quote.',
+      }),
+    }))
+
+    assert.equal(createResponse.status, 201)
+    const created = await createResponse.json() as {
+      ok: boolean
+      request: {
+        id: number
+        source: string
+        workflowType: string
+        workflowSummary: string
+        requestStatus: string
+      }
+      nextStep: string
+    }
+    assert.equal(created.ok, true)
+    assert.equal(created.request.source, 'hosted-beta-page')
+    assert.equal(created.request.workflowType, 'hosted-beta-partner-handoff')
+    assert.match(created.request.workflowSummary, /Procurement/)
+    assert.equal(created.request.requestStatus, 'new')
+    assert.match(created.nextStep, /review/i)
+
+    const listResponse = await app.request(new Request('http://localhost/admin/beta-requests?status=new', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listResponse.status, 200)
+
+    const listed = await listResponse.json() as {
+      total: number
+      requests: Array<{
+        id: number
+        email: string
+        workflowSummary: string
+        requestStatus: string
+      }>
+      summary: {
+        total: number
+        byStatus: Record<string, number>
+      }
+    }
+    assert.equal(listed.total, 1)
+    assert.equal(listed.summary.total, 1)
+    assert.equal(listed.summary.byStatus['new'], 1)
+    assert.equal(listed.requests[0]?.email, 'buyer@example.com')
+    assert.match(listed.requests[0]?.workflowSummary ?? '', /finance approves/)
+
+    const updateResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'operator@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'reviewing',
+        owner: 'operator@example.com',
+        operatorNotes: 'Intro email sent, follow-up call pending.',
+      }),
+    }))
+    assert.equal(updateResponse.status, 200)
+
+    const updated = await updateResponse.json() as {
+      ok: boolean
+      request: {
+        requestStatus: string
+        owner: string
+        operatorNotes: string
+      }
+    }
+    assert.equal(updated.ok, true)
+    assert.equal(updated.request.requestStatus, 'reviewing')
+    assert.equal(updated.request.owner, 'operator@example.com')
+    assert.match(updated.request.operatorNotes, /Intro email/)
+
+    const exportResponse = await app.request(new Request('http://localhost/admin/beta-requests/export?format=csv', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(exportResponse.status, 200)
+    assert.equal(exportResponse.headers.get('content-type'), 'text/csv; charset=utf-8')
+    const csv = await exportResponse.text()
+    assert.match(csv, /workflow_summary/)
+    assert.match(csv, /Northwind Systems/)
+    assert.match(csv, /operator@example.com/)
   } finally {
     db.close()
   }

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -49,6 +49,25 @@ type WaitlistSignupInput = {
   source: string | null
   company: string | null
   agentCount: number | null
+  workflowType: string | null
+  workflowSummary: string | null
+}
+
+type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
+
+type BetaRequestUpdateInput = {
+  status?: BetaRequestStatus
+  owner?: string | null
+  operatorNotes?: string | null
+}
+
+type BetaRequestFilters = {
+  q?: string
+  status?: string
+  owner?: string
+  source?: string
+  workflowType?: string
+  limit?: number
 }
 
 type WaitlistRow = {
@@ -57,7 +76,80 @@ type WaitlistRow = {
   source: string | null
   company: string | null
   agent_count: number | null
+  workflow_type: string | null
+  workflow_summary: string | null
+  status: string
+  owner: string | null
+  operator_notes: string | null
   created_at: string
+  updated_at: string
+}
+
+const BETA_REQUEST_STATUSES: BetaRequestStatus[] = ['new', 'reviewing', 'contacted', 'scheduled', 'active', 'closed']
+const BETA_REQUEST_STATUS_SET = new Set<string>(BETA_REQUEST_STATUSES)
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeBetaRequestStatus(value: unknown): BetaRequestStatus | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!BETA_REQUEST_STATUS_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as BetaRequestStatus
+}
+
+function serializeBetaRequest(row: WaitlistRow) {
+  return {
+    id: row.id,
+    email: row.email,
+    source: row.source,
+    company: row.company,
+    agentCount: row.agent_count,
+    workflowType: row.workflow_type,
+    workflowSummary: row.workflow_summary,
+    requestStatus: normalizeBetaRequestStatus(row.status) ?? 'new',
+    owner: row.owner,
+    operatorNotes: row.operator_notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function getBetaRequestNextStep(status: string): string {
+  switch (status) {
+    case 'reviewing':
+      return 'Beam is reviewing the workflow and assigning an operator.'
+    case 'contacted':
+      return 'Beam will follow up directly on the request by email.'
+    case 'scheduled':
+      return 'Beam has a follow-up call or working session queued for this request.'
+    case 'active':
+      return 'This request is in an active hosted beta rollout.'
+    case 'closed':
+      return 'This request is closed. Submit a fresh intake if the workflow changed materially.'
+    default:
+      return 'Beam will review the workflow, assign an owner, and follow up with the next concrete step.'
+  }
+}
+
+function escapeCsvValue(value: string | number | null | undefined): string {
+  if (value == null) {
+    return ''
+  }
+
+  const text = String(value)
+  if (!/[",\n]/.test(text)) {
+    return text
+  }
+
+  return `"${text.replaceAll('"', '""')}"`
 }
 
 const PUBLIC_CORS_ORIGINS = new Set([
@@ -136,7 +228,195 @@ function getTableColumns(db: Database, tableName: string): Set<string> {
   return new Set(rows.map((row) => row.name))
 }
 
-function getWaitlistEntries(db: Database): { available: boolean; waitlist: Array<{ email: string; company: string | null; signupDate: string | null }>; total: number } {
+function getBetaRequestWhereClause(filters: {
+  q?: string
+  status?: string
+  owner?: string
+  source?: string
+  workflowType?: string
+} = {}): { whereSql: string; params: unknown[] } {
+  const params: unknown[] = []
+  const conditions: string[] = []
+
+  if (filters.q) {
+    const needle = `%${filters.q.trim()}%`
+    conditions.push(`(
+      email LIKE ?
+      OR COALESCE(company, '') LIKE ?
+      OR COALESCE(source, '') LIKE ?
+      OR COALESCE(workflow_type, '') LIKE ?
+      OR COALESCE(workflow_summary, '') LIKE ?
+      OR COALESCE(owner, '') LIKE ?
+      OR COALESCE(operator_notes, '') LIKE ?
+    )`)
+    params.push(needle, needle, needle, needle, needle, needle, needle)
+  }
+
+  if (filters.status && BETA_REQUEST_STATUS_SET.has(filters.status)) {
+    conditions.push('status = ?')
+    params.push(filters.status)
+  }
+
+  if (filters.owner) {
+    conditions.push('COALESCE(owner, \'\') LIKE ?')
+    params.push(`%${filters.owner.trim()}%`)
+  }
+
+  if (filters.source) {
+    conditions.push('COALESCE(source, \'\') LIKE ?')
+    params.push(`%${filters.source.trim()}%`)
+  }
+
+  if (filters.workflowType) {
+    conditions.push('COALESCE(workflow_type, \'\') LIKE ?')
+    params.push(`%${filters.workflowType.trim()}%`)
+  }
+
+  return {
+    whereSql: conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  }
+}
+
+function listBetaRequestRows(db: Database, filters: {
+  q?: string
+  status?: string
+  owner?: string
+  source?: string
+  workflowType?: string
+  limit?: number
+} = {}): { rows: WaitlistRow[]; total: number } {
+  const limit = Math.min(Math.max(Number(filters.limit ?? 200) || 200, 1), 5000)
+  const { whereSql, params } = getBetaRequestWhereClause(filters)
+  const orderBy = `
+    ORDER BY CASE status
+      WHEN 'new' THEN 0
+      WHEN 'reviewing' THEN 1
+      WHEN 'contacted' THEN 2
+      WHEN 'scheduled' THEN 3
+      WHEN 'active' THEN 4
+      WHEN 'closed' THEN 5
+      ELSE 6
+    END ASC,
+    datetime(updated_at) DESC,
+    datetime(created_at) DESC,
+    id DESC
+  `
+
+  const rows = db.prepare(`
+    SELECT
+      id,
+      email,
+      source,
+      company,
+      agent_count,
+      workflow_type,
+      workflow_summary,
+      status,
+      owner,
+      operator_notes,
+      created_at,
+      updated_at
+    FROM waitlist
+    ${whereSql}
+    ${orderBy}
+    LIMIT ?
+  `).all(...params, limit) as WaitlistRow[]
+
+  const total = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM waitlist
+    ${whereSql}
+  `).get(...params) as { count: number } | undefined)?.count ?? rows.length
+
+  return { rows, total }
+}
+
+function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
+  const row = db.prepare(`
+    SELECT
+      id,
+      email,
+      source,
+      company,
+      agent_count,
+      workflow_type,
+      workflow_summary,
+      status,
+      owner,
+      operator_notes,
+      created_at,
+      updated_at
+    FROM waitlist
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as WaitlistRow | undefined
+
+  return row ?? null
+}
+
+function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
+  const byStatus = Object.fromEntries(BETA_REQUEST_STATUSES.map((status) => [status, 0])) as Record<BetaRequestStatus, number>
+  let unowned = 0
+  let active = 0
+
+  for (const row of rows) {
+    const status = normalizeBetaRequestStatus(row.status) ?? 'new'
+    byStatus[status] += 1
+    if (!row.owner) {
+      unowned += 1
+    }
+    if (status !== 'closed') {
+      active += 1
+    }
+  }
+
+  return {
+    total,
+    active,
+    unowned,
+    byStatus,
+  }
+}
+
+function buildBetaRequestCsv(rows: WaitlistRow[]): string {
+  const headers = [
+    'id',
+    'email',
+    'company',
+    'source',
+    'workflow_type',
+    'workflow_summary',
+    'agent_count',
+    'status',
+    'owner',
+    'operator_notes',
+    'created_at',
+    'updated_at',
+  ]
+
+  const lines = [headers.join(',')]
+  for (const row of rows) {
+    lines.push([
+      row.id,
+      row.email,
+      row.company,
+      row.source,
+      row.workflow_type,
+      row.workflow_summary,
+      row.agent_count,
+      row.status,
+      row.owner,
+      row.operator_notes,
+      row.created_at,
+      row.updated_at,
+    ].map((value) => escapeCsvValue(value as string | number | null | undefined)).join(','))
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+function getWaitlistEntries(db: Database): { available: boolean; waitlist: Array<{ email: string; company: string | null; signupDate: string | null; status: string | null; owner: string | null }>; total: number } {
   if (!tableExists(db, 'waitlist')) {
     return { available: false, waitlist: [], total: 0 }
   }
@@ -161,6 +441,12 @@ function getWaitlistEntries(db: Database): { available: boolean; waitlist: Array
       : columns.has('createdAt')
         ? 'createdAt'
         : 'NULL'
+  const statusExpr = columns.has('status')
+    ? 'status'
+    : 'NULL'
+  const ownerExpr = columns.has('owner')
+    ? 'owner'
+    : 'NULL'
   const orderByExpr = columns.has('created_at')
     ? 'created_at'
     : columns.has('signup_date')
@@ -173,10 +459,12 @@ function getWaitlistEntries(db: Database): { available: boolean; waitlist: Array
     SELECT
       ${emailExpr} AS email,
       ${companyExpr} AS company,
-      ${signupDateExpr} AS signupDate
+      ${signupDateExpr} AS signupDate,
+      ${statusExpr} AS status,
+      ${ownerExpr} AS owner
     FROM waitlist
     ORDER BY ${orderByExpr} DESC
-  `).all() as Array<{ email: string; company: string | null; signupDate: string | null }>
+  `).all() as Array<{ email: string; company: string | null; signupDate: string | null; status: string | null; owner: string | null }>
 
   return {
     available: true,
@@ -703,6 +991,206 @@ export function createApp(db: Database): Hono {
     }
   })
 
+  app.get('/admin/beta-requests', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    try {
+      const filters: BetaRequestFilters = {
+        q: c.req.query('q') ?? undefined,
+        status: c.req.query('status') ?? undefined,
+        owner: c.req.query('owner') ?? undefined,
+        source: c.req.query('source') ?? undefined,
+        workflowType: c.req.query('workflowType') ?? undefined,
+        limit: c.req.query('limit') ? Number.parseInt(c.req.query('limit') as string, 10) : undefined,
+      }
+
+      const { rows, total } = listBetaRequestRows(db, filters)
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        requests: rows.map((row) => serializeBetaRequest(row)),
+        total,
+        summary: summarizeBetaRequests(rows, total),
+      })
+    } catch (err) {
+      console.error('Admin beta requests error:', err)
+      return c.json({ error: 'Failed to load beta requests', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  app.get('/admin/beta-requests/export', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const format = (c.req.query('format') ?? 'json').trim().toLowerCase()
+    if (format !== 'json' && format !== 'csv') {
+      return c.json({ error: 'format must be json or csv', errorCode: 'INVALID_EXPORT_FORMAT' }, 400)
+    }
+
+    try {
+      const filters: BetaRequestFilters = {
+        q: c.req.query('q') ?? undefined,
+        status: c.req.query('status') ?? undefined,
+        owner: c.req.query('owner') ?? undefined,
+        source: c.req.query('source') ?? undefined,
+        workflowType: c.req.query('workflowType') ?? undefined,
+        limit: c.req.query('limit') ? Number.parseInt(c.req.query('limit') as string, 10) : 5000,
+      }
+
+      const { rows, total } = listBetaRequestRows(db, filters)
+      const timestamp = new Date().toISOString().replaceAll(':', '-')
+
+      logAuditEvent(db, {
+        action: 'admin.beta_requests.exported',
+        actor: auth.session.email,
+        target: 'beta_requests',
+        details: {
+          format,
+          total,
+          filters,
+          role: auth.session.role,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      if (format === 'csv') {
+        c.header('Content-Type', 'text/csv; charset=utf-8')
+        c.header('Content-Disposition', `attachment; filename="beam-beta-requests-${timestamp}.csv"`)
+        return c.body(buildBetaRequestCsv(rows))
+      }
+
+      c.header('Content-Type', 'application/json; charset=utf-8')
+      c.header('Content-Disposition', `attachment; filename="beam-beta-requests-${timestamp}.json"`)
+      return c.body(JSON.stringify({
+        exportedAt: new Date().toISOString(),
+        total,
+        summary: summarizeBetaRequests(rows, total),
+        requests: rows.map((row) => serializeBetaRequest(row)),
+      }, null, 2))
+    } catch (err) {
+      console.error('Admin beta request export error:', err)
+      return c.json({ error: 'Failed to export beta requests', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  app.get('/admin/beta-requests/:id', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const id = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(id) || id <= 0) {
+      return c.json({ error: 'Invalid beta request id', errorCode: 'INVALID_BETA_REQUEST_ID' }, 400)
+    }
+
+    try {
+      const row = getBetaRequestById(db, id)
+      if (!row) {
+        return c.json({ error: 'Beta request not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+      c.header('Cache-Control', 'no-store')
+      return c.json({ request: serializeBetaRequest(row) })
+    } catch (err) {
+      console.error('Admin beta request detail error:', err)
+      return c.json({ error: 'Failed to load beta request', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  app.patch('/admin/beta-requests/:id', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const id = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(id) || id <= 0) {
+      return c.json({ error: 'Invalid beta request id', errorCode: 'INVALID_BETA_REQUEST_ID' }, 400)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const patch: BetaRequestUpdateInput = {}
+
+    if ('status' in raw) {
+      const status = normalizeBetaRequestStatus(raw.status)
+      if (!status) {
+        return c.json({ error: 'Invalid beta request status', errorCode: 'INVALID_BETA_REQUEST_STATUS' }, 400)
+      }
+      patch.status = status
+    }
+
+    if ('owner' in raw) {
+      patch.owner = normalizeOptionalString(raw.owner)
+    }
+
+    if ('operatorNotes' in raw) {
+      patch.operatorNotes = normalizeOptionalString(raw.operatorNotes)
+    }
+
+    if (!('status' in patch) && !('owner' in patch) && !('operatorNotes' in patch)) {
+      return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
+    }
+
+    try {
+      const existing = getBetaRequestById(db, id)
+      if (!existing) {
+        return c.json({ error: 'Beta request not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      const nextStatus = patch.status ?? (normalizeBetaRequestStatus(existing.status) ?? 'new')
+      const nextOwner = 'owner' in patch ? patch.owner ?? null : existing.owner
+      const nextOperatorNotes = 'operatorNotes' in patch ? patch.operatorNotes ?? null : existing.operator_notes
+      const updatedAt = new Date().toISOString()
+
+      db.prepare(`
+        UPDATE waitlist
+        SET status = ?, owner = ?, operator_notes = ?, updated_at = ?
+        WHERE id = ?
+      `).run(nextStatus, nextOwner, nextOperatorNotes, updatedAt, id)
+
+      const updated = getBetaRequestById(db, id)
+      if (!updated) {
+        return c.json({ error: 'Beta request not found after update', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      logAuditEvent(db, {
+        action: 'admin.beta_request.updated',
+        actor: auth.session.email,
+        target: String(id),
+        details: {
+          role: auth.session.role,
+          status: nextStatus,
+          owner: nextOwner,
+          operatorNotesChanged: 'operatorNotes' in patch,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        request: serializeBetaRequest(updated),
+      })
+    } catch (err) {
+      console.error('Admin beta request update error:', err)
+      return c.json({ error: 'Failed to update beta request', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
   app.get('/admin/waitlist', (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
@@ -1017,18 +1505,28 @@ export function createApp(db: Database): Hono {
       return c.json({ error: 'A valid email is required', errorCode: 'INVALID_EMAIL' }, 400)
     }
 
+    const workflowType = normalizeOptionalString(raw.workflowType)
+      ?? (
+        typeof raw.source === 'string' && raw.source.trim().startsWith('hosted-beta-')
+          ? raw.source.trim()
+          : null
+      )
+    const workflowSummary = normalizeOptionalString(raw.workflowSummary) ?? normalizeOptionalString(raw.notes)
+
     const signup: WaitlistSignupInput = {
       email,
       source,
       company,
       agentCount,
+      workflowType,
+      workflowSummary,
     }
 
-    const createdAt = new Date().toISOString()
+    const timestamp = new Date().toISOString()
 
     try {
       const existing = db.prepare(`
-        SELECT id, email, source, company, agent_count, created_at
+        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, created_at, updated_at
         FROM waitlist
         WHERE email = ?
         ORDER BY created_at DESC, id DESC
@@ -1039,43 +1537,106 @@ export function createApp(db: Database): Hono {
         const nextSource = signup.source ?? existing.source
         const nextCompany = signup.company ?? existing.company
         const nextAgentCount = signup.agentCount ?? existing.agent_count
+        const nextWorkflowType = signup.workflowType ?? existing.workflow_type
+        const nextWorkflowSummary = signup.workflowSummary ?? existing.workflow_summary
+        const nextStatus = (normalizeBetaRequestStatus(existing.status) ?? 'new') === 'closed'
+          ? 'new'
+          : (normalizeBetaRequestStatus(existing.status) ?? 'new')
 
         db.prepare(`
           UPDATE waitlist
-          SET source = ?, company = ?, agent_count = ?
+          SET source = ?, company = ?, agent_count = ?, workflow_type = ?, workflow_summary = ?, status = ?, updated_at = ?
           WHERE id = ?
-        `).run(nextSource, nextCompany, nextAgentCount, existing.id)
+        `).run(nextSource, nextCompany, nextAgentCount, nextWorkflowType, nextWorkflowSummary, nextStatus, timestamp, existing.id)
+
+        const updated = getBetaRequestById(db, existing.id)
+        if (!updated) {
+          return c.json({ error: 'Failed to load updated beta request', errorCode: 'DB_ERROR' }, 500)
+        }
 
         return c.json({
           ok: true,
           status: 'already_registered',
-          id: existing.id,
-          email: existing.email,
-          source: nextSource,
-          company: nextCompany,
-          agentCount: nextAgentCount,
-          createdAt: existing.created_at,
+          id: updated.id,
+          email: updated.email,
+          source: updated.source,
+          company: updated.company,
+          agentCount: updated.agent_count,
+          workflowType: updated.workflow_type,
+          workflowSummary: updated.workflow_summary,
+          requestStatus: normalizeBetaRequestStatus(updated.status) ?? 'new',
+          owner: updated.owner,
+          operatorNotes: updated.operator_notes,
+          createdAt: updated.created_at,
+          updatedAt: updated.updated_at,
+          request: serializeBetaRequest(updated),
+          nextStep: getBetaRequestNextStep(updated.status),
         }, 200)
       }
 
       const result = db.prepare(`
-        INSERT INTO waitlist (email, source, company, agent_count, created_at)
-        VALUES (?, ?, ?, ?, ?)
-      `).run(signup.email, signup.source, signup.company, signup.agentCount, createdAt)
+        INSERT INTO waitlist (
+          email,
+          source,
+          company,
+          agent_count,
+          workflow_type,
+          workflow_summary,
+          status,
+          owner,
+          operator_notes,
+          created_at,
+          updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, ?, ?)
+      `).run(
+        signup.email,
+        signup.source,
+        signup.company,
+        signup.agentCount,
+        signup.workflowType,
+        signup.workflowSummary,
+        timestamp,
+        timestamp,
+      )
 
       console.log(
-        `[waitlist] new signup email=${signup.email} source=${signup.source ?? '-'} company=${signup.company ?? '-'} agentCount=${signup.agentCount ?? '-'} createdAt=${createdAt}`
+        `[waitlist] new signup email=${signup.email} source=${signup.source ?? '-'} company=${signup.company ?? '-'} agentCount=${signup.agentCount ?? '-'} workflowType=${signup.workflowType ?? '-'} createdAt=${timestamp}`
       )
+
+      logAuditEvent(db, {
+        action: 'beta_request.created',
+        actor: signup.email,
+        target: signup.company ?? signup.email,
+        details: {
+          source: signup.source,
+          workflowType: signup.workflowType,
+          agentCount: signup.agentCount,
+        },
+      })
+
+      const created = getBetaRequestById(db, Number(result.lastInsertRowid))
+      if (!created) {
+        return c.json({ error: 'Failed to load saved beta request', errorCode: 'DB_ERROR' }, 500)
+      }
 
       return c.json({
         ok: true,
         status: 'registered',
-        id: Number(result.lastInsertRowid),
-        email: signup.email,
-        source: signup.source,
-        company: signup.company,
-        agentCount: signup.agentCount,
-        createdAt,
+        id: created.id,
+        email: created.email,
+        source: created.source,
+        company: created.company,
+        agentCount: created.agent_count,
+        workflowType: created.workflow_type,
+        workflowSummary: created.workflow_summary,
+        requestStatus: normalizeBetaRequestStatus(created.status) ?? 'new',
+        owner: created.owner,
+        operatorNotes: created.operator_notes,
+        createdAt: created.created_at,
+        updatedAt: created.updated_at,
+        request: serializeBetaRequest(created),
+        nextStep: getBetaRequestNextStep(created.status),
       }, 201)
     } catch (err) {
       console.error('Waitlist signup error:', err)
@@ -1090,30 +1651,14 @@ export function createApp(db: Database): Hono {
     }
 
     try {
-      const rows = db.prepare(`
-        SELECT id, email, source, company, agent_count, created_at
-        FROM waitlist
-        ORDER BY created_at DESC, id DESC
-      `).all() as WaitlistRow[]
+      const { rows, total } = listBetaRequestRows(db, { limit: 5000 })
 
       return c.json({
-        waitlist: rows.map((row) => ({
-          id: row.id,
-          email: row.email,
-          source: row.source,
-          company: row.company,
-          agentCount: row.agent_count,
-          createdAt: row.created_at,
-        })),
-        signups: rows.map((row) => ({
-          id: row.id,
-          email: row.email,
-          source: row.source,
-          company: row.company,
-          agentCount: row.agent_count,
-          createdAt: row.created_at,
-        })),
-        total: rows.length,
+        waitlist: rows.map((row) => serializeBetaRequest(row)),
+        signups: rows.map((row) => serializeBetaRequest(row)),
+        requests: rows.map((row) => serializeBetaRequest(row)),
+        total,
+        summary: summarizeBetaRequests(rows, total),
       })
     } catch (err) {
       console.error('List waitlist error:', err)

--- a/packages/public-site/hosted-beta.html
+++ b/packages/public-site/hosted-beta.html
@@ -727,7 +727,7 @@
           <div class="section-kicker">Hosted beta request</div>
           <h2>Tell Beam what you want to operationalize.</h2>
           <p>
-            This intake stores a lightweight waitlist record so Beam can prioritize conversations around one concrete workflow instead of a generic “tell me more” thread.
+            This intake goes straight into the operator queue Beam uses to review hosted beta workflows. Keep it grounded in one real handoff, and Beam will respond with the next concrete step.
           </p>
 
           <form id="waitlist-form" class="form-grid">
@@ -762,7 +762,7 @@
             <div class="field">
               <label for="notes">What is the first handoff you want to make trustworthy?</label>
               <textarea id="notes" name="notes" placeholder="Example: procurement asks partner operations for stock and delivery, then finance needs an async approval path before purchase preflight."></textarea>
-              <small>The current public waitlist endpoint stores email, company, source, and agent count. Keep this note for the follow-up call; it is not persisted server-side yet.</small>
+              <small>This summary is stored for the operator review, so keep it short and specific.</small>
             </div>
 
             <div class="submit-row">
@@ -869,6 +869,12 @@
     const form = document.getElementById('waitlist-form')
     const submitButton = document.getElementById('submit-button')
     const formStatus = document.getElementById('form-status')
+    const WORKFLOW_LABELS = {
+      'hosted-beta-partner-handoff': 'Partner handoff',
+      'hosted-beta-operator-eval': 'Operator evaluation',
+      'hosted-beta-managed-rollout': 'Managed rollout',
+      'hosted-beta-compliance': 'Compliance-sensitive workflow',
+    }
 
     function setStatus(type, html) {
       formStatus.className = `status visible ${type}`
@@ -882,8 +888,10 @@
       const email = String(formData.get('email') || '').trim().toLowerCase()
       const company = String(formData.get('company') || '').trim()
       const workflow = String(formData.get('workflow') || 'hosted-beta-partner-handoff')
+      const workflowLabel = WORKFLOW_LABELS[workflow] || 'Hosted beta workflow'
       const agentCountRaw = String(formData.get('agentCount') || '').trim()
       const agentCount = agentCountRaw ? Number.parseInt(agentCountRaw, 10) : null
+      const notes = String(formData.get('notes') || '').trim()
 
       submitButton.disabled = true
       submitButton.textContent = 'Submitting...'
@@ -898,8 +906,10 @@
           body: JSON.stringify({
             email,
             company: company || null,
-            source: workflow,
+            source: 'hosted-beta-page',
             agentCount: Number.isFinite(agentCount) ? agentCount : null,
+            workflowType: workflow,
+            workflowSummary: notes || null,
           }),
         })
 
@@ -909,23 +919,27 @@
           throw new Error(payload.error || 'Hosted beta request failed')
         }
 
-        const createdAt = payload.createdAt ? new Date(payload.createdAt).toLocaleString('en-US', {
+        const request = payload.request || null
+        const createdAt = request?.createdAt ? new Date(request.createdAt).toLocaleString('en-US', {
           dateStyle: 'medium',
           timeStyle: 'short',
         }) : null
+        const nextStep = payload.nextStep || 'Beam will review the workflow and follow up with the next concrete step.'
 
         if (payload.status === 'already_registered') {
           setStatus(
             'success',
             `<strong>You are already on the hosted beta list.</strong><br />` +
-            `We kept the original signup and refreshed the latest company and workflow context for <code>${email}</code>.` +
-            (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Original signup: ${createdAt}</span>` : ''),
+            `Beam refreshed the latest workflow context for <code>${email}</code> and kept the original intake.` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
+            (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Original intake: ${createdAt}</span>` : ''),
           )
         } else {
           setStatus(
             'success',
             `<strong>Hosted beta request recorded.</strong><br />` +
-            `Beam now has the intake for <code>${email}</code> at <strong>${company}</strong>.` +
+            `Beam queued <strong>${workflowLabel}</strong> for <strong>${company}</strong>.` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
             (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Recorded: ${createdAt}</span>` : ''),
           )
           form.reset()


### PR DESCRIPTION
## Summary
- turn hosted beta intake into a real operator-owned request model with stable status, owner, notes, and export endpoints
- add a dashboard beta-requests surface plus richer hosted-beta intake copy and payloads
- document the API and cover public creation, operator review, and export in end-to-end tests

## Verification
- npm test --workspace=packages/directory
- npm run build --workspace=packages/dashboard
- npm run build
- npm run build (in docs/)
- npm test
- npm run test:e2e

Closes #36