### PR TITLE
Cut 0.7.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.7.0 (draft)
+## v0.7.0 (2026-03-30)
 
 ### Hosted Beta
 - align Beam around a hosted beta for verified B2B handoffs instead of an open-ended protocol pitch

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-03-30T19:00:00.000Z",
   "release": {
-    "version": "0.6.1",
+    "version": "0.7.0",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-03-30T19:00:00.000Z"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,14 +1,17 @@
 {
   "name": "beam-protocol-docs",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "devDependencies": {
         "vitepress": "1.6.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "0.6.1"
+  "version": "0.7.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.6.1",
+        "beam-protocol-sdk": "^0.7.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.6.1"
+        "beam-protocol-sdk": "^0.7.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/beam-crewai/pyproject.toml
+++ b/packages/beam-crewai/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "beam-crewai"
-version = "0.6.1"
+version = "0.7.0"
 description = "CrewAI integration for Beam Protocol"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,7 +25,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-  "beam-directory>=0.6.1",
+  "beam-directory>=0.7.0",
   "crewai>=0.1.0",
 ]
 

--- a/packages/beam-langchain/pyproject.toml
+++ b/packages/beam-langchain/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "beam-langchain"
-version = "0.6.1"
+version = "0.7.0"
 description = "LangChain tools and toolkit for Beam Protocol agent-to-agent communication"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "beam-directory>=0.6.1",
+  "beam-directory>=0.7.0",
   "langchain-core>=0.3.0",
   "pydantic>=2.0.0",
 ]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.6.1",
+    "beam-protocol-sdk": "^0.7.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/create-beam-agent/src/index.ts
+++ b/packages/create-beam-agent/src/index.ts
@@ -12,7 +12,7 @@ const valid = (value: string) => /^[a-z0-9_-]+$/.test(value)
 function renderPackageJson(name: string): string {
   return JSON.stringify({
     name,
-    version: '0.6.1',
+    version: '0.7.0',
     private: true,
     type: 'module',
     scripts: {
@@ -21,7 +21,7 @@ function renderPackageJson(name: string): string {
       start: 'node dist/index.js'
     },
     dependencies: {
-      'beam-protocol-sdk': '^0.6.1'
+      'beam-protocol-sdk': '^0.7.0'
     },
     devDependencies: {
       '@types/node': '^20.11.0',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -256,7 +256,7 @@ test('health, stats, and release endpoint expose consistent live release metadat
 
   try {
     process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
-    process.env['BEAM_RELEASE_VERSION'] = '0.6.1-test'
+    process.env['BEAM_RELEASE_VERSION'] = '0.7.0-test'
     process.env['BEAM_RELEASE_SHA'] = 'abcdef1234567890abcdef1234567890abcdef12'
     process.env['BEAM_DEPLOYED_AT'] = '2026-03-30T19:00:00.000Z'
 
@@ -288,9 +288,9 @@ test('health, stats, and release endpoint expose consistent live release metadat
       release: { version: string; gitSha: string; gitShaShort: string; deployedAt: string }
     }
 
-    assert.equal(health.version, '0.6.1-test')
-    assert.equal(stats.version, '0.6.1-test')
-    assert.equal(release.release.version, '0.6.1-test')
+    assert.equal(health.version, '0.7.0-test')
+    assert.equal(stats.version, '0.7.0-test')
+    assert.equal(release.release.version, '0.7.0-test')
     assert.equal(health.gitSha, 'abcdef1234567890abcdef1234567890abcdef12')
     assert.equal(stats.gitSha, 'abcdef1234567890abcdef1234567890abcdef12')
     assert.equal(release.release.gitShaShort, 'abcdef1')

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.6.1"
+    "beam-protocol-sdk": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-python/pyproject.toml
+++ b/packages/sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "beam-directory"
-version = "0.6.1"
+version = "0.7.0"
 description = "Python SDK for verified B2B handoffs over Beam"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/tests/api-key.test.ts
+++ b/packages/sdk-typescript/tests/api-key.test.ts
@@ -55,11 +55,11 @@ describe('SDK API key auth', () => {
       verifiedAgents: 2,
       intentsProcessed: 9,
       waitlistSize: 1,
-      version: '0.6.1',
+      version: '0.7.0',
       gitSha: 'abcdef1234567890abcdef1234567890abcdef12',
       deployedAt: '2026-03-30T19:00:00.000Z',
       release: {
-        version: '0.6.1',
+        version: '0.7.0',
         gitSha: 'abcdef1234567890abcdef1234567890abcdef12',
         gitShaShort: 'abcdef1',
         deployedAt: '2026-03-30T19:00:00.000Z',
@@ -78,7 +78,7 @@ describe('SDK API key auth', () => {
     const stats = await directory.getStats()
 
     expect(stats.totalAgents).toBe(3)
-    expect(stats.version).toBe('0.6.1')
+    expect(stats.version).toBe('0.7.0')
     expect(stats.gitSha).toBe('abcdef1234567890abcdef1234567890abcdef12')
     expect(stats.deployedAt).toBe('2026-03-30T19:00:00.000Z')
     expect(stats.release?.gitShaShort).toBe('abcdef1')

--- a/reports/0.7.0-operator-dogfood-rerun.md
+++ b/reports/0.7.0-operator-dogfood-rerun.md
@@ -1,0 +1,58 @@
+# 0.7.0 Operator Dogfood Rerun
+
+- date: 2026-03-30
+- repo checkout used for local verification: `caf0079f8543216c3fcb852a3757b406b0d3bf32`
+- local quickstart surfaces used:
+  - `http://localhost:43173`
+  - `http://localhost:43100`
+  - `http://localhost:43220`
+- live surfaces checked during the rerun:
+  - `https://api.beam.directory/health`
+  - `https://api.beam.directory/stats`
+  - `https://api.beam.directory/release`
+  - `https://beam.directory/status.html`
+
+## Goal
+
+Re-run the operator path after resolving #44 and #45 and confirm that the documented quickstart and live release-truth surfaces no longer block a release cut.
+
+## Path Followed
+
+1. Opened the hosted quickstart guide on `docs.beam.directory`.
+2. Opened the local dashboard login page.
+3. Requested a local magic link for `ops@beam.local` and logged in.
+4. Ran `npm run demo:run`.
+5. Opened the resulting quote nonce `6b62a351-41cd-45f2-88d2-a6c6140f94bd` in the trace view.
+6. Opened `Settings` and stored the local message-bus API key.
+7. Opened `Dead Letters` and confirmed the page loaded without the prior bus error.
+8. Opened `https://beam.directory/status.html` and confirmed the live API and WebSocket checks were healthy.
+9. Queried the live API directly for `health`, `stats`, and `/release`.
+
+## What Worked
+
+- The dashboard login flow remains straightforward for localhost.
+- The canonical demo handoff still produces a good operator nonce immediately.
+- The trace page remains the strongest proof surface and showed the nonce completing through `acked`.
+- `Dead Letters` now loads cleanly after storing the documented bus API key.
+- Local `Settings` now validates the message bus instead of leaving health unavailable.
+- The live API now exposes aligned release metadata on `health`, `stats`, and `/release`.
+- The public status page shows a healthy API and WebSocket path against the current live API.
+
+## Questions Answered Without Manual Debugging
+
+- "How do I sign in locally?"
+  - The dashboard login page answered this directly.
+- "Did the canonical partner handoff complete?"
+  - `npm run demo:run` and the nonce trace answered this directly.
+- "Can the operator inspect dead letters after configuring the documented bus settings?"
+  - Yes. The page loads and shows the empty queue state instead of a browser error.
+- "Does the live API expose release truth now?"
+  - Yes. `health`, `stats`, and `/release` all return the same version, SHA, and deploy time.
+
+## Blockers
+
+No release blocker was found in this rerun.
+
+## Decision
+
+The operator gate now passes. The remaining work before `v0.7.0` is release mechanics only: version cut, exact-commit deploy verification, and the tag/release flow.

--- a/reports/0.7.0-rc1-checklist.md
+++ b/reports/0.7.0-rc1-checklist.md
@@ -20,16 +20,16 @@ The goal is to end the hosted-beta milestone with one deliberate cut commit, one
   - closed, or
   - explicitly moved to the next milestone with an owner
 - [ ] no release blocker is left in chat, notes, or ad hoc comments only
-- [ ] changelog draft is updated in `CHANGELOG.md`
-- [ ] release-notes draft exists in `reports/0.7.0-release-notes-draft.md`
+- [x] changelog draft is updated in `CHANGELOG.md`
+- [x] release-notes draft exists in `reports/0.7.0-release-notes-draft.md`
 
 ## Repo Checks
 
-- [ ] `npm test`
-- [ ] `npm run build`
-- [ ] `cd docs && npm run build`
-- [ ] `npm run test:e2e`
-- [ ] `npm run quickstart:smoke`
+- [x] `npm test`
+- [x] `npm run build`
+- [x] `cd docs && npm run build`
+- [x] `npm run test:e2e`
+- [x] `npm run quickstart:smoke`
 - [ ] all GitHub Actions checks are green on the candidate commit:
   - `docs`
   - `monorepo (20)`
@@ -52,21 +52,23 @@ The goal is to end the hosted-beta milestone with one deliberate cut commit, one
 
 Go/no-go depends on the current dogfood reports, not on feature appetite.
 
-- [ ] buyer-like dogfood pass completed after the latest public-surface refresh
+- [x] buyer-like dogfood pass completed after the latest public-surface refresh
   - latest report: [0.7.0-buyer-dogfood-pass.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-buyer-dogfood-pass.md)
-- [ ] operator-like dogfood pass completed after the latest release-truth rollout
-  - latest report: [0.7.0-operator-dogfood-pass.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-operator-dogfood-pass.md)
-- [ ] both reports are attached to the repo and point to the exact commit used
-- [ ] no blocker remains in the following classes:
+- [x] operator-like dogfood pass completed after the latest release-truth rollout
+  - initial blocker report: [0.7.0-operator-dogfood-pass.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-operator-dogfood-pass.md)
+  - post-fix rerun: [0.7.0-operator-dogfood-rerun.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.7.0-operator-dogfood-rerun.md)
+- [x] both reports are attached to the repo and point to the exact commit used
+- [x] no blocker remains in the following classes:
   - onboarding confusion that prevents a first run
   - trace or alert confusion that blocks operator diagnosis
   - release-truth drift between `health`, `stats`, status page, or live surfaces
   - deployment order ambiguity between API, public site, docs, and tag
 
-Current blocker references from the latest dogfood pass:
+Latest dogfood rerun outcome:
 
-- #44 `Unblock dashboard bus observability in hosted quickstart`
-- #45 `Deploy live release-truth endpoints before 0.7.0 cut`
+- #44 resolved via PR #47
+- #45 resolved via PR #48 plus a verified Fly deploy
+- no open blocker remained in the rerun report
 
 ## Go / No-Go
 


### PR DESCRIPTION
## Summary
- cut the 0.7.0 release candidate across npm, docs, and Python package metadata
- attach the post-fix operator dogfood rerun and update the RC checklist with the completed local gates
- align release-truth examples, scaffolded versions, and SDK dependency ranges with 0.7.0

## Verification
- npm test
- npm run build
- cd docs && npm run build
- npm run test:e2e
- npm run quickstart:smoke
