### PR TITLE
Fix live release truth across public surfaces

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -98,11 +98,31 @@ Typical health response:
   "status": "ok",
   "protocol": "beam/1",
   "connectedAgents": 12,
-  "timestamp": "2026-03-08T12:00:00.000Z"
+  "timestamp": "2026-03-08T12:00:00.000Z",
+  "version": "0.6.1",
+  "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
+  "deployedAt": "2026-03-30T19:00:00.000Z",
+  "release": {
+    "version": "0.6.1",
+    "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
+    "gitShaShort": "abcdef1",
+    "deployedAt": "2026-03-30T19:00:00.000Z"
+  }
 }
 ```
 
 If you publish a friendlier `/stats` endpoint in front of the directory, it should usually aggregate health, connection count, and relay metrics.
+The current built-in `/stats` endpoint now exposes the same release metadata, so `health` and `stats` can be compared for deploy-truth drift.
+
+## `GET /release`
+
+For a small operator-facing release-truth check, the directory also exposes:
+
+```text
+GET /release
+```
+
+It returns the current protocol family plus the live release metadata (`version`, `gitSha`, `gitShaShort`, `deployedAt`).
 
 ## Admin auth
 

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -31,6 +31,8 @@ export async function cmdStats(options: StatsOptions): Promise<void> {
     console.log(`${chalk.cyan('Intents:')}      ${stats.intentsProcessed}`)
     if (stats.consumerAgents !== undefined) console.log(`${chalk.cyan('Consumers:')}    ${stats.consumerAgents}`)
     if (stats.version) console.log(`${chalk.cyan('Version:')}      ${stats.version}`)
+    if (stats.gitSha) console.log(`${chalk.cyan('Git SHA:')}      ${stats.gitSha.slice(0, 12)}`)
+    if (stats.deployedAt) console.log(`${chalk.cyan('Deployed:')}     ${stats.deployedAt}`)
     console.log('')
   } catch (err) {
     spinner.fail('Stats failed')

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -52,6 +52,29 @@ export interface DirectoryHealth {
   protocol: string
   connectedAgents: number
   timestamp: string
+  uptimeSeconds?: number
+  version?: string
+  gitSha?: string | null
+  deployedAt?: string
+  release?: DirectoryReleaseInfo
+}
+
+export interface DirectoryReleaseInfo {
+  version: string
+  gitSha: string | null
+  gitShaShort: string | null
+  deployedAt: string
+}
+
+export interface RootStatsResponse {
+  agents: number
+  intentsProcessed: number
+  uptime: number
+  waitlistSize: number
+  version: string
+  gitSha?: string | null
+  deployedAt?: string
+  release?: DirectoryReleaseInfo
 }
 
 export interface BusHealth {
@@ -835,7 +858,7 @@ function getFilenameFromResponse(response: Response, dataset: string, format: Ex
 
 export const directoryApi = {
   getHealth: () => request<DirectoryHealth>('/health'),
-  getRootStats: () => request<{ agents: number; intentsProcessed: number; uptime: number; waitlistSize: number; version: string }>('/stats'),
+  getRootStats: () => request<RootStatsResponse>('/stats'),
   getAgentStats: () => request<DirectoryStats>('/agents/stats'),
   searchAgents: (params?: {
     q?: string

--- a/packages/dashboard/src/pages/SettingsPage.tsx
+++ b/packages/dashboard/src/pages/SettingsPage.tsx
@@ -16,6 +16,7 @@ import {
   type BusHealth,
   type BusStats,
   type DirectoryHealth,
+  type RootStatsResponse,
   type RetentionResponse,
 } from '../lib/api'
 import { useAdminAuth } from '../lib/admin-auth'
@@ -25,6 +26,7 @@ const PRIVATE_KEY_PREFIX = 'beam-dashboard-private-key:'
 export default function SettingsPage() {
   const { session, config, logout } = useAdminAuth()
   const [health, setHealth] = useState<DirectoryHealth | null>(null)
+  const [rootStats, setRootStats] = useState<RootStatsResponse | null>(null)
   const [busHealth, setBusHealth] = useState<BusHealth | null>(null)
   const [busStats, setBusStats] = useState<BusStats | null>(null)
   const [retention, setRetention] = useState<RetentionResponse | null>(null)
@@ -38,8 +40,9 @@ export default function SettingsPage() {
 
     async function load() {
       try {
-        const [healthResponse, retentionResponse] = await Promise.allSettled([
+        const [healthResponse, statsResponse, retentionResponse] = await Promise.allSettled([
           directoryApi.getHealth(),
+          directoryApi.getRootStats(),
           directoryApi.getRetention(),
         ])
 
@@ -50,6 +53,10 @@ export default function SettingsPage() {
           setError(null)
         } else if (healthResponse.reason instanceof ApiError) {
           setError(healthResponse.reason.message)
+        }
+
+        if (statsResponse.status === 'fulfilled') {
+          setRootStats(statsResponse.value)
         }
 
         if (retentionResponse.status === 'fulfilled') {
@@ -84,6 +91,23 @@ export default function SettingsPage() {
       cancelled = true
     }
   }, [])
+
+  const releaseTruthMatches = useMemo(() => {
+    const healthVersion = health?.release?.version ?? health?.version ?? null
+    const healthSha = health?.release?.gitSha ?? health?.gitSha ?? null
+    const healthDeployedAt = health?.release?.deployedAt ?? health?.deployedAt ?? null
+    const statsVersion = rootStats?.release?.version ?? rootStats?.version ?? null
+    const statsSha = rootStats?.release?.gitSha ?? rootStats?.gitSha ?? null
+    const statsDeployedAt = rootStats?.release?.deployedAt ?? rootStats?.deployedAt ?? null
+
+    if (!healthVersion || !statsVersion) {
+      return null
+    }
+
+    return healthVersion === statsVersion
+      && (healthSha ?? '') === (statsSha ?? '')
+      && (healthDeployedAt ?? '') === (statsDeployedAt ?? '')
+  }, [health, rootStats])
 
   const storedKeys = useMemo(() => {
     return Object.keys(localStorage).filter((key) => key.startsWith(PRIVATE_KEY_PREFIX))
@@ -135,6 +159,13 @@ export default function SettingsPage() {
           <InfoRow label="Protocol" value={health?.protocol ?? '—'} />
           <InfoRow label="Connected agents" value={health ? String(health.connectedAgents) : '—'} />
           <InfoRow label="Last heartbeat" value={health?.timestamp ?? '—'} />
+          <InfoRow label="Release version" value={health?.release?.version ?? health?.version ?? '—'} />
+          <InfoRow label="Git SHA" value={health?.release?.gitShaShort ?? health?.gitSha ?? '—'} />
+          <InfoRow label="Deployed at" value={health?.release?.deployedAt ?? health?.deployedAt ?? '—'} />
+          <InfoRow
+            label="Release truth"
+            value={releaseTruthMatches == null ? 'Unavailable' : releaseTruthMatches ? 'health/stats match' : 'drift detected'}
+          />
         </div>
 
         <div className="panel space-y-3">
@@ -231,14 +262,24 @@ export default function SettingsPage() {
         <p className="text-sm text-slate-500 dark:text-slate-400">
           Admin setup, alert triage, exports, and prune safety are documented end to end in the operator guide.
         </p>
-        <a
-          className="inline-flex w-fit rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
-          href="https://docs.beam.directory/guide/operator-observability"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Open operator guide
-        </a>
+        <div className="flex flex-wrap gap-3">
+          <a
+            className="inline-flex w-fit rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
+            href="https://docs.beam.directory/guide/operator-observability"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open operator guide
+          </a>
+          <a
+            className="inline-flex w-fit rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition-colors hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
+            href="https://beam.directory/status.html"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Open release status
+          </a>
+        </div>
       </section>
     </div>
   )

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -247,3 +247,66 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     db.close()
   }
 })
+
+test('health, stats, and release endpoint expose consistent live release metadata', async () => {
+  const db = createDatabase(':memory:')
+  const originalVersion = process.env['BEAM_RELEASE_VERSION']
+  const originalSha = process.env['BEAM_RELEASE_SHA']
+  const originalDeployedAt = process.env['BEAM_DEPLOYED_AT']
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    process.env['BEAM_RELEASE_VERSION'] = '0.6.1-test'
+    process.env['BEAM_RELEASE_SHA'] = 'abcdef1234567890abcdef1234567890abcdef12'
+    process.env['BEAM_DEPLOYED_AT'] = '2026-03-30T19:00:00.000Z'
+
+    const app = createApp(db)
+
+    const [healthResponse, statsResponse, releaseResponse] = await Promise.all([
+      app.request('http://localhost/health'),
+      app.request('http://localhost/stats'),
+      app.request('http://localhost/release'),
+    ])
+
+    assert.equal(healthResponse.status, 200)
+    assert.equal(statsResponse.status, 200)
+    assert.equal(releaseResponse.status, 200)
+
+    const health = await healthResponse.json() as {
+      version: string
+      gitSha: string
+      deployedAt: string
+      release: { version: string; gitSha: string; gitShaShort: string; deployedAt: string }
+    }
+    const stats = await statsResponse.json() as {
+      version: string
+      gitSha: string
+      deployedAt: string
+      release: { version: string; gitSha: string; gitShaShort: string; deployedAt: string }
+    }
+    const release = await releaseResponse.json() as {
+      release: { version: string; gitSha: string; gitShaShort: string; deployedAt: string }
+    }
+
+    assert.equal(health.version, '0.6.1-test')
+    assert.equal(stats.version, '0.6.1-test')
+    assert.equal(release.release.version, '0.6.1-test')
+    assert.equal(health.gitSha, 'abcdef1234567890abcdef1234567890abcdef12')
+    assert.equal(stats.gitSha, 'abcdef1234567890abcdef1234567890abcdef12')
+    assert.equal(release.release.gitShaShort, 'abcdef1')
+    assert.equal(health.deployedAt, '2026-03-30T19:00:00.000Z')
+    assert.deepEqual(health.release, stats.release)
+    assert.deepEqual(stats.release, release.release)
+  } finally {
+    if (originalVersion === undefined) delete process.env['BEAM_RELEASE_VERSION']
+    else process.env['BEAM_RELEASE_VERSION'] = originalVersion
+
+    if (originalSha === undefined) delete process.env['BEAM_RELEASE_SHA']
+    else process.env['BEAM_RELEASE_SHA'] = originalSha
+
+    if (originalDeployedAt === undefined) delete process.env['BEAM_DEPLOYED_AT']
+    else process.env['BEAM_DEPLOYED_AT'] = originalDeployedAt
+
+    db.close()
+  }
+})

--- a/packages/directory/src/release.ts
+++ b/packages/directory/src/release.ts
@@ -1,0 +1,144 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(__dirname, '../../../')
+const rootPackageJsonPath = resolve(repoRoot, 'package.json')
+const directoryPackageJsonPath = resolve(__dirname, '../package.json')
+const gitRootPath = resolve(repoRoot, '.git')
+
+export type ReleaseInfo = {
+  version: string
+  gitSha: string | null
+  gitShaShort: string | null
+  deployedAt: string
+}
+
+function readPackageVersion(): string {
+  for (const path of [rootPackageJsonPath, directoryPackageJsonPath]) {
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf8')) as { version?: string }
+      if (typeof raw.version === 'string' && raw.version.trim().length > 0) {
+        return raw.version.trim()
+      }
+    } catch {
+      // Try the next package source.
+    }
+  }
+
+  return '0.0.0-dev'
+}
+
+function normalizeSha(value: string | undefined | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return /^[0-9a-f]{7,40}$/i.test(trimmed) ? trimmed : null
+}
+
+function resolveGitDir(candidate: string): string | null {
+  try {
+    if (!existsSync(candidate)) {
+      return null
+    }
+
+    const statLike = readFileSync(candidate, 'utf8')
+    if (statLike.startsWith('gitdir:')) {
+      const relativeGitDir = statLike.slice('gitdir:'.length).trim()
+      return resolve(dirname(candidate), relativeGitDir)
+    }
+  } catch {
+    // .git may be a directory, not a file.
+  }
+
+  return candidate
+}
+
+function readPackedRef(gitDir: string, ref: string): string | null {
+  try {
+    const packedRefs = readFileSync(resolve(gitDir, 'packed-refs'), 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#') && !line.startsWith('^'))
+
+    for (const line of packedRefs) {
+      const [sha, refName] = line.split(' ')
+      if (refName === ref) {
+        return normalizeSha(sha)
+      }
+    }
+  } catch {
+    // packed-refs is optional.
+  }
+
+  return null
+}
+
+function readGitShaFromRepo(): string | null {
+  const gitDir = resolveGitDir(gitRootPath)
+  if (!gitDir) {
+    return null
+  }
+
+  try {
+    const head = readFileSync(resolve(gitDir, 'HEAD'), 'utf8').trim()
+    if (head.startsWith('ref:')) {
+      const ref = head.slice('ref:'.length).trim()
+      const refPath = resolve(gitDir, ref)
+      if (existsSync(refPath)) {
+        return normalizeSha(readFileSync(refPath, 'utf8'))
+      }
+
+      return readPackedRef(gitDir, ref)
+    }
+
+    return normalizeSha(head)
+  } catch {
+    return null
+  }
+}
+
+function readGitSha(): string | null {
+  const fromEnv = normalizeSha(
+    process.env['BEAM_RELEASE_SHA']
+      ?? process.env['VERCEL_GIT_COMMIT_SHA']
+      ?? process.env['SOURCE_VERSION']
+      ?? process.env['GITHUB_SHA']
+      ?? null,
+  )
+
+  return fromEnv ?? readGitShaFromRepo()
+}
+
+function readDeployedAt(startedAtMs: number): string {
+  const candidate = (
+    process.env['BEAM_DEPLOYED_AT']
+      ?? process.env['VERCEL_DEPLOYMENT_CREATED_AT']
+      ?? process.env['DEPLOYED_AT']
+      ?? null
+  )
+
+  if (candidate) {
+    const parsed = new Date(candidate)
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString()
+    }
+  }
+
+  return new Date(startedAtMs).toISOString()
+}
+
+export function getReleaseInfo(startedAtMs: number): ReleaseInfo {
+  const version = (process.env['BEAM_RELEASE_VERSION'] ?? readPackageVersion()).trim()
+  const gitSha = readGitSha()
+
+  return {
+    version,
+    gitSha,
+    gitShaShort: gitSha ? gitSha.slice(0, 7) : null,
+    deployedAt: readDeployedAt(startedAtMs),
+  }
+}

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -38,6 +38,7 @@ import { getAdminSessionFromRequest, requireAdminRole } from './admin-auth.js'
 import { assignDirectoryRole, deleteDirectoryRole, getAgent, getDIDDocument, listAgentKeys, listAuditLog, listDirectoryRoles, listRecentIntentLogs, listTrustScores, logAuditEvent, upsertDIDDocument } from './db.js'
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
+import { getReleaseInfo } from './release.js'
 import type { AgentRow, IntentFrame } from './types.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -877,6 +878,7 @@ function renderDashboardHtml(): string {
 
 export function createApp(db: Database): Hono {
   const app = new Hono()
+  const releaseInfo = getReleaseInfo(serverStartedAt)
   seedAclsFromCatalog(db)
 
   app.use('*', cors({
@@ -1785,6 +1787,10 @@ export function createApp(db: Database): Hono {
         connectedAgents: getConnectedCount(),
         timestamp,
         uptimeSeconds: Math.floor((Date.now() - serverStartedAt) / 1000),
+        version: releaseInfo.version,
+        gitSha: releaseInfo.gitSha,
+        deployedAt: releaseInfo.deployedAt,
+        release: releaseInfo,
         db: {
           status: row?.ok === 1 ? 'ok' : 'error',
         },
@@ -1796,12 +1802,24 @@ export function createApp(db: Database): Hono {
         connectedAgents: getConnectedCount(),
         timestamp,
         uptimeSeconds: Math.floor((Date.now() - serverStartedAt) / 1000),
+        version: releaseInfo.version,
+        gitSha: releaseInfo.gitSha,
+        deployedAt: releaseInfo.deployedAt,
+        release: releaseInfo,
         db: {
           status: 'error',
           message: error instanceof Error ? error.message : 'Unknown database error',
         },
       }, 503)
     }
+  })
+
+  app.get('/release', (c) => {
+    return c.json({
+      protocol: 'beam/1',
+      release: releaseInfo,
+      reportedAt: new Date().toISOString(),
+    })
   })
 
   app.get('/stats', (c) => {
@@ -1835,7 +1853,10 @@ export function createApp(db: Database): Hono {
       intentsProcessed,
       uptime: Math.floor(process.uptime()),
       waitlistSize,
-      version: '0.5.0',
+      version: releaseInfo.version,
+      gitSha: releaseInfo.gitSha,
+      deployedAt: releaseInfo.deployedAt,
+      release: releaseInfo,
     })
   })
 

--- a/packages/public-site/status.html
+++ b/packages/public-site/status.html
@@ -83,7 +83,7 @@
       </div>
       <div class="card">
         <div class="metric-label">Status source</div>
-        <div class="metric-value mono">https://api.beam.directory/health</div>
+        <div class="metric-value mono">/health + /stats</div>
         <div class="metric-sub">WebSocket check: <span class="mono">wss://api.beam.directory/ws?feed=intents</span></div>
       </div>
     </section>
@@ -109,6 +109,16 @@
         <div class="metric-value" id="uptime">—</div>
         <div class="metric-sub">Reported in seconds by the directory</div>
       </div>
+      <div class="card">
+        <div class="metric-label">Release</div>
+        <div class="metric-value" id="release-version">—</div>
+        <div class="metric-sub" id="release-detail">Waiting for release metadata</div>
+      </div>
+      <div class="card">
+        <div class="metric-label">Deploy truth</div>
+        <div class="metric-value" id="release-truth">—</div>
+        <div class="metric-sub" id="release-truth-detail">Waiting for cross-endpoint comparison</div>
+      </div>
     </section>
 
     <section class="checks">
@@ -131,6 +141,7 @@
 
   <script>
     const HEALTH_URL = 'https://api.beam.directory/health';
+    const STATS_URL = 'https://api.beam.directory/stats';
     const WS_URL = 'wss://api.beam.directory/ws?feed=intents';
     const REFRESH_MS = 30_000;
 
@@ -143,6 +154,10 @@
       wsDetail: document.getElementById('ws-detail'),
       connectedAgents: document.getElementById('connected-agents'),
       uptime: document.getElementById('uptime'),
+      releaseVersion: document.getElementById('release-version'),
+      releaseDetail: document.getElementById('release-detail'),
+      releaseTruth: document.getElementById('release-truth'),
+      releaseTruthDetail: document.getElementById('release-truth-detail'),
       httpBadge: document.getElementById('http-badge'),
       httpPayload: document.getElementById('http-payload'),
       socketBadge: document.getElementById('socket-badge'),
@@ -170,23 +185,60 @@
       return `${seconds}s`;
     }
 
+    function extractRelease(payload) {
+      const release = payload && typeof payload === 'object' && payload.release && typeof payload.release === 'object'
+        ? payload.release
+        : payload || {};
+
+      return {
+        version: typeof release.version === 'string' ? release.version : '—',
+        gitSha: typeof release.gitSha === 'string' ? release.gitSha : (typeof payload.gitSha === 'string' ? payload.gitSha : null),
+        deployedAt: typeof release.deployedAt === 'string' ? release.deployedAt : (typeof payload.deployedAt === 'string' ? payload.deployedAt : null),
+      };
+    }
+
+    function sameRelease(left, right) {
+      return left.version === right.version
+        && (left.gitSha || '') === (right.gitSha || '')
+        && (left.deployedAt || '') === (right.deployedAt || '');
+    }
+
     async function checkHttp() {
       const startedAt = performance.now();
-      const response = await fetch(HEALTH_URL, { cache: 'no-store' });
+      const [healthResponse, statsResponse] = await Promise.all([
+        fetch(HEALTH_URL, { cache: 'no-store' }),
+        fetch(STATS_URL, { cache: 'no-store' }),
+      ]);
       const latency = Math.round(performance.now() - startedAt);
-      const payload = await response.json().catch(() => ({}));
+      const healthPayload = await healthResponse.json().catch(() => ({}));
+      const statsPayload = await statsResponse.json().catch(() => ({}));
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+      if (!healthResponse.ok || !statsResponse.ok) {
+        throw new Error(`health ${healthResponse.status} / stats ${statsResponse.status}`);
       }
 
       setBadge(elements.httpBadge, 'ok', `Healthy · ${latency} ms`);
-      elements.httpPayload.textContent = JSON.stringify(payload, null, 2);
-      elements.apiStatus.textContent = String(payload.status || 'ok').toUpperCase();
-      elements.apiDetail.textContent = `${latency} ms · ${payload.protocol || 'beam/1'}`;
-      elements.connectedAgents.textContent = String(payload.connectedAgents ?? '—');
-      elements.uptime.textContent = formatUptime(payload.uptimeSeconds);
-      return { ok: true, payload, latency };
+      elements.httpPayload.textContent = JSON.stringify({ health: healthPayload, stats: statsPayload }, null, 2);
+      elements.apiStatus.textContent = String(healthPayload.status || 'ok').toUpperCase();
+      elements.apiDetail.textContent = `${latency} ms · ${healthPayload.protocol || 'beam/1'}`;
+      elements.connectedAgents.textContent = String(healthPayload.connectedAgents ?? '—');
+      elements.uptime.textContent = formatUptime(healthPayload.uptimeSeconds);
+
+      const healthRelease = extractRelease(healthPayload);
+      const statsRelease = extractRelease(statsPayload);
+      const consistent = sameRelease(healthRelease, statsRelease);
+
+      elements.releaseVersion.textContent = healthRelease.version;
+      elements.releaseDetail.textContent = [
+        healthRelease.gitSha ? healthRelease.gitSha.slice(0, 12) : 'no sha',
+        healthRelease.deployedAt ? new Date(healthRelease.deployedAt).toLocaleString() : 'no deploy time',
+      ].join(' · ');
+      elements.releaseTruth.textContent = consistent ? 'MATCH' : 'DRIFT';
+      elements.releaseTruthDetail.textContent = consistent
+        ? 'health and stats agree on the live release metadata.'
+        : 'health and stats disagree on version, git SHA, or deploy time.';
+
+      return { ok: true, consistent, healthPayload, statsPayload, latency };
     }
 
     function checkWebSocket() {
@@ -220,10 +272,12 @@
       elements.lastRefresh.textContent = new Date().toLocaleString();
       let httpOk = false;
       let wsOk = false;
+      let releaseConsistent = false;
 
       try {
-        await checkHttp();
+        const result = await checkHttp();
         httpOk = true;
+        releaseConsistent = Boolean(result.consistent);
       } catch (error) {
         setBadge(elements.httpBadge, 'err', 'Unavailable');
         elements.httpPayload.textContent = error instanceof Error ? error.message : 'HTTP check failed';
@@ -231,6 +285,10 @@
         elements.apiDetail.textContent = 'Health endpoint unavailable';
         elements.connectedAgents.textContent = '—';
         elements.uptime.textContent = '—';
+        elements.releaseVersion.textContent = '—';
+        elements.releaseDetail.textContent = 'Release metadata unavailable';
+        elements.releaseTruth.textContent = 'UNKNOWN';
+        elements.releaseTruthDetail.textContent = 'Could not compare health and stats.';
       }
 
       try {
@@ -243,7 +301,7 @@
         elements.wsDetail.textContent = 'Handshake failed';
       }
 
-      if (httpOk && wsOk) {
+      if (httpOk && wsOk && releaseConsistent) {
         setOverall('ok', 'All core services operational');
       } else if (httpOk || wsOk) {
         setOverall('warn', 'Partial degradation detected');

--- a/packages/sdk-typescript/src/directory.ts
+++ b/packages/sdk-typescript/src/directory.ts
@@ -89,6 +89,16 @@ function normalizeProfile(raw: Record<string, unknown>): AgentProfile {
 }
 
 function normalizeStats(raw: Record<string, unknown>): DirectoryStats {
+  const releaseRaw = raw['release']
+  const release = releaseRaw && typeof releaseRaw === 'object' && !Array.isArray(releaseRaw)
+    ? {
+        version: getString(releaseRaw as Record<string, unknown>, 'version') ?? getString(raw, 'version') ?? '',
+        gitSha: getString(releaseRaw as Record<string, unknown>, 'gitSha', 'git_sha') ?? null,
+        gitShaShort: getString(releaseRaw as Record<string, unknown>, 'gitShaShort', 'git_sha_short') ?? null,
+        deployedAt: getString(releaseRaw as Record<string, unknown>, 'deployedAt', 'deployed_at') ?? '',
+      }
+    : undefined
+
   return {
     totalAgents: getNumber(raw, 'totalAgents', 'total_agents', 'agents') ?? 0,
     verifiedAgents: getNumber(raw, 'verifiedAgents', 'verified_agents') ?? 0,
@@ -96,7 +106,10 @@ function normalizeStats(raw: Record<string, unknown>): DirectoryStats {
     consumerAgents: getNumber(raw, 'consumerAgents', 'consumer_agents'),
     uptime: getNumber(raw, 'uptime', 'uptimeSeconds', 'uptime_seconds'),
     waitlistSize: getNumber(raw, 'waitlistSize', 'waitlist_size'),
-    version: getString(raw, 'version'),
+    version: getString(raw, 'version') ?? release?.version,
+    gitSha: getString(raw, 'gitSha', 'git_sha') ?? release?.gitSha ?? null,
+    deployedAt: getString(raw, 'deployedAt', 'deployed_at') ?? release?.deployedAt,
+    release,
   }
 }
 

--- a/packages/sdk-typescript/src/types.ts
+++ b/packages/sdk-typescript/src/types.ts
@@ -85,6 +85,14 @@ export interface DirectoryStats {
   uptime?: number
   waitlistSize?: number
   version?: string
+  gitSha?: string | null
+  deployedAt?: string
+  release?: {
+    version: string
+    gitSha: string | null
+    gitShaShort?: string | null
+    deployedAt: string
+  }
 }
 
 export interface Delegation {

--- a/packages/sdk-typescript/tests/api-key.test.ts
+++ b/packages/sdk-typescript/tests/api-key.test.ts
@@ -47,4 +47,40 @@ describe('SDK API key auth', () => {
       }),
     )
   })
+
+  it('parses release truth fields from /stats responses', async () => {
+    const apiKey = makeApiKey('agent@beam.directory')
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      agents: 3,
+      verifiedAgents: 2,
+      intentsProcessed: 9,
+      waitlistSize: 1,
+      version: '0.6.1',
+      gitSha: 'abcdef1234567890abcdef1234567890abcdef12',
+      deployedAt: '2026-03-30T19:00:00.000Z',
+      release: {
+        version: '0.6.1',
+        gitSha: 'abcdef1234567890abcdef1234567890abcdef12',
+        gitShaShort: 'abcdef1',
+        deployedAt: '2026-03-30T19:00:00.000Z',
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const directory = new BeamDirectory({
+      baseUrl: 'https://api.beam.directory',
+      apiKey,
+    })
+
+    const stats = await directory.getStats()
+
+    expect(stats.totalAgents).toBe(3)
+    expect(stats.version).toBe('0.6.1')
+    expect(stats.gitSha).toBe('abcdef1234567890abcdef1234567890abcdef12')
+    expect(stats.deployedAt).toBe('2026-03-30T19:00:00.000Z')
+    expect(stats.release?.gitShaShort).toBe('abcdef1')
+  })
 })


### PR DESCRIPTION
## Summary
- replace stale hard-coded stats versioning with shared release metadata on health, stats, and a dedicated release endpoint
- surface the same release truth in the public status page, dashboard settings, SDK parsing, and CLI stats output
- add regression coverage for release metadata consistency and stats parsing

## Verification
- npm test
- npm run build
- npm run build (in docs/)
- npm run test:e2e

Closes #37