### PR TITLE
Fix waitlist schema migration on legacy volumes

### DIFF
--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -210,3 +210,74 @@ test('createDatabase migrates legacy Fly volumes without nonce columns', () => {
     rmSync(root, { force: true, recursive: true })
   }
 })
+
+test('createDatabase migrates legacy waitlist tables before creating status indexes', () => {
+  const { root, dbPath } = createTempDbPath()
+  const legacyDb = new Database(dbPath)
+
+  try {
+    legacyDb.exec(`
+      CREATE TABLE waitlist (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL,
+        source TEXT,
+        company TEXT,
+        agent_count INTEGER,
+        created_at TEXT NOT NULL
+      );
+
+      INSERT INTO waitlist (
+        email,
+        source,
+        company,
+        agent_count,
+        created_at
+      ) VALUES (
+        'ops@legacy.example',
+        'hosted-beta',
+        'Legacy Co',
+        3,
+        '2026-03-30T18:00:00.000Z'
+      );
+    `)
+  } finally {
+    legacyDb.close()
+  }
+
+  const db = createDatabase(dbPath)
+
+  try {
+    const waitlistColumns = db.prepare('PRAGMA table_info(waitlist)').all() as Array<{ name: string }>
+    assert.ok(waitlistColumns.some((column) => column.name === 'status'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'owner'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'operator_notes'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'updated_at'))
+
+    const waitlistRow = db.prepare(`
+      SELECT email, status, owner, operator_notes, updated_at, created_at
+      FROM waitlist
+      LIMIT 1
+    `).get() as {
+      email: string
+      status: string
+      owner: string | null
+      operator_notes: string | null
+      updated_at: string
+      created_at: string
+    } | undefined
+
+    assert.ok(waitlistRow)
+    assert.equal(waitlistRow?.email, 'ops@legacy.example')
+    assert.equal(waitlistRow?.status, 'new')
+    assert.equal(waitlistRow?.owner ?? null, null)
+    assert.equal(waitlistRow?.operator_notes ?? null, null)
+    assert.equal(waitlistRow?.updated_at, waitlistRow?.created_at)
+
+    const indexes = db.prepare("PRAGMA index_list('waitlist')").all() as Array<{ name: string }>
+    assert.ok(indexes.some((index) => index.name === 'idx_waitlist_status'))
+    assert.ok(indexes.some((index) => index.name === 'idx_waitlist_owner'))
+  } finally {
+    db.close()
+    rmSync(root, { force: true, recursive: true })
+  }
+})

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -169,12 +169,6 @@ function initSchema(db: DB): void {
     CREATE INDEX IF NOT EXISTS idx_waitlist_created_at
       ON waitlist(created_at DESC);
 
-    CREATE INDEX IF NOT EXISTS idx_waitlist_status
-      ON waitlist(status, created_at DESC);
-
-    CREATE INDEX IF NOT EXISTS idx_waitlist_owner
-      ON waitlist(owner, created_at DESC);
-
     CREATE TABLE IF NOT EXISTS intent_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       nonce TEXT NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary
- stop creating waitlist indexes before legacy waitlist columns have been added
- add a regression test for legacy waitlist tables missing `status`, `owner`, and `updated_at`
- unblock Fly volume migrations for the live API deploy path

## Verification
- `npm test --workspace=packages/directory`
- `npm run build --workspace=packages/directory`

Closes #45
