### PR TITLE
Add 0.8.0 design partner plan

### DIFF
--- a/reports/0.8.0-design-partner-plan.md
+++ b/reports/0.8.0-design-partner-plan.md
@@ -1,0 +1,306 @@
+# Beam 0.8.0 Design Partner Plan
+
+## Goal
+
+Beam `0.8.0` should turn the freshly shipped hosted beta into a design-partner-ready product for one narrow job:
+
+**verified B2B handoffs between two companies' agents, explained clearly enough that a normal buyer can understand it and an operator can run it**
+
+At the end of this milestone, Beam should no longer feel like "a promising protocol repo with a good demo". It should feel like:
+
+1. a clear product with one understandable use case,
+2. a hosted evaluation path that a buyer can complete,
+3. an operator workflow that supports real follow-up and debugging,
+4. a proof package strong enough for external design-partner conversations.
+
+## Target Date
+
+- target release: `v0.8.0`
+- target cut window: **May 29, 2026**
+
+## North Star
+
+By `0.8.0`, a first external team should be able to:
+
+1. land on `beam.directory` and understand Beam in under 30 seconds,
+2. request hosted beta access without needing protocol context,
+3. complete a guided hosted handoff evaluation,
+4. receive proof that the handoff was verified and observable,
+5. continue the conversation through a concrete operator-owned follow-up flow.
+
+## Non-Goals
+
+This milestone is not for:
+
+- expanding Beam into a generic agent platform,
+- adding broad new framework integrations as headline work,
+- inventing a new protocol family or widening the signed frame contract,
+- self-serve enterprise packaging, billing, or marketplace-style onboarding,
+- building multiple unrelated demos instead of one dominant proof path.
+
+## Current Position
+
+As of `v0.7.0`:
+
+- the release is live and consistent across `api.beam.directory`, `beam.directory`, and `docs.beam.directory`,
+- release-truth drift is fixed,
+- quickstart, CI, E2E, and publish are green,
+- the hosted beta story is materially clearer than it was before,
+- the repo currently has **no open issues**, which means the next milestone needs an explicit execution backlog instead of ad hoc follow-ups.
+
+What is still missing is not protocol credibility. It is product readiness:
+
+- buyer language is better, but still not yet fully outcome-first,
+- hosted-beta requests are captured, but the follow-up workflow is not yet strong enough for real pipeline use,
+- the product has proof, but not yet a polished proof pack for external conversations,
+- operator surfaces are good for internal use, but still need one more pass for real support rhythm,
+- there is no visible measurement loop tying landing-page traffic to hosted-beta requests and evaluations.
+
+## Success Criteria
+
+`0.8.0` is done when all of the following are true:
+
+- Beam has one dominant public message:
+  - "Beam helps one company agent hand work to another company agent, with verification and operator visibility."
+- `beam.directory` has a clearly non-technical top-level story:
+  - what Beam is,
+  - who it is for,
+  - what happens in a hosted evaluation,
+  - what the next step is.
+- hosted-beta intake behaves like a real pipeline:
+  - qualified request data,
+  - owner,
+  - stage,
+  - next action,
+  - last contact,
+  - exportable state.
+- new hosted-beta requests and demo failures create an operator-visible follow-up signal.
+- one external-style guided evaluation can be run from hosted surfaces without repo access.
+- operators can recover the common failure classes without leaving the dashboard and runbook:
+  - registration failure,
+  - ACL denial,
+  - retry/backoff loop,
+  - dead-letter outcome,
+  - stale or revoked key,
+  - buyer/demo setup confusion.
+- buyer-facing proof exists as a package, not only as product internals:
+  - screenshots,
+  - short explanation blocks,
+  - evaluation steps,
+  - FAQ/pricing posture.
+- the funnel is measured:
+  - page visit -> hosted-beta request,
+  - request -> qualified conversation,
+  - request -> demo run,
+  - demo run -> follow-up outcome.
+- at least two fresh post-`0.7.0` dry runs are documented:
+  - one buyer-like,
+  - one operator-like.
+
+## Product Thesis For This Milestone
+
+The most important product decision for `0.8.0` is this:
+
+**Beam wins the next phase by becoming easier to buy and easier to evaluate, not by becoming broader.**
+
+That means the milestone should optimize for:
+
+- clarity over protocol ambition,
+- one proof path over many options,
+- follow-up workflow over more raw capability,
+- external usability over internal elegance.
+
+## Workstreams
+
+### 1. Public Story And Conversion Surface
+
+Goal: make Beam immediately understandable to a normal business user.
+
+Scope:
+
+- reduce the remaining protocol-heavy wording on the public site,
+- add a plain-language "what Beam does" section above the fold,
+- add a concise "who this is for / not for" frame,
+- add a hosted-beta FAQ and early pricing/engagement posture,
+- make the primary CTA lead into one evaluation path only.
+
+Definition of done:
+
+- a new visitor can explain Beam back in one sentence after reading the landing page,
+- the page no longer assumes the reader already understands agents, protocols, or federation,
+- the CTA structure is obvious: proof -> request -> guided evaluation.
+
+### 2. Hosted Beta Pipeline And Follow-Up
+
+Goal: turn hosted-beta submissions into a real operator-owned workflow.
+
+Scope:
+
+- extend request stages beyond raw request capture,
+- support stage, owner, next step, last contact, and qualification notes,
+- add notifications for new requests and stage-sensitive follow-up,
+- add templates for common reply states,
+- keep export paths usable for manual CRM handoff if needed.
+
+Definition of done:
+
+- every hosted-beta request has a visible owner and stage,
+- no request can silently sit unowned,
+- operators can answer "who owns this?" and "what happens next?" instantly.
+
+### 3. Guided Demo And Design Partner Onboarding
+
+Goal: make the hosted evaluation feel like a product onboarding flow rather than a repo exercise.
+
+Scope:
+
+- produce one guided hosted demo script,
+- create one reusable evaluation checklist,
+- create a design-partner onboarding pack:
+  - intro,
+  - prerequisites,
+  - sample workflow framing,
+  - operator expectations,
+  - follow-up checklist,
+- align landing, hosted-beta page, docs, and demo language around the same evaluation promise.
+
+Definition of done:
+
+- a guided evaluation can be run without sending the user to the repo first,
+- the onboarding artifacts explain expectations before the call starts.
+
+### 4. Operator Product And Support Loop
+
+Goal: make internal operations boring enough for real external pilots.
+
+Scope:
+
+- improve operator shortcuts from alert -> trace -> agent -> retry/dead-letter context,
+- tighten the beta-request dashboard loop with linked operational evidence,
+- add better canned states for investigation and follow-up,
+- document recovery expectations and operator SLAs in the runbook,
+- ensure the dashboard is usable as the central pane of glass for hosted evaluations.
+
+Definition of done:
+
+- an operator can answer "what failed, who owns it, and what do we do next?" without jumping across too many surfaces,
+- demo and failure handling feel procedural instead of improvised.
+
+### 5. Proof, Analytics, And Release Control
+
+Goal: give Beam a measurable funnel and a disciplined release path toward the first external design partner.
+
+Scope:
+
+- add analytics for key public and evaluation events,
+- capture the proof assets needed for outreach and follow-up,
+- run two documented dry runs after the new surfaces land,
+- keep one explicit `0.8.0` cut checklist and release-note draft from the start.
+
+Definition of done:
+
+- the team can see what converts and where evaluation flow breaks,
+- release readiness is based on explicit evidence, not vibes.
+
+## Execution Backlog
+
+The milestone backlog is tracked as these concrete work items:
+
+1. **#50 Rewrite the landing page around plain-language buyer outcomes**
+2. **#51 Add FAQ and engagement/pricing posture for hosted beta**
+3. **#52 Turn hosted-beta requests into a staged operator pipeline**
+4. **#53 Notify operators about new beta requests and demo-critical failures**
+5. **#54 Create a guided hosted evaluation path with reusable proof assets**
+6. **#55 Ship a design-partner onboarding pack and operator follow-up templates**
+7. **#56 Tighten operator shortcuts from alerts and dead letters into trace/recovery**
+8. **#57 Instrument landing, intake, and demo funnel analytics**
+9. **#58 Run one buyer-like and one operator-like 0.8.0 dry run after the public refresh**
+10. **#59 Prepare the 0.8.0 cut checklist and release notes from day one**
+
+## Sequence
+
+### Phase 1: Clarify The Product
+
+Duration: week 1
+
+- finish the public-language pass,
+- decide the hosted-beta CTA and pricing posture,
+- tighten the top-of-funnel story before touching more backend depth.
+
+### Phase 2: Build The Pipeline
+
+Duration: week 2
+
+- make hosted-beta requests operationally real,
+- add ownership and notification semantics,
+- make sure no request enters a dead zone.
+
+### Phase 3: Package The Evaluation
+
+Duration: week 3
+
+- create guided evaluation assets,
+- align hosted pages and docs with them,
+- make the demo path usable for a real conversation.
+
+### Phase 4: Tighten The Operator Loop
+
+Duration: week 4
+
+- reduce investigation friction,
+- connect buyer workflow with operator workflow,
+- make support and follow-up repeatable.
+
+### Phase 5: Measure And Dry Run
+
+Duration: week 5
+
+- turn on funnel measurement,
+- run two post-change dry runs,
+- document what still causes confusion.
+
+### Phase 6: Cut Or Slip
+
+Duration: week 6
+
+- cut `0.8.0` only if the dry runs are boring,
+- otherwise keep the milestone narrow and fix only the blockers exposed by the dry runs.
+
+## Release Gates
+
+Do not cut `0.8.0` unless all of the following are true:
+
+- `npm test`
+- `npm run build`
+- `cd docs && npm run build`
+- `npm run test:e2e`
+- `npm run quickstart:smoke`
+- GitHub Actions green on the candidate commit
+- hosted-beta request pipeline works end-to-end
+- live release-truth surfaces still agree
+- the latest buyer-like and operator-like dry runs report no ambiguous blocker
+
+## Metrics To Watch
+
+The milestone should track these practical metrics:
+
+- landing page -> hosted-beta request conversion rate
+- time from hosted-beta request to first operator follow-up
+- time from first follow-up to guided evaluation
+- time to first successful hosted handoff during evaluation
+- number of manual explanations required during buyer dry runs
+- number of operator context switches required during recovery
+
+## Immediate Next Actions
+
+Setup status after creating this plan:
+
+1. `0.6.0` and `0.7.0 Hosted Beta` are closed,
+2. `0.8.0 Design Partner Beta` is open,
+3. the execution backlog exists as `#50` through `#59`.
+
+The next actions now are:
+
+1. start `#50` and `#51` as the public-story pass,
+2. move directly into `#52`, with `#53` following immediately behind it,
+3. hold broader product work until the public story and hosted-beta pipeline are both materially stronger.


### PR DESCRIPTION
## Summary
- add the repo-visible 0.8.0 plan focused on design-partner readiness
- define goal, success criteria, workstreams, sequence, gates, and metrics
- align the report with the new 0.8.0 milestone and issue backlog (#50-#59)

## Notes
- no code or product behavior changed
- GitHub milestone and issue setup was done alongside this report
