### PR TITLE
Document 0.7.0 dogfood findings

### DIFF
--- a/reports/0.7.0-buyer-dogfood-pass.md
+++ b/reports/0.7.0-buyer-dogfood-pass.md
@@ -1,0 +1,52 @@
+# 0.7.0 Buyer Dogfood Pass
+
+- date: 2026-03-30
+- repo checkout used for review notes: `7e68783dc4da10398f1bf04eedd6981d2758f78c`
+- public surfaces used:
+  - `https://beam.directory/`
+  - `https://beam.directory/playground.html`
+  - `https://beam.directory/hosted-beta.html`
+
+## Goal
+
+Check whether a normal evaluator can understand Beam's public funnel, get a real proof moment in the browser, and reach the hosted-beta intake without needing internal context.
+
+## Path Followed
+
+1. Opened `https://beam.directory/`.
+2. Clicked the primary CTA `Watch the demo path`.
+3. Landed on the docs quickstart rather than the browser playground.
+4. Navigated manually to `https://beam.directory/playground.html`.
+5. Created the temporary browser identity and sent the default test message to `echo@beam.directory`.
+6. Reached a successful echo response in `16 ms`.
+7. Navigated to `https://beam.directory/hosted-beta.html`.
+8. Submitted a clearly marked dogfood request with a reserved `example.com` email to inspect the real success state.
+
+## What Worked
+
+- The browser playground is easy to understand once the user is on the page.
+- The temporary identity flow is fast and low-friction.
+- The echo proof moment is immediate and concrete.
+- The hosted-beta page keeps the scope narrow around one workflow instead of generic lead capture.
+- The hosted-beta success state confirms that the request was recorded and explains the next step.
+
+## Confusion Points
+
+- The landing CTA `Watch the demo path` reads like the buyer-friendly browser proof, but it opens the docs quickstart instead. A new evaluator has to infer that the browser playground lives elsewhere.
+- The public landing did not expose the playground path clearly enough during the pass. I answered that question by typing the URL directly.
+- The hosted-beta form still says the workflow note is "not persisted server-side yet." That copy is stale and undermines trust during intake because the request is now stored as an operator workflow record.
+
+## Questions Answered Manually
+
+- "Where is the quick proof in the browser?"
+  - Answered manually by going straight to `/playground.html`.
+- "Is the hosted-beta request actually recorded?"
+  - Answered by the success state, but the stale copy on the form creates unnecessary doubt first.
+
+## Blockers
+
+No buyer-path release blocker was found in this pass.
+
+## Decision
+
+The buyer funnel is viable, but the first CTA hierarchy still needs to make the browser proof path more obvious. The remaining buyer issues are UX friction, not release blockers.

--- a/reports/0.7.0-operator-dogfood-pass.md
+++ b/reports/0.7.0-operator-dogfood-pass.md
@@ -1,0 +1,84 @@
+# 0.7.0 Operator Dogfood Pass
+
+- date: 2026-03-30
+- repo checkout used for notes and local commands: `7e68783dc4da10398f1bf04eedd6981d2758f78c`
+- docs entry used: `https://docs.beam.directory/guide/hosted-quickstart`
+- local quickstart surfaces used:
+  - `http://localhost:43100`
+  - `http://localhost:43173`
+  - `http://localhost:43220`
+
+## Goal
+
+Validate the operator path from docs to login to trace investigation on the hosted quickstart stack, then confirm whether the documented observability surfaces remain usable without internal debugging.
+
+## Path Followed
+
+1. Opened the hosted quickstart guide in the public docs.
+2. Verified that the guide points to the local dashboard login and the manual operator flow.
+3. Opened `http://localhost:43173/login`.
+4. Requested a magic link for `ops@beam.local`.
+5. Used the local-dev magic link surfaced by the dashboard and logged in successfully.
+6. Ran `npm run demo:run`.
+7. Investigated the resulting quote nonce `62e5a76d-fc47-40fa-826b-5de7ae263525` in `Intents`.
+8. Opened the trace view and confirmed the canonical lifecycle through `acked`.
+9. Opened `Alerts` and confirmed the clean baseline state.
+10. Opened `Settings`, stored the documented bus URL and API key, then opened `Dead Letters`.
+
+## What Worked
+
+- The local dashboard login flow is better than the fallback curl path in the docs. The page itself is sufficient for localhost.
+- `npm run demo:run` still gives a clean canonical operator nonce to inspect.
+- The trace page is strong. It shows sender, recipient, lifecycle stages, and the terminal state clearly.
+- `Alerts` is readable and the export/prune model is understandable.
+
+## Confusion Points
+
+- The docs still include the curl-based magic-link flow, but the local login page is now simpler. The page is the path a real operator will actually use first.
+- The trace view links to audit, but clean-path audit correlation is currently sparse. That is not a blocker, but it leaves the operator with less context than the link implies.
+- The hosted quickstart docs describe dead-letter inspection as part of the operator path, but the page did not work in the browser during the pass.
+
+## Questions Answered Manually
+
+- "How do I log in locally?"
+  - Answered by the dashboard login page itself, not by the curl flow.
+- "Which nonce should I inspect?"
+  - Answered by `npm run demo:run`.
+- "Why does the dead-letter view fail after I enter the documented settings?"
+  - Answered manually with curl verification. The browser UI does not explain the real failure mode.
+- "Can live release truth be verified on production yet?"
+  - Answered manually with curl. The answer is no right now.
+
+## Concrete Blockers
+
+### Blocker 1: Dashboard bus observability is broken in-browser
+
+Tracked in #44.
+
+- `Settings` kept `Bus health` as `Unavailable` even after storing:
+  - Bus URL `http://localhost:43220`
+  - Bus API key `beam-local-bus-key`
+- `Dead Letters` showed `Failed to load dead-letter messages`.
+- Direct curl to the bus succeeded with `Authorization: Bearer beam-local-bus-key`.
+- The bus responses do not emit CORS headers for `Origin: http://localhost:43173`.
+
+This blocks the documented operator path for dead-letter inspection and bus health.
+
+### Blocker 2: Live release-truth rollout is not actually live
+
+Tracked in #45.
+
+Production checks during this pass returned:
+
+- `GET https://api.beam.directory/health`
+  - no release metadata
+- `GET https://api.beam.directory/stats`
+  - still reports `version: 0.5.0`
+- `GET https://api.beam.directory/release`
+  - `404 NOT_FOUND`
+
+This blocks the `0.7.0` RC checklist item that requires one verifiable release truth across API, public site, and docs.
+
+## Decision
+
+The operator path is almost release-ready up to trace and alert investigation, but it is not yet cut-ready. `0.7.0` should remain blocked until #44 and #45 are closed and re-verified on a fresh pass.

--- a/reports/0.7.0-rc1-checklist.md
+++ b/reports/0.7.0-rc1-checklist.md
@@ -53,13 +53,20 @@ The goal is to end the hosted-beta milestone with one deliberate cut commit, one
 Go/no-go depends on the current dogfood reports, not on feature appetite.
 
 - [ ] buyer-like dogfood pass completed after the latest public-surface refresh
+  - latest report: [0.7.0-buyer-dogfood-pass.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-buyer-dogfood-pass.md)
 - [ ] operator-like dogfood pass completed after the latest release-truth rollout
+  - latest report: [0.7.0-operator-dogfood-pass.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-operator-dogfood-pass.md)
 - [ ] both reports are attached to the repo and point to the exact commit used
 - [ ] no blocker remains in the following classes:
   - onboarding confusion that prevents a first run
   - trace or alert confusion that blocks operator diagnosis
   - release-truth drift between `health`, `stats`, status page, or live surfaces
   - deployment order ambiguity between API, public site, docs, and tag
+
+Current blocker references from the latest dogfood pass:
+
+- #44 `Unblock dashboard bus observability in hosted quickstart`
+- #45 `Deploy live release-truth endpoints before 0.7.0 cut`
 
 ## Go / No-Go
 


### PR DESCRIPTION
## Summary
- add buyer and operator dogfood reports for the latest public refresh
- link both reports from the 0.7.0 RC checklist
- attach the real blockers discovered during the pass to the milestone (#44, #45)

## Verification
- buyer-like pass on live beam.directory surfaces
- operator-like pass through docs, localhost dashboard login, demo run, trace review, alerts, and dead-letter attempt
- live release-truth checks via curl against api.beam.directory

Closes #39