### PR TITLE
Allow dashboard origins to reach the message bus

### DIFF
--- a/packages/message-bus/README.md
+++ b/packages/message-bus/README.md
@@ -70,6 +70,7 @@ Environment variables:
 - `DIRECTORY_URL` - Beam directory base URL
 - `IDENTITY_PATH` - optional identity bundle for directory delivery helpers
 - `BEAM_BUS_API_KEY` - bearer token required for API access
+- `BEAM_BUS_ALLOWED_ORIGINS` - optional comma-separated browser origins allowed to call bus operator endpoints; defaults already permit `beam.directory`, `dashboard.beam.directory`, and loopback dashboards such as `http://localhost:43173`
 - `BEAM_BUS_STATS_PUBLIC=true` - allow unauthenticated `GET /v1/beam/stats`
 - `BEAM_BUS_CLEAN_TEST_DATA=true` - remove demo/test rows on startup
 

--- a/packages/message-bus/src/cors.ts
+++ b/packages/message-bus/src/cors.ts
@@ -1,0 +1,54 @@
+import type { Hono } from 'hono'
+import { cors } from 'hono/cors'
+
+const DEFAULT_PUBLIC_CORS_ORIGINS = new Set([
+  'https://beam.directory',
+  'https://www.beam.directory',
+  'https://dashboard.beam.directory',
+  'https://beam-dashboard.vercel.app',
+])
+
+function getConfiguredOrigins(): Set<string> {
+  const configured = process.env['BEAM_BUS_ALLOWED_ORIGINS']
+  if (!configured) {
+    return DEFAULT_PUBLIC_CORS_ORIGINS
+  }
+
+  return new Set(
+    configured
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+  )
+}
+
+export function resolveBusCorsOrigin(origin?: string | null): string | null {
+  if (!origin) {
+    return null
+  }
+
+  if (getConfiguredOrigins().has(origin)) {
+    return origin
+  }
+
+  try {
+    const parsed = new URL(origin)
+    const isLoopbackHost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1'
+    const isHttp = parsed.protocol === 'http:' || parsed.protocol === 'https:'
+    if (isLoopbackHost && isHttp) {
+      return origin
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+export function applyBusCors(app: Hono): void {
+  app.use('*', cors({
+    origin: (origin) => resolveBusCorsOrigin(origin) ?? '',
+    allowMethods: ['GET', 'POST', 'OPTIONS'],
+    allowHeaders: ['Content-Type', 'Authorization'],
+  }))
+}

--- a/packages/message-bus/src/index.ts
+++ b/packages/message-bus/src/index.ts
@@ -28,10 +28,12 @@ export {
 export { createBusRouter, type RouterOptions } from './router.js'
 export { startRetryWorker, stopRetryWorker, type WorkerOptions } from './worker.js'
 export { loadIdentities, deliverToDirectory, type DeliveryResult } from './delivery.js'
+export { applyBusCors, resolveBusCorsOrigin } from './cors.js'
 
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { cleanTestMessages, initDatabase, recoverInterruptedMessages } from './db.js'
+import { applyBusCors } from './cors.js'
 import { createBusRouter } from './router.js'
 import { startRetryWorker } from './worker.js'
 import { loadIdentities } from './delivery.js'
@@ -93,6 +95,7 @@ export function createBus(options: BusOptions = {}): Bus {
       const busRouter = createBusRouter({ db, directoryUrl, rateLimit })
 
       const app = new Hono()
+      applyBusCors(app)
       app.route('/v1/beam', busRouter)
       app.get('/health', (c) => c.json({ status: 'ok', service: 'beam-message-bus' }))
 

--- a/packages/message-bus/tests/bus.test.ts
+++ b/packages/message-bus/tests/bus.test.ts
@@ -21,6 +21,7 @@ import {
   recoverInterruptedMessages,
   scheduleRetry,
 } from '../src/db.js'
+import { applyBusCors } from '../src/cors.js'
 import { deliverToDirectory } from '../src/delivery.js'
 import { createBusRouter } from '../src/router.js'
 import { startRetryWorker, stopRetryWorker } from '../src/worker.js'
@@ -32,10 +33,14 @@ describe('message bus', () => {
   beforeEach(() => {
     db = initDatabase(':memory:')
     app = new Hono()
+    applyBusCors(app)
     app.route('/v1/beam', createBusRouter({ db, directoryUrl: 'http://directory.test', rateLimit: 10 }))
+    app.get('/health', (c) => c.json({ status: 'ok', service: 'beam-message-bus' }))
   })
 
   afterEach(() => {
+    delete process.env['BEAM_BUS_API_KEY']
+    delete process.env['BEAM_BUS_ALLOWED_ORIGINS']
     db.close()
     vi.clearAllMocks()
     vi.useRealTimers()
@@ -436,6 +441,50 @@ describe('message bus', () => {
     expect(body['acked']).toBe(1)
     expect(body['failed']).toBe(1)
     expect(body['dead_letter']).toBe(0)
+  })
+
+  it('allows loopback dashboard origins to read bus health and dead-letter data', async () => {
+    const healthResponse = await app.request('http://localhost/health', {
+      headers: { Origin: 'http://localhost:43173' },
+    })
+    expect(healthResponse.status).toBe(200)
+    expect(healthResponse.headers.get('access-control-allow-origin')).toBe('http://localhost:43173')
+
+    const deadLetterResponse = await app.request('http://localhost/v1/beam/dead-letter', {
+      headers: {
+        Origin: 'http://localhost:43173',
+        Authorization: 'Bearer local-dev-token',
+      },
+    })
+    expect(deadLetterResponse.status).toBe(200)
+    expect(deadLetterResponse.headers.get('access-control-allow-origin')).toBe('http://localhost:43173')
+  })
+
+  it('responds to browser preflight for protected dead-letter routes', async () => {
+    const originalApiKey = process.env['BEAM_BUS_API_KEY']
+    process.env['BEAM_BUS_API_KEY'] = 'local-dev-token'
+    const protectedApp = new Hono()
+    applyBusCors(protectedApp)
+    protectedApp.route('/v1/beam', createBusRouter({ db, directoryUrl: 'http://directory.test', rateLimit: 10 }))
+
+    const response = await protectedApp.request('http://localhost/v1/beam/dead-letter', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:43173',
+        'Access-Control-Request-Method': 'GET',
+        'Access-Control-Request-Headers': 'Authorization',
+      },
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:43173')
+    expect(response.headers.get('access-control-allow-headers')).toContain('Authorization')
+
+    if (originalApiKey === undefined) {
+      delete process.env['BEAM_BUS_API_KEY']
+    } else {
+      process.env['BEAM_BUS_API_KEY'] = originalApiKey
+    }
   })
 
   it('rate limits the 11th message from the same sender', async () => {


### PR DESCRIPTION
## Summary
- add explicit message-bus CORS handling for loopback dashboards and Beam public origins
- answer browser preflight requests for protected dead-letter routes
- document the new optional  env var

## Verification
- 
> @beam-protocol/message-bus@0.6.1 test
> vitest run


 RUN  v4.1.2 /Users/tobik/Documents/BEAM/beam-protocol/packages/message-bus


 Test Files  1 passed (1)
      Tests  26 passed (26)
   Start at  22:40:01
   Duration  254ms (transform 56ms, setup 0ms, import 81ms, tests 62ms, environment 0ms)
- 
> @beam-protocol/message-bus@0.6.1 build
> tsc
- 
> beam-protocol@0.6.1 quickstart:smoke
> node scripts/quickstart/smoke.mjs

[quickstart] waiting for the directory, dashboard, message bus, and hosted demo agents
[quickstart] requesting a local admin magic link
- browser verification on  and 

Closes #44