### PR TITLE
Draft the 0.7.0 release candidate plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.7.0 (draft)
+
+### Hosted Beta
+- align Beam around a hosted beta for verified B2B handoffs instead of an open-ended protocol pitch
+- keep landing page, hosted beta intake, quickstart, docs, and demo flow on the same hosted evaluation path
+
+### Operator Workflow
+- add a dedicated hosted-beta request queue with stable request status, owner, notes, and export surfaces
+- improve operator-facing proof across trace, audit, alerts, dead letters, and hosted-beta review
+
+### Reliability and Security
+- harden retries, dead-letter handling, restart recovery, key lifecycle, and abuse controls for the hosted-beta baseline
+- keep cross-stack compatibility fixtures and test coverage across directory, CLI, TypeScript SDK, Python SDK, and message bus
+
+### Release Control
+- add repo-visible RC and cut artifacts for `0.7.0`
+- expose live release truth on the API, status page, dashboard, SDK, and CLI so deploy drift is visible before tagging
+
+### Compatibility Note
+- No protocol-family change in this release train. Beam `0.7.0` remains on `beam/1`.
+
 ## v0.6.1 (2026-03-30)
 
 ### Quickstart

--- a/reports/0.7.0-rc1-checklist.md
+++ b/reports/0.7.0-rc1-checklist.md
@@ -1,0 +1,108 @@
+# Beam 0.7.0 RC1 Checklist
+
+## Purpose
+
+This checklist is the release-control path for `0.7.0-rc1`.
+
+The goal is to end the hosted-beta milestone with one deliberate cut commit, one verified deployment sequence, and zero ambiguous blockers.
+
+## Candidate Commit
+
+- target branch: `main`
+- release candidate commit: `TBD before cut`
+- rc owner: `TBD`
+- target tag: `v0.7.0`
+
+## Pre-Cut Freeze
+
+- [ ] `main` contains only milestone-scoped changes for `0.7.0`
+- [ ] every open `0.7.0 Hosted Beta` issue is either:
+  - closed, or
+  - explicitly moved to the next milestone with an owner
+- [ ] no release blocker is left in chat, notes, or ad hoc comments only
+- [ ] changelog draft is updated in `CHANGELOG.md`
+- [ ] release-notes draft exists in `reports/0.7.0-release-notes-draft.md`
+
+## Repo Checks
+
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] `cd docs && npm run build`
+- [ ] `npm run test:e2e`
+- [ ] `npm run quickstart:smoke`
+- [ ] all GitHub Actions checks are green on the candidate commit:
+  - `docs`
+  - `monorepo (20)`
+  - `monorepo (22)`
+  - full `e2e` matrix
+  - `quickstart`
+
+## Smoke and Live-Surface Verification
+
+- [ ] clean-start onboarding still matches the latest report in [0.7.0-clean-start-onboarding.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-clean-start-onboarding.md)
+- [ ] hosted demo still matches the latest report in [0.7.0-hosted-demo-readiness.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-hosted-demo-readiness.md)
+- [ ] `https://api.beam.directory/health` returns `status: ok`
+- [ ] `https://api.beam.directory/stats` returns the same release metadata as `health`
+- [ ] `https://api.beam.directory/release` reports the target `version`, `gitSha`, and `deployedAt`
+- [ ] `https://beam.directory/status.html` shows `MATCH` for deploy truth
+- [ ] `https://beam.directory/` renders the hosted-demo / hosted-beta funnel without stale copy
+- [ ] `https://docs.beam.directory/` renders the current hosted-beta docs
+
+## Dogfood Gate
+
+Go/no-go depends on the current dogfood reports, not on feature appetite.
+
+- [ ] buyer-like dogfood pass completed after the latest public-surface refresh
+- [ ] operator-like dogfood pass completed after the latest release-truth rollout
+- [ ] both reports are attached to the repo and point to the exact commit used
+- [ ] no blocker remains in the following classes:
+  - onboarding confusion that prevents a first run
+  - trace or alert confusion that blocks operator diagnosis
+  - release-truth drift between `health`, `stats`, status page, or live surfaces
+  - deployment order ambiguity between API, public site, docs, and tag
+
+## Go / No-Go
+
+### Go
+
+Ship `0.7.0` only if all of the following are true:
+
+- every checkbox above is complete
+- live release-truth surfaces agree on one candidate commit
+- the latest dogfood passes show no ambiguous blocker
+- release notes and changelog match what is actually deployed
+
+### No-Go
+
+Do not tag if any of the following is true:
+
+- `status.html` reports drift
+- `health`, `stats`, and `/release` disagree
+- hosted API, public site, and docs are on different commits
+- a blocker exists but has no owner, no severity, or no next action
+
+## Final Cut Sequence
+
+Follow this exact order:
+
+1. merge the final release-blocker PRs into `main`
+2. choose the candidate commit SHA and freeze further feature work
+3. verify repo checks and smoke checks on that commit
+4. deploy the hosted API from that exact commit
+5. verify `health`, `stats`, and `/release` on `api.beam.directory`
+6. deploy the public site from that exact commit
+7. verify `beam.directory/` and `beam.directory/status.html`
+8. verify docs deployment from that exact commit on `docs.beam.directory`
+9. update `CHANGELOG.md` and `reports/0.7.0-release-notes-draft.md` if the verified surfaces forced wording changes
+10. create and push the `v0.7.0` tag from the verified commit
+11. publish the GitHub release using the drafted notes
+12. perform one final live truth check after the tag workflow completes
+
+## Closeout
+
+The milestone is done only when:
+
+- [ ] the tag exists and points at the verified commit
+- [ ] live API, public site, and docs all reflect that same release
+- [ ] the release notes are published
+- [ ] the milestone is closed with zero ambiguous blockers

--- a/reports/0.7.0-release-notes-draft.md
+++ b/reports/0.7.0-release-notes-draft.md
@@ -1,0 +1,63 @@
+# Beam 0.7.0 Release Notes Draft
+
+## Headline
+
+Beam 0.7.0 turns the current protocol release into an operator-ready hosted beta for one narrow job:
+
+**verified B2B handoffs between two companies' agents**
+
+## What Changed
+
+### Hosted beta onboarding
+
+- narrowed the public story around one real partner handoff instead of a generic protocol pitch
+- aligned landing page, hosted beta intake, docs home, quickstart, and demo flow around the same hosted evaluation path
+- added a concrete hosted-beta intake that captures workflow type and workflow summary instead of a bare waitlist record
+
+### Operator workflow
+
+- added a dedicated dashboard workflow for hosted beta requests with queue, assignment, owner, notes, and export
+- tightened traceability, audit, dead-letter visibility, and alert investigation around the same operator loop
+- documented the operator path and hosted-beta runbook expectations
+
+### Reliability and control
+
+- kept the canonical lifecycle on `beam/1` and hardened retry, dead-letter, restart recovery, key lifecycle, and abuse controls
+- preserved compatibility fixtures and cross-stack checks across TypeScript SDK, Python SDK, CLI, directory, and message bus
+- kept the quickstart and hosted demo reproducible from a clean checkout
+
+### Release truth
+
+- replaced stale hard-coded release metadata on `/stats`
+- exposed live release metadata on `health`, `stats`, and `/release`
+- added release-truth verification on the public status page, dashboard settings, SDK parsing, and CLI stats output
+
+## Operator Impact
+
+Operators now have one consistent path to answer three questions:
+
+1. what workflow was requested?
+2. who owns it and what happened next?
+3. is the live system actually on the release we think it is?
+
+## Compatibility Note
+
+- no protocol-family change in this release
+- Beam `0.7.0` still targets `beam/1`
+- additive metadata fields were added, but the signed frame contract is unchanged
+
+## Validation Inputs Before Tagging
+
+Use these as release-note sources of truth before the final cut:
+
+- [0.7.0-clean-start-onboarding.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-clean-start-onboarding.md)
+- [0.7.0-hosted-demo-readiness.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-hosted-demo-readiness.md)
+- [0.7.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-rc1-checklist.md)
+
+## Publish Notes
+
+Before publishing this text as the GitHub release body:
+
+- replace any remaining `TBD` values with the final commit SHA and live URLs
+- verify that `beam.directory`, `api.beam.directory`, and `docs.beam.directory` all reflect the tagged release
+- remove any bullet that did not actually ship on the tagged commit


### PR DESCRIPTION
## Summary
- add a repo-visible 0.7.0-rc1 checklist with smoke, docs, live-surface, and go/no-go gates
- draft the 0.7.0 release notes input and the release-control cut sequence
- add a draft 0.7.0 changelog section so tagging does not start from a blank page

## Verification
- docs-only planning update; no code paths changed

Closes #38