### PR TITLE
Add hosted beta operator pipeline and inbox

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -195,8 +195,16 @@ The canonical request payload now includes:
 - `workflowType`
 - `workflowSummary`
 - `requestStatus`
+- `stage`
 - `owner`
 - `operatorNotes`
+- `nextAction`
+- `lastContactAt`
+- `stale`
+- `staleReason`
+- `attentionFlags`
+- `notificationId`
+- `notificationStatus`
 - `createdAt`
 - `updatedAt`
 
@@ -227,6 +235,8 @@ List filtering currently supports:
 - `owner`
 - `source`
 - `workflowType`
+- `attention` (`unowned` or `stale`)
+- `sort` (`attention`, `updated_desc`, `created_desc`, `stage`, `owner`, `last_contact_desc`)
 - `limit`
 
 `PATCH /admin/beta-requests/:id` accepts:
@@ -235,9 +245,48 @@ List filtering currently supports:
 {
   "status": "reviewing",
   "owner": "operator@beam.directory",
-  "operatorNotes": "Intro email sent, follow-up call pending."
+  "operatorNotes": "Intro email sent, follow-up call pending.",
+  "nextAction": "Prepare a 30 minute buyer walkthrough.",
+  "lastContactAt": "2026-03-31T09:30:00.000Z"
 }
 ```
+
+The response request record carries the same pipeline fields plus notification state, so operators can tell whether a request is still `new`, already `acknowledged`, or fully `acted` on.
+
+Hosted beta export includes:
+
+- `next_action`
+- `last_contact_at`
+- `notification_status`
+- `stale`
+- `attention_flags`
+
+## Operator notifications
+
+Operator-visible intake and incident signals are exposed through:
+
+```text
+GET   /admin/operator-notifications
+PATCH /admin/operator-notifications/:id
+```
+
+`GET /admin/operator-notifications` supports:
+
+- `q`
+- `status` (`new`, `acknowledged`, `acted`)
+- `source` (`beta_request`, `critical_alert`)
+- `limit`
+- `hours` to control the critical-alert window that is synced before listing
+
+Example patch:
+
+```json
+{
+  "status": "acknowledged"
+}
+```
+
+Critical alerts from observability reuse the same notification path. The `notificationStatus` and `notificationId` fields also appear on critical alert payloads from `GET /observability/overview` and `GET /observability/alerts`.
 
 All hosted beta admin endpoints require an authenticated admin session and accept either:
 

--- a/docs/guide/operator-runbook.md
+++ b/docs/guide/operator-runbook.md
@@ -8,9 +8,29 @@ Use it together with:
 - [Operator Observability](/guide/operator-observability) for dashboards, exports, and retention controls
 - [Intent Lifecycle](/guide/intent-lifecycle) for status semantics
 
+## Operator Inbox First
+
+Start the day in `Inbox` before drilling into traces.
+
+- `new` means nobody has acknowledged the request or alert yet.
+- `acknowledged` means an operator has taken ownership or triaged the signal.
+- `acted` means the next concrete step or remediation was already recorded.
+
+Use the inbox for two classes of work:
+
+- hosted beta requests that still need assignment, contact, or a next action
+- critical alerts that need triage, acknowledgement, and an explicit follow-up
+
+The shortest daily loop is:
+
+1. Open `Inbox`.
+2. Filter to `new`.
+3. Acknowledge or act on each signal.
+4. Jump into `Beta Requests`, `Alerts`, or the linked trace from there.
+
 ## The Default Investigation Loop
 
-1. Start from `Alerts` or the nonce you already have.
+1. Start from `Inbox`, `Alerts`, or the nonce you already have.
 2. Open the trace and note the current lifecycle status.
 3. Confirm related audit or Shield events.
 4. Check `Dead Letters` only if the nonce is terminal or obviously retrying.
@@ -108,5 +128,7 @@ In the seeded hosted demo:
 - async finance preflight may stay in `delivered`
 - dead-letter count stays `0`
 - alerts stay empty for the clean path
+- inbox contains no lingering `new` critical-alert signals after triage
+- hosted beta requests should move from `new` to `acknowledged` or `acted` once an owner and next action exist
 
 If those assumptions drift, use this runbook before editing code or SQLite directly.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import ErrorsPage from './pages/ErrorsPage'
 import FederationPage from './pages/FederationPage'
 import IntentsPage from './pages/IntentsPage'
 import LoginPage from './pages/LoginPage'
+import OperatorInboxPage from './pages/OperatorInboxPage'
 import OverviewPage from './pages/OverviewPage'
 import RegisterPage from './pages/RegisterPage'
 import SettingsPage from './pages/SettingsPage'
@@ -55,6 +56,7 @@ export default function App() {
             <Route path="federation" element={<FederationPage />} />
             <Route path="errors" element={<ErrorsPage />} />
             <Route path="alerts" element={<AlertsPage />} />
+            <Route path="inbox" element={<OperatorInboxPage />} />
             <Route path="beta-requests" element={<BetaRequestsPage />} />
             <Route path="dead-letter" element={<DeadLetterPage />} />
             <Route path="register" element={<RegisterPage />} />

--- a/packages/dashboard/src/components/AlertCard.tsx
+++ b/packages/dashboard/src/components/AlertCard.tsx
@@ -39,6 +39,7 @@ export default function AlertCard({
         <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium uppercase tracking-[0.14em]', alertSeverityColor(alert.severity))}>
           {alert.severity}
         </span>
+        {alert.notificationStatus ? <StatusPill label={`signal ${alert.notificationStatus}`} tone={alert.notificationStatus === 'acted' ? 'success' : alert.notificationStatus === 'acknowledged' ? 'default' : 'warning'} /> : null}
         <span className="text-xs text-slate-500 dark:text-slate-400">{alert.scope}</span>
         <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(alert.startedAt)}</span>
       </div>
@@ -86,6 +87,14 @@ export default function AlertCard({
 
       {visibleLinks.length > 0 ? (
         <div className="mt-4 flex flex-wrap gap-2">
+          {alert.notificationId ? (
+            <Link
+              className="rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
+              to="/inbox"
+            >
+              Open inbox signal
+            </Link>
+          ) : null}
           {visibleLinks.map((link) => (
             <Link
               key={`${alert.id}-${link.label}-${link.href}`}

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { Activity, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
+import { Activity, BellDot, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
 import { useAdminAuth } from '../lib/admin-auth'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
@@ -13,6 +13,7 @@ const NAV_ITEMS = [
   { path: '/federation', label: 'Federation', icon: Globe2 },
   { path: '/errors', label: 'Errors', icon: TriangleAlert },
   { path: '/alerts', label: 'Alerts', icon: Shield },
+  { path: '/inbox', label: 'Inbox', icon: BellDot },
   { path: '/beta-requests', label: 'Beta Requests', icon: FileText },
   { path: '/dead-letter', label: 'Dead Letters', icon: Inbox },
   { path: '/register', label: 'Register', icon: UserPlus },

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -6,7 +6,10 @@ export type IntentLifecycleStatus = 'received' | 'validated' | 'queued' | 'dispa
 export type AlertMetricUnit = 'ratio' | 'ms' | 'count'
 export type AlertLinkSurface = 'trace' | 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
 export type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
+export type BetaRequestAttention = 'unowned' | 'stale'
 export type BetaRequestExportFormat = 'json' | 'csv'
+export type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
+export type OperatorNotificationSource = 'beta_request' | 'critical_alert'
 
 export interface DirectoryAgent {
   beamId: string
@@ -201,6 +204,8 @@ export interface AlertItem {
   severityReason: string
   links: AlertLink[]
   sampleTraces: AlertTraceSample[]
+  notificationId?: number | null
+  notificationStatus?: OperatorNotificationStatus | null
 }
 
 export interface AlertLink {
@@ -560,8 +565,16 @@ export interface BetaRequest {
   workflowType: string | null
   workflowSummary: string | null
   requestStatus: BetaRequestStatus
+  stage: BetaRequestStatus
   owner: string | null
   operatorNotes: string | null
+  nextAction: string | null
+  lastContactAt: string | null
+  stale: boolean
+  staleReason: string | null
+  attentionFlags: BetaRequestAttention[]
+  notificationId: number | null
+  notificationStatus: OperatorNotificationStatus | null
   createdAt: string
   updatedAt: string
 }
@@ -580,6 +593,8 @@ export interface BetaRequestSummary {
   total: number
   active: number
   unowned: number
+  stale: number
+  needsAttention: number
   byStatus: Record<BetaRequestStatus, number>
 }
 
@@ -597,11 +612,49 @@ export interface BetaRequestUpdateInput {
   status?: BetaRequestStatus
   owner?: string | null
   operatorNotes?: string | null
+  nextAction?: string | null
+  lastContactAt?: string | null
 }
 
 export interface BetaRequestUpdateResponse {
   ok: boolean
   request: BetaRequest
+}
+
+export interface OperatorNotification {
+  id: number
+  sourceType: OperatorNotificationSource
+  sourceKey: string
+  betaRequestId: number | null
+  alertId: string | null
+  severity: AlertSeverity
+  title: string
+  message: string
+  href: string | null
+  status: OperatorNotificationStatus
+  createdAt: string
+  updatedAt: string
+  acknowledgedAt: string | null
+  actedAt: string | null
+  actor: string | null
+  details: Record<string, unknown> | null
+}
+
+export interface OperatorNotificationSummary {
+  total: number
+  byStatus: Record<OperatorNotificationStatus, number>
+  bySource: Record<OperatorNotificationSource, number>
+}
+
+export interface OperatorNotificationListResponse {
+  notifications: OperatorNotification[]
+  total: number
+  summary: OperatorNotificationSummary
+}
+
+export interface OperatorNotificationUpdateResponse {
+  ok: boolean
+  notification: OperatorNotification
 }
 
 export interface IntentFeedMessage {
@@ -900,6 +953,8 @@ export const directoryApi = {
     owner?: string
     source?: string
     workflowType?: string
+    attention?: BetaRequestAttention
+    sort?: 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
     limit?: number
   }) => request<BetaRequestListResponse>(`/admin/beta-requests${buildQuery({
     q: params?.q,
@@ -907,6 +962,8 @@ export const directoryApi = {
     owner: params?.owner,
     source: params?.source,
     workflowType: params?.workflowType,
+    attention: params?.attention,
+    sort: params?.sort,
     limit: params?.limit,
   })}`, undefined, { admin: true }),
   getBetaRequest: (id: number) => request<BetaRequestDetailResponse>(`/admin/beta-requests/${id}`, undefined, { admin: true }),
@@ -920,6 +977,8 @@ export const directoryApi = {
     owner?: string
     source?: string
     workflowType?: string
+    attention?: BetaRequestAttention
+    sort?: 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
     limit?: number
   }): Promise<ExportDownload> => {
     const response = await requestRaw(`/admin/beta-requests/export${buildQuery({
@@ -929,6 +988,8 @@ export const directoryApi = {
       owner: params?.owner,
       source: params?.source,
       workflowType: params?.workflowType,
+      attention: params?.attention,
+      sort: params?.sort,
       limit: params?.limit,
     })}`, undefined, { admin: true })
 
@@ -937,6 +998,25 @@ export const directoryApi = {
       filename: getFilenameFromResponse(response, 'beta-requests', format),
     }
   },
+  listOperatorNotifications: (params?: {
+    q?: string
+    status?: OperatorNotificationStatus
+    source?: OperatorNotificationSource
+    limit?: number
+    hours?: number
+  }) => request<OperatorNotificationListResponse>(`/admin/operator-notifications${buildQuery({
+    q: params?.q,
+    status: params?.status,
+    source: params?.source,
+    limit: params?.limit,
+    hours: params?.hours,
+  })}`, undefined, { admin: true }),
+  updateOperatorNotification: (id: number, input: {
+    status: OperatorNotificationStatus
+  }) => request<OperatorNotificationUpdateResponse>(`/admin/operator-notifications/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   createOrg: (input: OrgRegistrationInput) => request<OrgRegistrationResponse>('/orgs', {
     method: 'POST',
     body: JSON.stringify(input),

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -1,18 +1,20 @@
+import { Clock3, Download, RefreshCw, Search, TriangleAlert } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
-import { Download, RefreshCw, Search } from 'lucide-react'
-import { useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
 import { useAdminAuth } from '../lib/admin-auth'
 import {
   ApiError,
   directoryApi,
   type BetaRequest,
+  type BetaRequestAttention,
   type BetaRequestStatus,
+  type OperatorNotificationStatus,
 } from '../lib/api'
 import { downloadBlob, formatDateTime, formatRelativeTime } from '../lib/utils'
 
 const STATUS_OPTIONS: Array<{ value: '' | BetaRequestStatus; label: string }> = [
-  { value: '', label: 'All statuses' },
+  { value: '', label: 'All stages' },
   { value: 'new', label: 'New' },
   { value: 'reviewing', label: 'Reviewing' },
   { value: 'contacted', label: 'Contacted' },
@@ -20,6 +22,23 @@ const STATUS_OPTIONS: Array<{ value: '' | BetaRequestStatus; label: string }> = 
   { value: 'active', label: 'Active' },
   { value: 'closed', label: 'Closed' },
 ]
+
+const ATTENTION_OPTIONS: Array<{ value: '' | BetaRequestAttention; label: string }> = [
+  { value: '', label: 'All requests' },
+  { value: 'unowned', label: 'Unowned' },
+  { value: 'stale', label: 'Stale' },
+]
+
+const SORT_OPTIONS = [
+  { value: 'attention', label: 'Attention first' },
+  { value: 'updated_desc', label: 'Recently updated' },
+  { value: 'last_contact_desc', label: 'Recent contact' },
+  { value: 'stage', label: 'Stage' },
+  { value: 'owner', label: 'Owner' },
+  { value: 'created_desc', label: 'Recently created' },
+] as const
+
+type SortOption = typeof SORT_OPTIONS[number]['value']
 
 export default function BetaRequestsPage() {
   const { session } = useAdminAuth()
@@ -30,6 +49,8 @@ export default function BetaRequestsPage() {
     total: number
     active: number
     unowned: number
+    stale: number
+    needsAttention: number
     byStatus: Record<BetaRequestStatus, number>
   } | null>(null)
   const [loading, setLoading] = useState(true)
@@ -40,6 +61,8 @@ export default function BetaRequestsPage() {
   const query = searchParams.get('q') ?? ''
   const status = (searchParams.get('status') ?? '') as '' | BetaRequestStatus
   const ownerFilter = searchParams.get('owner') ?? ''
+  const attention = (searchParams.get('attention') ?? '') as '' | BetaRequestAttention
+  const sort = (searchParams.get('sort') ?? 'attention') as SortOption
   const selectedId = Number.parseInt(searchParams.get('id') ?? '', 10)
   const canEdit = session?.role === 'admin' || session?.role === 'operator'
 
@@ -50,6 +73,8 @@ export default function BetaRequestsPage() {
 
   const [draftStatus, setDraftStatus] = useState<BetaRequestStatus>('new')
   const [draftOwner, setDraftOwner] = useState('')
+  const [draftNextAction, setDraftNextAction] = useState('')
+  const [draftLastContactAt, setDraftLastContactAt] = useState('')
   const [draftNotes, setDraftNotes] = useState('')
 
   function updateSearchParam(key: string, value: string) {
@@ -78,12 +103,16 @@ export default function BetaRequestsPage() {
     if (!selectedRequest) {
       setDraftStatus('new')
       setDraftOwner('')
+      setDraftNextAction('')
+      setDraftLastContactAt('')
       setDraftNotes('')
       return
     }
 
-    setDraftStatus(selectedRequest.requestStatus)
+    setDraftStatus(selectedRequest.stage)
     setDraftOwner(selectedRequest.owner ?? '')
+    setDraftNextAction(selectedRequest.nextAction ?? '')
+    setDraftLastContactAt(toDateTimeLocalValue(selectedRequest.lastContactAt))
     setDraftNotes(selectedRequest.operatorNotes ?? '')
   }, [selectedRequest])
 
@@ -94,6 +123,8 @@ export default function BetaRequestsPage() {
         q: query || undefined,
         status: status || undefined,
         owner: ownerFilter || undefined,
+        attention: attention || undefined,
+        sort,
         limit: 200,
       })
       setRequests(response.requests)
@@ -109,7 +140,7 @@ export default function BetaRequestsPage() {
 
   useEffect(() => {
     void load()
-  }, [ownerFilter, query, status])
+  }, [attention, ownerFilter, query, sort, status])
 
   async function saveRequest() {
     if (!selectedRequest || !canEdit) {
@@ -122,6 +153,8 @@ export default function BetaRequestsPage() {
       const response = await directoryApi.updateBetaRequest(selectedRequest.id, {
         status: draftStatus,
         owner: draftOwner || null,
+        nextAction: draftNextAction || null,
+        lastContactAt: draftLastContactAt || null,
         operatorNotes: draftNotes || null,
       })
       setRequests((current) => current.map((entry) => (
@@ -143,6 +176,8 @@ export default function BetaRequestsPage() {
         q: query || undefined,
         status: status || undefined,
         owner: ownerFilter || undefined,
+        attention: attention || undefined,
+        sort,
         limit: 5000,
       })
       downloadBlob(download.blob, download.filename)
@@ -156,7 +191,7 @@ export default function BetaRequestsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Hosted Beta Requests"
-        description="Review, assign, and export incoming hosted beta workflows without touching the database."
+        description="Run hosted beta intake as a real operator queue with stage, ownership, next action, and follow-up state."
         actions={(
           <div className="flex flex-wrap gap-2">
             <button className="btn-secondary" onClick={() => void exportRequests('json')} type="button">
@@ -176,16 +211,17 @@ export default function BetaRequestsPage() {
       />
 
       {summary ? (
-        <section className="grid gap-4 md:grid-cols-4">
+        <section className="grid gap-4 md:grid-cols-4 xl:grid-cols-5">
           <MetricCard label="Total requests" value={String(summary.total)} hint="All hosted beta requests in the current filter." />
-          <MetricCard label="Active requests" value={String(summary.active)} hint="Everything that is not closed." tone="success" />
-          <MetricCard label="Unowned" value={String(summary.unowned)} hint="Requests without an assigned operator." tone={summary.unowned > 0 ? 'warning' : 'default'} />
-          <MetricCard label="New" value={String(summary.byStatus.new)} hint="Fresh requests that still need first review." tone={summary.byStatus.new > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Need attention" value={String(summary.needsAttention)} hint="Requests that are unowned or stale." tone={summary.needsAttention > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Unowned" value={String(summary.unowned)} hint="Requests without an assigned operator." tone={summary.unowned > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Stale" value={String(summary.stale)} hint="Requests that have gone too long without contact." tone={summary.stale > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Active" value={String(summary.active)} hint="Everything that is not closed." tone="success" />
         </section>
       ) : null}
 
       <section className="panel">
-        <div className="grid gap-3 lg:grid-cols-[1.5fr,0.8fr,0.8fr]">
+        <div className="grid gap-3 xl:grid-cols-[1.6fr,0.9fr,0.9fr,0.9fr,0.9fr]">
           <label className="relative block">
             <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
             <input
@@ -202,12 +238,26 @@ export default function BetaRequestsPage() {
               </option>
             ))}
           </select>
+          <select className="input-field" value={attention} onChange={(event) => updateSearchParam('attention', event.target.value)}>
+            {ATTENTION_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
           <input
             className="input-field"
             placeholder="Filter by owner"
             value={ownerFilter}
             onChange={(event) => updateSearchParam('owner', event.target.value)}
           />
+          <select className="input-field" value={sort} onChange={(event) => updateSearchParam('sort', event.target.value)}>
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </div>
       </section>
 
@@ -244,24 +294,45 @@ export default function BetaRequestsPage() {
                 return (
                   <button
                     key={entry.id}
-                    className={`flex w-full flex-col gap-2 px-5 py-4 text-left transition ${active ? 'bg-orange-50 dark:bg-orange-500/10' : 'hover:bg-slate-50 dark:hover:bg-slate-900'}`}
+                    className={`flex w-full flex-col gap-3 px-5 py-4 text-left transition ${active ? 'bg-orange-50 dark:bg-orange-500/10' : 'hover:bg-slate-50 dark:hover:bg-slate-900'}`}
                     onClick={() => updateSearchParam('id', String(entry.id))}
                     type="button"
                   >
                     <div className="flex flex-wrap items-center gap-2">
-                      <StatusPill label={entry.requestStatus} tone={statusTone(entry.requestStatus)} />
-                      <span className="text-sm font-medium text-slate-900 dark:text-slate-100">{entry.company ?? entry.email}</span>
-                      <span className="text-xs text-slate-500 dark:text-slate-400">{entry.email}</span>
+                      <StatusPill label={entry.stage} tone={stageTone(entry.stage)} />
+                      {entry.notificationStatus ? <StatusPill label={`signal ${entry.notificationStatus}`} tone={signalTone(entry.notificationStatus)} /> : null}
+                      {entry.attentionFlags.map((flag) => (
+                        <StatusPill key={`${entry.id}-${flag}`} label={flag} tone={flag === 'unowned' ? 'critical' : 'warning'} />
+                      ))}
                     </div>
+
+                    <div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{entry.company ?? entry.email}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{entry.email}</div>
+                    </div>
+
                     <div className="text-sm text-slate-600 dark:text-slate-300">
                       {formatWorkflowType(entry.workflowType)}
                       {entry.agentCount != null ? ` · ${entry.agentCount} agent${entry.agentCount === 1 ? '' : 's'}` : ''}
                     </div>
-                    <div className="flex flex-wrap gap-3 text-xs text-slate-500 dark:text-slate-400">
+
+                    <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
                       <span>Owner: {entry.owner ?? 'unassigned'}</span>
                       <span>Updated {formatRelativeTime(entry.updatedAt)}</span>
+                      <span>Last contact: {entry.lastContactAt ? formatRelativeTime(entry.lastContactAt) : 'not recorded'}</span>
                       <span>Source: {entry.source ?? 'unknown'}</span>
                     </div>
+
+                    <div className="rounded-xl bg-slate-50 px-3 py-3 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                      {entry.nextAction ?? 'No next action is recorded yet.'}
+                    </div>
+
+                    {entry.staleReason ? (
+                      <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                        <TriangleAlert size={16} className="mt-0.5 shrink-0" />
+                        <span>{entry.staleReason}</span>
+                      </div>
+                    ) : null}
                   </button>
                 )
               })}
@@ -273,21 +344,43 @@ export default function BetaRequestsPage() {
           <div className="panel space-y-4">
             <div className="panel-title">Request detail</div>
             {!selectedRequest ? (
-              <EmptyPanel label="Select a hosted beta request to inspect its workflow summary and assignment state." />
+              <EmptyPanel label="Select a hosted beta request to inspect its workflow summary and operator state." />
             ) : (
               <>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <InfoRow label="Company" value={selectedRequest.company ?? '—'} />
                   <InfoRow label="Email" value={selectedRequest.email} />
-                  <InfoRow label="Workflow" value={formatWorkflowType(selectedRequest.workflowType)} />
-                  <InfoRow label="Source" value={selectedRequest.source ?? '—'} />
+                  <InfoRow label="Stage" value={selectedRequest.stage} />
+                  <InfoRow label="Signal" value={selectedRequest.notificationStatus ?? 'no operator signal'} />
                   <InfoRow label="Created" value={formatDateTime(selectedRequest.createdAt)} />
                   <InfoRow label="Updated" value={formatDateTime(selectedRequest.updatedAt)} />
+                  <InfoRow label="Last contact" value={formatDateTime(selectedRequest.lastContactAt)} />
+                  <InfoRow label="Owner" value={selectedRequest.owner ?? 'unassigned'} />
                 </div>
 
                 <div className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
                   {selectedRequest.workflowSummary || 'No workflow summary was provided in the intake.'}
                 </div>
+
+                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Next action</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                    {selectedRequest.nextAction ?? 'No next action is recorded yet.'}
+                  </div>
+                  {selectedRequest.notificationId ? (
+                    <div className="mt-3">
+                      <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/inbox">
+                        Open operator inbox signal
+                      </Link>
+                    </div>
+                  ) : null}
+                </div>
+
+                {selectedRequest.staleReason ? (
+                  <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                    {selectedRequest.staleReason}
+                  </div>
+                ) : null}
               </>
             )}
           </div>
@@ -295,11 +388,11 @@ export default function BetaRequestsPage() {
           <div className="panel space-y-4">
             <div className="panel-title">Operator assignment</div>
             {!selectedRequest ? (
-              <EmptyPanel label="Select a request to assign an owner, move the status, and capture follow-up notes." />
+              <EmptyPanel label="Select a request to assign an owner, move the stage, and capture follow-up." />
             ) : (
               <>
                 <label className="block space-y-2">
-                  <span className="text-sm font-medium">Status</span>
+                  <span className="text-sm font-medium">Stage</span>
                   <select
                     className="input-field"
                     disabled={!canEdit || saving}
@@ -326,11 +419,43 @@ export default function BetaRequestsPage() {
                 </label>
 
                 <label className="block space-y-2">
+                  <span className="text-sm font-medium">Next action</span>
+                  <textarea
+                    className="input-field min-h-28"
+                    disabled={!canEdit || saving}
+                    placeholder="What exactly happens next, and who is waiting on it?"
+                    value={draftNextAction}
+                    onChange={(event) => setDraftNextAction(event.target.value)}
+                  />
+                </label>
+
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium">Last contact</span>
+                  <input
+                    className="input-field"
+                    disabled={!canEdit || saving}
+                    type="datetime-local"
+                    value={draftLastContactAt}
+                    onChange={(event) => setDraftLastContactAt(event.target.value)}
+                  />
+                </label>
+
+                <button
+                  className="btn-secondary"
+                  disabled={!canEdit || saving}
+                  onClick={() => setDraftLastContactAt(toDateTimeLocalValue(new Date().toISOString()))}
+                  type="button"
+                >
+                  <Clock3 size={16} />
+                  <span>Mark contact now</span>
+                </button>
+
+                <label className="block space-y-2">
                   <span className="text-sm font-medium">Operator notes</span>
                   <textarea
                     className="input-field min-h-36"
                     disabled={!canEdit || saving}
-                    placeholder="Capture the next step, missing context, or why the request is blocked."
+                    placeholder="Capture missing context, qualification notes, blockers, or why this request is paused."
                     value={draftNotes}
                     onChange={(event) => setDraftNotes(event.target.value)}
                   />
@@ -373,19 +498,26 @@ function formatWorkflowType(value: string | null): string {
     .join(' ')
 }
 
-function statusTone(status: BetaRequestStatus): 'default' | 'success' | 'warning' | 'critical' {
-  switch (status) {
+function stageTone(stage: BetaRequestStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (stage) {
     case 'active':
       return 'success'
     case 'closed':
       return 'default'
-    case 'new':
-    case 'reviewing':
-    case 'contacted':
-    case 'scheduled':
-      return 'warning'
     default:
+      return 'warning'
+  }
+}
+
+function signalTone(status: OperatorNotificationStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'acted':
+      return 'success'
+    case 'acknowledged':
       return 'default'
+    case 'new':
+    default:
+      return 'warning'
   }
 }
 
@@ -396,4 +528,19 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <div className="mt-1 break-words text-sm font-medium text-slate-900 dark:text-slate-100">{value}</div>
     </div>
   )
+}
+
+function toDateTimeLocalValue(value?: string | null): string {
+  if (!value) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  const offset = date.getTimezoneOffset()
+  const localDate = new Date(date.getTime() - offset * 60_000)
+  return localDate.toISOString().slice(0, 16)
 }

--- a/packages/dashboard/src/pages/OperatorInboxPage.tsx
+++ b/packages/dashboard/src/pages/OperatorInboxPage.tsx
@@ -1,0 +1,272 @@
+import { BellDot, RefreshCw, Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import {
+  ApiError,
+  directoryApi,
+  type OperatorNotification,
+  type OperatorNotificationSource,
+  type OperatorNotificationStatus,
+} from '../lib/api'
+import { formatDateTime, formatRelativeTime } from '../lib/utils'
+
+const STATUS_OPTIONS: Array<{ value: '' | OperatorNotificationStatus; label: string }> = [
+  { value: '', label: 'All signals' },
+  { value: 'new', label: 'New' },
+  { value: 'acknowledged', label: 'Acknowledged' },
+  { value: 'acted', label: 'Acted' },
+]
+
+const SOURCE_OPTIONS: Array<{ value: '' | OperatorNotificationSource; label: string }> = [
+  { value: '', label: 'All sources' },
+  { value: 'beta_request', label: 'Beta requests' },
+  { value: 'critical_alert', label: 'Critical failures' },
+]
+
+export default function OperatorInboxPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [notifications, setNotifications] = useState<OperatorNotification[]>([])
+  const [total, setTotal] = useState(0)
+  const [summary, setSummary] = useState<{
+    total: number
+    byStatus: Record<OperatorNotificationStatus, number>
+    bySource: Record<OperatorNotificationSource, number>
+  } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [savingId, setSavingId] = useState<number | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const query = searchParams.get('q') ?? ''
+  const status = (searchParams.get('status') ?? '') as '' | OperatorNotificationStatus
+  const source = (searchParams.get('source') ?? '') as '' | OperatorNotificationSource
+
+  function updateSearchParam(key: string, value: string) {
+    const next = new URLSearchParams(searchParams)
+    if (!value) {
+      next.delete(key)
+    } else {
+      next.set(key, value)
+    }
+    setSearchParams(next, { replace: true })
+  }
+
+  async function load() {
+    try {
+      setLoading(true)
+      const response = await directoryApi.listOperatorNotifications({
+        q: query || undefined,
+        status: status || undefined,
+        source: source || undefined,
+        limit: 200,
+      })
+      setNotifications(response.notifications)
+      setTotal(response.total)
+      setSummary(response.summary)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load operator inbox')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+  }, [query, source, status])
+
+  async function updateSignal(id: number, nextStatus: OperatorNotificationStatus) {
+    try {
+      setSavingId(id)
+      setNotice(null)
+      const response = await directoryApi.updateOperatorNotification(id, { status: nextStatus })
+      setNotifications((current) => current.map((entry) => (
+        entry.id === response.notification.id ? response.notification : entry
+      )))
+      setNotice(`Signal marked ${nextStatus}.`)
+      await load()
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to update operator signal')
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Operator Inbox"
+        description="New hosted beta requests and critical demo or evaluation failures land here until someone acknowledges or acts on them."
+        actions={(
+          <button className="btn-secondary" onClick={() => void load()} type="button">
+            <RefreshCw size={16} />
+            <span>Refresh</span>
+          </button>
+        )}
+      />
+
+      {summary ? (
+        <section className="grid gap-4 md:grid-cols-5">
+          <MetricCard label="Total signals" value={String(summary.total)} hint="All visible operator signals in the current filter." />
+          <MetricCard label="New" value={String(summary.byStatus.new)} hint="Not yet triaged." tone={summary.byStatus.new > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Acknowledged" value={String(summary.byStatus.acknowledged)} hint="Seen and assigned, but not finished." />
+          <MetricCard label="Acted" value={String(summary.byStatus.acted)} hint="A concrete next step has been recorded." tone="success" />
+          <MetricCard label="Critical failures" value={String(summary.bySource.critical_alert)} hint="Signals tied to critical alerts." tone={summary.bySource.critical_alert > 0 ? 'critical' : 'default'} />
+        </section>
+      ) : null}
+
+      <section className="panel">
+        <div className="grid gap-3 lg:grid-cols-[1.8fr,1fr,1fr]">
+          <label className="relative block">
+            <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
+            <input
+              className="input-field pl-10"
+              placeholder="Search title, message, alert id, actor"
+              value={query}
+              onChange={(event) => updateSearchParam('q', event.target.value)}
+            />
+          </label>
+          <select className="input-field" value={status} onChange={(event) => updateSearchParam('status', event.target.value)}>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <select className="input-field" value={source} onChange={(event) => updateSearchParam('source', event.target.value)}>
+            {SOURCE_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </section>
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {notice ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+          {notice}
+        </div>
+      ) : null}
+
+      <section className="panel overflow-hidden p-0">
+        <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+          <div className="panel-title">Signals</div>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{total} signal(s) match the current filters.</p>
+        </div>
+
+        {loading ? (
+          <div className="p-5 text-sm text-slate-500 dark:text-slate-400">Loading operator signals…</div>
+        ) : notifications.length === 0 ? (
+          <div className="p-5">
+            <EmptyPanel label="No operator signals matched the current filters." />
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-200 dark:divide-slate-800">
+            {notifications.map((notification) => (
+              <div key={notification.id} className="space-y-4 px-5 py-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusPill label={notification.status} tone={notificationTone(notification.status)} />
+                  <StatusPill label={notification.sourceType === 'beta_request' ? 'beta request' : 'critical failure'} tone={notification.sourceType === 'critical_alert' ? 'critical' : 'warning'} />
+                  <StatusPill label={notification.severity} tone={severityTone(notification.severity)} />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(notification.createdAt)}</span>
+                </div>
+
+                <div>
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{notification.title}</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{notification.message}</div>
+                </div>
+
+                <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2 lg:grid-cols-4">
+                  <span>Updated {formatRelativeTime(notification.updatedAt)}</span>
+                  <span>Acknowledged: {formatDateTime(notification.acknowledgedAt)}</span>
+                  <span>Acted: {formatDateTime(notification.actedAt)}</span>
+                  <span>Actor: {notification.actor ?? '—'}</span>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  {notification.status !== 'acknowledged' ? (
+                    <button
+                      className="btn-secondary"
+                      disabled={savingId === notification.id}
+                      onClick={() => void updateSignal(notification.id, 'acknowledged')}
+                      type="button"
+                    >
+                      <BellDot size={16} />
+                      <span>{savingId === notification.id ? 'Saving…' : 'Acknowledge'}</span>
+                    </button>
+                  ) : null}
+                  {notification.status !== 'acted' ? (
+                    <button
+                      className="btn-secondary"
+                      disabled={savingId === notification.id}
+                      onClick={() => void updateSignal(notification.id, 'acted')}
+                      type="button"
+                    >
+                      <BellDot size={16} />
+                      <span>{savingId === notification.id ? 'Saving…' : 'Mark acted'}</span>
+                    </button>
+                  ) : null}
+                  {notification.status !== 'new' ? (
+                    <button
+                      className="btn-secondary"
+                      disabled={savingId === notification.id}
+                      onClick={() => void updateSignal(notification.id, 'new')}
+                      type="button"
+                    >
+                      <BellDot size={16} />
+                      <span>{savingId === notification.id ? 'Saving…' : 'Reset to new'}</span>
+                    </button>
+                  ) : null}
+                  {notification.href ? (
+                    <Link className="btn-secondary" to={notification.href}>
+                      Open context
+                    </Link>
+                  ) : notification.betaRequestId ? (
+                    <Link className="btn-secondary" to={`/beta-requests?id=${notification.betaRequestId}`}>
+                      Open beta request
+                    </Link>
+                  ) : (
+                    <Link className="btn-secondary" to="/alerts">
+                      Open alerts
+                    </Link>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+function notificationTone(status: OperatorNotificationStatus | 'new'): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'acted':
+      return 'success'
+    case 'acknowledged':
+      return 'default'
+    case 'new':
+    default:
+      return 'warning'
+  }
+}
+
+function severityTone(severity: 'info' | 'warning' | 'critical'): 'default' | 'success' | 'warning' | 'critical' {
+  switch (severity) {
+    case 'critical':
+      return 'critical'
+    case 'warning':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -251,10 +251,12 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.ok(waitlistColumns.some((column) => column.name === 'status'))
     assert.ok(waitlistColumns.some((column) => column.name === 'owner'))
     assert.ok(waitlistColumns.some((column) => column.name === 'operator_notes'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'next_action'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'last_contact_at'))
     assert.ok(waitlistColumns.some((column) => column.name === 'updated_at'))
 
     const waitlistRow = db.prepare(`
-      SELECT email, status, owner, operator_notes, updated_at, created_at
+      SELECT email, status, owner, operator_notes, next_action, last_contact_at, updated_at, created_at
       FROM waitlist
       LIMIT 1
     `).get() as {
@@ -262,6 +264,8 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
       status: string
       owner: string | null
       operator_notes: string | null
+      next_action: string | null
+      last_contact_at: string | null
       updated_at: string
       created_at: string
     } | undefined
@@ -271,11 +275,23 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.equal(waitlistRow?.status, 'new')
     assert.equal(waitlistRow?.owner ?? null, null)
     assert.equal(waitlistRow?.operator_notes ?? null, null)
+    assert.equal(waitlistRow?.next_action ?? null, null)
+    assert.equal(waitlistRow?.last_contact_at ?? null, null)
     assert.equal(waitlistRow?.updated_at, waitlistRow?.created_at)
 
     const indexes = db.prepare("PRAGMA index_list('waitlist')").all() as Array<{ name: string }>
     assert.ok(indexes.some((index) => index.name === 'idx_waitlist_status'))
     assert.ok(indexes.some((index) => index.name === 'idx_waitlist_owner'))
+    assert.ok(indexes.some((index) => index.name === 'idx_waitlist_last_contact'))
+
+    const notificationColumns = db.prepare('PRAGMA table_info(operator_notifications)').all() as Array<{ name: string }>
+    assert.ok(notificationColumns.some((column) => column.name === 'source_type'))
+    assert.ok(notificationColumns.some((column) => column.name === 'source_key'))
+    assert.ok(notificationColumns.some((column) => column.name === 'status'))
+
+    const notificationIndexes = db.prepare("PRAGMA index_list('operator_notifications')").all() as Array<{ name: string }>
+    assert.ok(notificationIndexes.some((index) => index.name === 'idx_operator_notifications_status'))
+    assert.ok(notificationIndexes.some((index) => index.name === 'idx_operator_notifications_source'))
   } finally {
     db.close()
     rmSync(root, { force: true, recursive: true })

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -16,6 +16,7 @@ import type {
   IntentFrame,
   IntentLogRow,
   IntentTraceEventRow,
+  OperatorNotificationRow,
   OrgAgentRow,
   OrgRow,
   ReportRow,
@@ -162,12 +163,42 @@ function initSchema(db: DB): void {
       status TEXT NOT NULL DEFAULT 'new',
       owner TEXT,
       operator_notes TEXT,
+      next_action TEXT,
+      last_contact_at TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
 
     CREATE INDEX IF NOT EXISTS idx_waitlist_created_at
       ON waitlist(created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS operator_notifications (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source_type TEXT NOT NULL CHECK(source_type IN ('beta_request', 'critical_alert')),
+      source_key TEXT NOT NULL UNIQUE,
+      beta_request_id INTEGER,
+      alert_id TEXT,
+      severity TEXT NOT NULL CHECK(severity IN ('info', 'warning', 'critical')),
+      title TEXT NOT NULL,
+      message TEXT NOT NULL,
+      href TEXT,
+      status TEXT NOT NULL DEFAULT 'new' CHECK(status IN ('new', 'acknowledged', 'acted')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      acknowledged_at TEXT,
+      acted_at TEXT,
+      actor TEXT,
+      details_json TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_operator_notifications_status
+      ON operator_notifications(status, updated_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_operator_notifications_source
+      ON operator_notifications(source_type, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_operator_notifications_beta_request
+      ON operator_notifications(beta_request_id, created_at DESC);
 
     CREATE TABLE IF NOT EXISTS intent_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -471,14 +502,28 @@ function initSchema(db: DB): void {
   ensureColumn(db, 'waitlist', 'status', "TEXT NOT NULL DEFAULT 'new'")
   ensureColumn(db, 'waitlist', 'owner', 'TEXT')
   ensureColumn(db, 'waitlist', 'operator_notes', 'TEXT')
+  ensureColumn(db, 'waitlist', 'next_action', 'TEXT')
+  ensureColumn(db, 'waitlist', 'last_contact_at', 'TEXT')
   ensureColumn(db, 'waitlist', 'updated_at', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_status ON waitlist(status, created_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_owner ON waitlist(owner, created_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_last_contact ON waitlist(last_contact_at, updated_at DESC)')
   db.prepare(`
     UPDATE waitlist
     SET status = COALESCE(NULLIF(status, ''), 'new'),
         updated_at = COALESCE(NULLIF(updated_at, ''), created_at)
   `).run()
+  db.prepare(`
+    UPDATE waitlist
+    SET last_contact_at = CASE
+      WHEN COALESCE(NULLIF(last_contact_at, ''), '') = '' AND status IN ('contacted', 'scheduled', 'active')
+        THEN updated_at
+      ELSE last_contact_at
+    END
+  `).run()
+  db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_status ON operator_notifications(status, updated_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_source ON operator_notifications(source_type, created_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_beta_request ON operator_notifications(beta_request_id, created_at DESC)')
   ensureIntentLogSchema(db)
   ensureColumn(db, 'intent_trace_events', 'nonce', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_intent_trace_nonce ON intent_trace_events(nonce, timestamp ASC, id ASC)')
@@ -2126,6 +2171,258 @@ export function listAuditLog(
     ORDER BY timestamp DESC, id DESC
     LIMIT ${limit}
   `).all(...params) as AuditLogRow[]
+}
+
+export function getOperatorNotificationById(db: DB, id: number): OperatorNotificationRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM operator_notifications
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as OperatorNotificationRow | undefined
+
+  return row ?? null
+}
+
+export function getOperatorNotificationBySourceKey(db: DB, sourceKey: string): OperatorNotificationRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM operator_notifications
+    WHERE source_key = ?
+    LIMIT 1
+  `).get(sourceKey) as OperatorNotificationRow | undefined
+
+  return row ?? null
+}
+
+export function listOperatorNotificationsBySourceKeys(db: DB, sourceKeys: string[]): OperatorNotificationRow[] {
+  const uniqueKeys = [...new Set(sourceKeys.map((value) => value.trim()).filter(Boolean))]
+  if (uniqueKeys.length === 0) {
+    return []
+  }
+
+  const placeholders = uniqueKeys.map(() => '?').join(', ')
+  return db.prepare(`
+    SELECT *
+    FROM operator_notifications
+    WHERE source_key IN (${placeholders})
+    ORDER BY created_at DESC, id DESC
+  `).all(...uniqueKeys) as OperatorNotificationRow[]
+}
+
+export function listOperatorNotifications(
+  db: DB,
+  query: {
+    limit?: number
+    status?: string
+    sourceType?: string
+    betaRequestId?: number
+    q?: string
+  } = {},
+): OperatorNotificationRow[] {
+  const limit = Math.max(1, Math.min(500, Math.trunc(query.limit ?? 100)))
+  const conditions: string[] = []
+  const params: Array<string | number> = []
+
+  if (query.status) {
+    conditions.push('status = ?')
+    params.push(query.status)
+  }
+
+  if (query.sourceType) {
+    conditions.push('source_type = ?')
+    params.push(query.sourceType)
+  }
+
+  if (query.betaRequestId) {
+    conditions.push('beta_request_id = ?')
+    params.push(query.betaRequestId)
+  }
+
+  if (query.q) {
+    const needle = `%${query.q.trim()}%`
+    conditions.push(`(
+      title LIKE ?
+      OR message LIKE ?
+      OR COALESCE(actor, '') LIKE ?
+      OR COALESCE(alert_id, '') LIKE ?
+      OR COALESCE(source_key, '') LIKE ?
+    )`)
+    params.push(needle, needle, needle, needle, needle)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  return db.prepare(`
+    SELECT *
+    FROM operator_notifications
+    ${where}
+    ORDER BY CASE status
+      WHEN 'new' THEN 0
+      WHEN 'acknowledged' THEN 1
+      WHEN 'acted' THEN 2
+      ELSE 3
+    END ASC,
+    datetime(updated_at) DESC,
+    id DESC
+    LIMIT ${limit}
+  `).all(...params) as OperatorNotificationRow[]
+}
+
+export function countOperatorNotifications(
+  db: DB,
+  query: { status?: string; sourceType?: string } = {},
+): number {
+  const conditions: string[] = []
+  const params: string[] = []
+
+  if (query.status) {
+    conditions.push('status = ?')
+    params.push(query.status)
+  }
+
+  if (query.sourceType) {
+    conditions.push('source_type = ?')
+    params.push(query.sourceType)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  return (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM operator_notifications
+    ${where}
+  `).get(...params) as { count: number } | undefined)?.count ?? 0
+}
+
+export function upsertOperatorNotification(
+  db: DB,
+  input: {
+    sourceType: OperatorNotificationRow['source_type']
+    sourceKey: string
+    betaRequestId?: number | null
+    alertId?: string | null
+    severity: OperatorNotificationRow['severity']
+    title: string
+    message: string
+    href?: string | null
+    details?: unknown
+    resetStatus?: boolean
+  },
+): OperatorNotificationRow {
+  const now = nowIso()
+  const existing = getOperatorNotificationBySourceKey(db, input.sourceKey)
+  const details = input.details === undefined ? null : JSON.stringify(input.details)
+
+  if (existing) {
+    const nextStatus = input.resetStatus ? 'new' : existing.status
+    const acknowledgedAt = input.resetStatus ? null : existing.acknowledged_at
+    const actedAt = input.resetStatus ? null : existing.acted_at
+    const actor = input.resetStatus ? null : existing.actor
+
+    db.prepare(`
+      UPDATE operator_notifications
+      SET source_type = ?,
+          beta_request_id = ?,
+          alert_id = ?,
+          severity = ?,
+          title = ?,
+          message = ?,
+          href = ?,
+          status = ?,
+          updated_at = ?,
+          acknowledged_at = ?,
+          acted_at = ?,
+          actor = ?,
+          details_json = ?
+      WHERE id = ?
+    `).run(
+      input.sourceType,
+      input.betaRequestId ?? existing.beta_request_id,
+      input.alertId ?? existing.alert_id,
+      input.severity,
+      input.title,
+      input.message,
+      input.href ?? existing.href,
+      nextStatus,
+      now,
+      acknowledgedAt,
+      actedAt,
+      actor,
+      details,
+      existing.id,
+    )
+
+    return getOperatorNotificationById(db, existing.id) as OperatorNotificationRow
+  }
+
+  const result = db.prepare(`
+    INSERT INTO operator_notifications (
+      source_type,
+      source_key,
+      beta_request_id,
+      alert_id,
+      severity,
+      title,
+      message,
+      href,
+      status,
+      created_at,
+      updated_at,
+      acknowledged_at,
+      acted_at,
+      actor,
+      details_json
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'new', ?, ?, NULL, NULL, NULL, ?)
+  `).run(
+    input.sourceType,
+    input.sourceKey,
+    input.betaRequestId ?? null,
+    input.alertId ?? null,
+    input.severity,
+    input.title,
+    input.message,
+    input.href ?? null,
+    now,
+    now,
+    details,
+  )
+
+  return getOperatorNotificationById(db, Number(result.lastInsertRowid)) as OperatorNotificationRow
+}
+
+export function updateOperatorNotificationStatus(
+  db: DB,
+  input: {
+    id: number
+    status: OperatorNotificationRow['status']
+    actor: string
+  },
+): OperatorNotificationRow | null {
+  const existing = getOperatorNotificationById(db, input.id)
+  if (!existing) {
+    return null
+  }
+
+  const now = nowIso()
+  const acknowledgedAt = input.status === 'new'
+    ? null
+    : input.status === 'acknowledged'
+      ? (existing.acknowledged_at ?? now)
+      : (existing.acknowledged_at ?? now)
+  const actedAt = input.status === 'acted' ? now : null
+  const actor = input.status === 'new' ? null : input.actor
+
+  db.prepare(`
+    UPDATE operator_notifications
+    SET status = ?,
+        updated_at = ?,
+        acknowledged_at = ?,
+        acted_at = ?,
+        actor = ?
+    WHERE id = ?
+  `).run(input.status, now, acknowledgedAt, actedAt, actor, input.id)
+
+  return getOperatorNotificationById(db, input.id)
 }
 
 export function listShieldAuditLog(

--- a/packages/directory/src/observability.test.ts
+++ b/packages/directory/src/observability.test.ts
@@ -191,6 +191,8 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
         thresholdExplanation: string
         links: Array<{ href: string }>
         sampleTraces: Array<{ nonce: string }>
+        notificationId?: number | null
+        notificationStatus?: string | null
       }>
     }
 
@@ -204,12 +206,93 @@ test('alerts endpoint surfaces elevated error rate and error hotspots', async ()
     assert.match(errorRateAlert.thresholdExplanation, /10%/)
     assert.ok(errorRateAlert.links.some((link) => link.href.includes('/intents?')))
     assert.equal(errorRateAlert.sampleTraces[0]?.nonce, 'error-9')
+    assert.ok((errorRateAlert.notificationId ?? 0) > 0)
+    assert.equal(errorRateAlert.notificationStatus, 'new')
 
     assert.ok(hotspotAlert)
     if (!hotspotAlert) {
       throw new Error('Expected error-hotspot-timeout alert to exist')
     }
     assert.ok(hotspotAlert.links.some((link) => link.href.includes('/audit?')))
+    assert.ok((hotspotAlert.notificationId ?? 0) > 0)
+    assert.equal(hotspotAlert.notificationStatus, 'new')
+
+    const inboxResponse = await app.request(new Request('http://localhost/admin/operator-notifications?source=critical_alert&status=new', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(inboxResponse.status, 200)
+
+    const inbox = await inboxResponse.json() as {
+      total: number
+      notifications: Array<{
+        id: number
+        alertId: string | null
+        status: string
+      }>
+      summary: {
+        byStatus: Record<string, number>
+        bySource: Record<string, number>
+      }
+    }
+    assert.equal(inbox.total, 2)
+    assert.equal(inbox.summary.byStatus['new'], 2)
+    assert.equal(inbox.summary.bySource['critical_alert'], 2)
+
+    const errorRateNotification = inbox.notifications.find((entry) => entry.alertId === 'network-error-rate')
+    const hotspotNotification = inbox.notifications.find((entry) => entry.alertId === 'error-hotspot-timeout')
+    assert.ok(errorRateNotification)
+    assert.ok(hotspotNotification)
+
+    const acknowledgeResponse = await app.request(new Request(`http://localhost/admin/operator-notifications/${errorRateNotification?.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'operator@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ status: 'acknowledged' }),
+    }))
+    assert.equal(acknowledgeResponse.status, 200)
+
+    const actedResponse = await app.request(new Request(`http://localhost/admin/operator-notifications/${hotspotNotification?.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'operator@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ status: 'acted' }),
+    }))
+    assert.equal(actedResponse.status, 200)
+
+    const inboxAfterUpdateResponse = await app.request(new Request('http://localhost/admin/operator-notifications?source=critical_alert', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(inboxAfterUpdateResponse.status, 200)
+    const inboxAfterUpdate = await inboxAfterUpdateResponse.json() as {
+      summary: {
+        byStatus: Record<string, number>
+      }
+      notifications: Array<{
+        alertId: string | null
+        status: string
+      }>
+    }
+    assert.equal(inboxAfterUpdate.summary.byStatus['acknowledged'], 1)
+    assert.equal(inboxAfterUpdate.summary.byStatus['acted'], 1)
+    assert.equal(inboxAfterUpdate.notifications.find((entry) => entry.alertId === 'network-error-rate')?.status, 'acknowledged')
+    assert.equal(inboxAfterUpdate.notifications.find((entry) => entry.alertId === 'error-hotspot-timeout')?.status, 'acted')
+
+    const refreshedAlertsResponse = await app.request(new Request('http://localhost/observability/alerts?hours=24', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(refreshedAlertsResponse.status, 200)
+    const refreshedAlerts = await refreshedAlertsResponse.json() as {
+      alerts: Array<{
+        id: string
+        notificationStatus?: string | null
+      }>
+    }
+    assert.equal(refreshedAlerts.alerts.find((alert) => alert.id === 'network-error-rate')?.notificationStatus, 'acknowledged')
+    assert.equal(refreshedAlerts.alerts.find((alert) => alert.id === 'error-hotspot-timeout')?.notificationStatus, 'acted')
   } finally {
     db.close()
   }

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -79,6 +79,12 @@ test('waitlist signups are idempotent by email and preserve the original created
         company: string
         agentCount: number
         requestStatus: string
+        stage: string
+        nextAction: string
+        lastContactAt: string | null
+        attentionFlags: string[]
+        notificationStatus: string
+        notificationId: number
       }
     }
     assert.equal(first.ok, true)
@@ -86,6 +92,12 @@ test('waitlist signups are idempotent by email and preserve the original created
     assert.equal(first.request.company, 'Acme')
     assert.equal(first.request.agentCount, 8)
     assert.equal(first.request.requestStatus, 'new')
+    assert.equal(first.request.stage, 'new')
+    assert.equal(first.request.lastContactAt, null)
+    assert.ok(first.request.nextAction.length > 0)
+    assert.deepEqual(first.request.attentionFlags, ['unowned'])
+    assert.equal(first.request.notificationStatus, 'new')
+    assert.ok(first.request.notificationId > 0)
 
     const secondResponse = await app.request(new Request('http://localhost/waitlist', {
       method: 'POST',
@@ -110,6 +122,8 @@ test('waitlist signups are idempotent by email and preserve the original created
         company: string
         agentCount: number
         source: string
+        stage: string
+        notificationStatus: string
       }
     }
     assert.equal(second.ok, true)
@@ -118,6 +132,8 @@ test('waitlist signups are idempotent by email and preserve the original created
     assert.equal(second.request.agentCount, 14)
     assert.equal(second.request.source, 'hosted-beta-follow-up')
     assert.equal(second.request.createdAt, first.request.createdAt)
+    assert.equal(second.request.stage, 'new')
+    assert.equal(second.request.notificationStatus, 'new')
 
     const row = db.prepare(`
       SELECT COUNT(*) AS count, company, agent_count, source, created_at
@@ -173,6 +189,10 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         workflowType: string
         workflowSummary: string
         requestStatus: string
+        stage: string
+        notificationId: number
+        notificationStatus: string
+        attentionFlags: string[]
       }
       nextStep: string
     }
@@ -181,9 +201,13 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(created.request.workflowType, 'hosted-beta-partner-handoff')
     assert.match(created.request.workflowSummary, /Procurement/)
     assert.equal(created.request.requestStatus, 'new')
+    assert.equal(created.request.stage, 'new')
+    assert.ok(created.request.notificationId > 0)
+    assert.equal(created.request.notificationStatus, 'new')
+    assert.deepEqual(created.request.attentionFlags, ['unowned'])
     assert.match(created.nextStep, /review/i)
 
-    const listResponse = await app.request(new Request('http://localhost/admin/beta-requests?status=new', {
+    const listResponse = await app.request(new Request('http://localhost/admin/beta-requests?status=new&attention=unowned&sort=attention', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
     }))
     assert.equal(listResponse.status, 200)
@@ -195,17 +219,52 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         email: string
         workflowSummary: string
         requestStatus: string
+        attentionFlags: string[]
+        notificationStatus: string
       }>
       summary: {
         total: number
+        unowned: number
+        stale: number
+        needsAttention: number
         byStatus: Record<string, number>
       }
     }
     assert.equal(listed.total, 1)
     assert.equal(listed.summary.total, 1)
+    assert.equal(listed.summary.unowned, 1)
+    assert.equal(listed.summary.stale, 0)
+    assert.equal(listed.summary.needsAttention, 1)
     assert.equal(listed.summary.byStatus['new'], 1)
     assert.equal(listed.requests[0]?.email, 'buyer@example.com')
     assert.match(listed.requests[0]?.workflowSummary ?? '', /finance approves/)
+    assert.deepEqual(listed.requests[0]?.attentionFlags ?? [], ['unowned'])
+    assert.equal(listed.requests[0]?.notificationStatus, 'new')
+
+    const inboxResponse = await app.request(new Request('http://localhost/admin/operator-notifications?source=beta_request&status=new', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(inboxResponse.status, 200)
+
+    const inboxPayload = await inboxResponse.json() as {
+      total: number
+      notifications: Array<{
+        id: number
+        betaRequestId: number | null
+        status: string
+        sourceType: string
+      }>
+      summary: {
+        byStatus: Record<string, number>
+        bySource: Record<string, number>
+      }
+    }
+    assert.equal(inboxPayload.total, 1)
+    assert.equal(inboxPayload.summary.byStatus['new'], 1)
+    assert.equal(inboxPayload.summary.bySource['beta_request'], 1)
+    assert.equal(inboxPayload.notifications[0]?.betaRequestId, created.request.id)
+    assert.equal(inboxPayload.notifications[0]?.status, 'new')
+    assert.equal(inboxPayload.notifications[0]?.sourceType, 'beta_request')
 
     const updateResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
       method: 'PATCH',
@@ -225,14 +284,66 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
       ok: boolean
       request: {
         requestStatus: string
+        stage: string
         owner: string
         operatorNotes: string
+        notificationStatus: string
+        attentionFlags: string[]
       }
     }
     assert.equal(updated.ok, true)
     assert.equal(updated.request.requestStatus, 'reviewing')
+    assert.equal(updated.request.stage, 'reviewing')
     assert.equal(updated.request.owner, 'operator@example.com')
     assert.match(updated.request.operatorNotes, /Intro email/)
+    assert.equal(updated.request.notificationStatus, 'acknowledged')
+    assert.deepEqual(updated.request.attentionFlags, [])
+
+    const contactTimestamp = '2026-03-30T20:15:00.000Z'
+    const contactResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'operator@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'contacted',
+        nextAction: 'Schedule a 30 minute pilot review with procurement and finance.',
+        lastContactAt: contactTimestamp,
+      }),
+    }))
+    assert.equal(contactResponse.status, 200)
+
+    const contacted = await contactResponse.json() as {
+      ok: boolean
+      request: {
+        requestStatus: string
+        nextAction: string
+        lastContactAt: string | null
+        notificationStatus: string
+      }
+    }
+    assert.equal(contacted.ok, true)
+    assert.equal(contacted.request.requestStatus, 'contacted')
+    assert.equal(contacted.request.nextAction, 'Schedule a 30 minute pilot review with procurement and finance.')
+    assert.equal(contacted.request.lastContactAt, contactTimestamp)
+    assert.equal(contacted.request.notificationStatus, 'acted')
+
+    const actedInboxResponse = await app.request(new Request('http://localhost/admin/operator-notifications?source=beta_request&status=acted', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(actedInboxResponse.status, 200)
+
+    const actedInbox = await actedInboxResponse.json() as {
+      total: number
+      notifications: Array<{
+        betaRequestId: number | null
+        status: string
+      }>
+    }
+    assert.equal(actedInbox.total, 1)
+    assert.equal(actedInbox.notifications[0]?.betaRequestId, created.request.id)
+    assert.equal(actedInbox.notifications[0]?.status, 'acted')
 
     const exportResponse = await app.request(new Request('http://localhost/admin/beta-requests/export?format=csv', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
@@ -241,8 +352,14 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(exportResponse.headers.get('content-type'), 'text/csv; charset=utf-8')
     const csv = await exportResponse.text()
     assert.match(csv, /workflow_summary/)
+    assert.match(csv, /next_action/)
+    assert.match(csv, /last_contact_at/)
+    assert.match(csv, /notification_status/)
+    assert.match(csv, /attention_flags/)
     assert.match(csv, /Northwind Systems/)
     assert.match(csv, /operator@example.com/)
+    assert.match(csv, /Schedule a 30 minute pilot review/)
+    assert.match(csv, /acted/)
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -1,7 +1,15 @@
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
 import { requireAdminRole } from '../admin-auth.js'
-import { getAgent, listAuditLog, listIntentTraceEvents, listShieldAuditLog, logAuditEvent } from '../db.js'
+import {
+  getAgent,
+  listAuditLog,
+  listIntentTraceEvents,
+  listOperatorNotificationsBySourceKeys,
+  listShieldAuditLog,
+  logAuditEvent,
+  upsertOperatorNotification,
+} from '../db.js'
 import {
   classifyIntentLifecycle,
   isIntentLifecycleFailure,
@@ -15,6 +23,7 @@ import type {
   FederationPeerRow,
   IntentLogRow,
   IntentTraceEventRow,
+  OperatorNotificationStatus,
   ShieldAuditLogRow,
 } from '../types.js'
 
@@ -45,7 +54,7 @@ type AlertTraceSample = {
   errorCode: string | null
 }
 
-type AlertItem = {
+export type AlertItem = {
   id: string
   severity: AlertSeverity
   title: string
@@ -60,6 +69,8 @@ type AlertItem = {
   severityReason: string
   links: AlertLink[]
   sampleTraces: AlertTraceSample[]
+  notificationId?: number | null
+  notificationStatus?: OperatorNotificationStatus | null
 }
 
 type IntentQuery = {
@@ -997,7 +1008,7 @@ function buildAlertLinks(
   ]
 }
 
-function buildAlerts(db: Database, windowHours: number): AlertItem[] {
+export function buildAlerts(db: Database, windowHours: number): AlertItem[] {
   const overview = buildOverviewPayload(db, windowHours)
   const errors = buildErrorsPayload(db, windowHours)
   const federation = buildFederationPayload(db)
@@ -1324,6 +1335,51 @@ function buildAlerts(db: Database, windowHours: number): AlertItem[] {
   })
 }
 
+function criticalAlertNotificationSourceKey(alertId: string): string {
+  return `critical-alert:${alertId}`
+}
+
+export function buildAlertsWithNotificationState(db: Database, windowHours: number): AlertItem[] {
+  const alerts = buildAlerts(db, windowHours)
+  const criticalAlerts = alerts.filter((alert) => alert.severity === 'critical')
+
+  for (const alert of criticalAlerts) {
+    upsertOperatorNotification(db, {
+      sourceType: 'critical_alert',
+      sourceKey: criticalAlertNotificationSourceKey(alert.id),
+      alertId: alert.id,
+      severity: alert.severity,
+      title: alert.title,
+      message: alert.message,
+      href: alert.links[0]?.href ?? '/alerts',
+      details: {
+        scope: alert.scope,
+        metric: alert.metric,
+        startedAt: alert.startedAt,
+        sampleTraces: alert.sampleTraces.map((sample) => sample.nonce),
+      },
+    })
+  }
+
+  const notifications = new Map(
+    listOperatorNotificationsBySourceKeys(
+      db,
+      criticalAlerts.map((alert) => criticalAlertNotificationSourceKey(alert.id)),
+    ).map((entry) => [entry.source_key, entry]),
+  )
+
+  return alerts.map((alert) => {
+    const notification = notifications.get(criticalAlertNotificationSourceKey(alert.id))
+    return notification
+      ? {
+        ...alert,
+        notificationId: notification.id,
+        notificationStatus: notification.status,
+      }
+      : alert
+  })
+}
+
 function createSyntheticTrace(intent: IntentLogRow): Array<ReturnType<typeof serializeTraceEvent>> {
   const lifecycleStatus = normalizeIntentLifecycleStatus(intent.status) ?? 'received'
   const stages: Array<ReturnType<typeof serializeTraceEvent>> = [
@@ -1457,7 +1513,7 @@ export function observabilityRouter(db: Database): Hono {
 
     const windowHours = parseHours(c.req.query('hours'), 24)
     const overview = buildOverviewPayload(db, windowHours)
-    const alerts = buildAlerts(db, windowHours)
+    const alerts = buildAlertsWithNotificationState(db, windowHours)
     return c.json({
       ...overview,
       alerts: alerts.slice(0, 5),
@@ -1580,7 +1636,7 @@ export function observabilityRouter(db: Database): Hono {
     return c.json({
       windowHours,
       generatedAt: new Date().toISOString(),
-      alerts: buildAlerts(db, windowHours),
+      alerts: buildAlertsWithNotificationState(db, windowHours),
       retention: {
         defaultDays: DEFAULT_RETENTION_DAYS,
         minimumDays: 1,

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -18,7 +18,7 @@ import { didRouter } from './routes/did.js'
 import { federationRouter } from './routes/federation.js'
 import { agentKeysRouter, revokedKeysRouter } from './routes/keys.js'
 import { orgsRouter } from './routes/orgs.js'
-import { observabilityRouter } from './routes/observability.js'
+import { buildAlertsWithNotificationState, observabilityRouter } from './routes/observability.js'
 import { reportsRouter } from './routes/reports.js'
 import { shieldRouter } from './routes/shield.js'
 import { verificationRouter } from './routes/verify.js'
@@ -35,11 +35,28 @@ import {
 } from './websocket.js'
 import { createAcl, deleteAcl, listAclsForBeam, seedAclsFromCatalog } from './acl.js'
 import { getAdminSessionFromRequest, requireAdminRole } from './admin-auth.js'
-import { assignDirectoryRole, deleteDirectoryRole, getAgent, getDIDDocument, listAgentKeys, listAuditLog, listDirectoryRoles, listRecentIntentLogs, listTrustScores, logAuditEvent, upsertDIDDocument } from './db.js'
+import {
+  assignDirectoryRole,
+  deleteDirectoryRole,
+  getAgent,
+  getDIDDocument,
+  getOperatorNotificationBySourceKey,
+  listAgentKeys,
+  listAuditLog,
+  listDirectoryRoles,
+  listOperatorNotifications,
+  listOperatorNotificationsBySourceKeys,
+  listRecentIntentLogs,
+  listTrustScores,
+  logAuditEvent,
+  updateOperatorNotificationStatus,
+  upsertDIDDocument,
+  upsertOperatorNotification,
+} from './db.js'
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import { getReleaseInfo } from './release.js'
-import type { AgentRow, IntentFrame } from './types.js'
+import type { AgentRow, IntentFrame, OperatorNotificationRow } from './types.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
@@ -55,11 +72,17 @@ type WaitlistSignupInput = {
 }
 
 type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
+type BetaRequestAttention = 'unowned' | 'stale'
+type BetaRequestSort = 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
+type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
+type OperatorNotificationSource = 'beta_request' | 'critical_alert'
 
 type BetaRequestUpdateInput = {
   status?: BetaRequestStatus
   owner?: string | null
   operatorNotes?: string | null
+  nextAction?: string | null
+  lastContactAt?: string | null
 }
 
 type BetaRequestFilters = {
@@ -68,7 +91,17 @@ type BetaRequestFilters = {
   owner?: string
   source?: string
   workflowType?: string
+  attention?: string
+  sort?: string
   limit?: number
+}
+
+type OperatorNotificationFilters = {
+  q?: string
+  status?: string
+  source?: string
+  limit?: number
+  hours?: number
 }
 
 type WaitlistRow = {
@@ -82,15 +115,54 @@ type WaitlistRow = {
   status: string
   owner: string | null
   operator_notes: string | null
+  next_action: string | null
+  last_contact_at: string | null
   created_at: string
   updated_at: string
 }
 
 const BETA_REQUEST_STATUSES: BetaRequestStatus[] = ['new', 'reviewing', 'contacted', 'scheduled', 'active', 'closed']
 const BETA_REQUEST_STATUS_SET = new Set<string>(BETA_REQUEST_STATUSES)
+const BETA_REQUEST_SORTS: BetaRequestSort[] = ['attention', 'updated_desc', 'created_desc', 'stage', 'owner', 'last_contact_desc']
+const BETA_REQUEST_SORT_SET = new Set<string>(BETA_REQUEST_SORTS)
+const BETA_REQUEST_ATTENTION_SET = new Set<BetaRequestAttention>(['unowned', 'stale'])
+const OPERATOR_NOTIFICATION_STATUSES: OperatorNotificationStatus[] = ['new', 'acknowledged', 'acted']
+const OPERATOR_NOTIFICATION_STATUS_SET = new Set<string>(OPERATOR_NOTIFICATION_STATUSES)
+const OPERATOR_NOTIFICATION_SOURCES: OperatorNotificationSource[] = ['beta_request', 'critical_alert']
+const OPERATOR_NOTIFICATION_SOURCE_SET = new Set<string>(OPERATOR_NOTIFICATION_SOURCES)
+const BETA_REQUEST_STALE_HOURS: Record<BetaRequestStatus, number | null> = {
+  new: 24,
+  reviewing: 24,
+  contacted: 72,
+  scheduled: 120,
+  active: 96,
+  closed: null,
+}
 
 function normalizeOptionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeOptionalIsoDateTime(value: unknown): string | null {
+  if (value == null || value === '') {
+    return null
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+  if (!normalized) {
+    return null
+  }
+
+  const date = new Date(normalized)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  return date.toISOString()
 }
 
 function normalizeBetaRequestStatus(value: unknown): BetaRequestStatus | null {
@@ -106,7 +178,137 @@ function normalizeBetaRequestStatus(value: unknown): BetaRequestStatus | null {
   return normalized as BetaRequestStatus
 }
 
-function serializeBetaRequest(row: WaitlistRow) {
+function normalizeBetaRequestAttention(value: unknown): BetaRequestAttention | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!BETA_REQUEST_ATTENTION_SET.has(normalized as BetaRequestAttention)) {
+    return null
+  }
+
+  return normalized as BetaRequestAttention
+}
+
+function normalizeBetaRequestSort(value: unknown): BetaRequestSort {
+  if (typeof value !== 'string') {
+    return 'attention'
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!BETA_REQUEST_SORT_SET.has(normalized)) {
+    return 'attention'
+  }
+
+  return normalized as BetaRequestSort
+}
+
+function normalizeOperatorNotificationStatus(value: unknown): OperatorNotificationStatus | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!OPERATOR_NOTIFICATION_STATUS_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as OperatorNotificationStatus
+}
+
+function normalizeOperatorNotificationSource(value: unknown): OperatorNotificationSource | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!OPERATOR_NOTIFICATION_SOURCE_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as OperatorNotificationSource
+}
+
+function betaRequestNotificationSourceKey(id: number): string {
+  return `beta-request:${id}`
+}
+
+function getBetaRequestContactTimestamp(row: WaitlistRow): string {
+  return row.last_contact_at ?? row.updated_at ?? row.created_at
+}
+
+function getBetaRequestAttention(row: WaitlistRow) {
+  const stage = normalizeBetaRequestStatus(row.status) ?? 'new'
+  const attentionFlags: BetaRequestAttention[] = []
+
+  if (stage !== 'closed' && !row.owner) {
+    attentionFlags.push('unowned')
+  }
+
+  let stale = false
+  let staleReason: string | null = null
+  const thresholdHours = BETA_REQUEST_STALE_HOURS[stage]
+  const contactTimestamp = getBetaRequestContactTimestamp(row)
+
+  if (thresholdHours != null) {
+    const contactTime = new Date(contactTimestamp).getTime()
+    if (!Number.isNaN(contactTime)) {
+      const ageHours = (Date.now() - contactTime) / (1000 * 60 * 60)
+      if (ageHours >= thresholdHours) {
+        stale = true
+        staleReason = row.last_contact_at
+          ? `No operator contact has been recorded for ${thresholdHours}+ hours in the ${stage} stage.`
+          : `This request has sat in the ${stage} stage for ${thresholdHours}+ hours without a recorded operator contact.`
+        attentionFlags.push('stale')
+      }
+    }
+  }
+
+  return {
+    stage,
+    stale,
+    staleReason,
+    attentionFlags,
+  }
+}
+
+function serializeOperatorNotification(row: OperatorNotificationRow) {
+  let details: unknown = null
+  if (row.details_json) {
+    try {
+      details = JSON.parse(row.details_json)
+    } catch {
+      details = null
+    }
+  }
+
+  return {
+    id: row.id,
+    sourceType: row.source_type,
+    sourceKey: row.source_key,
+    betaRequestId: row.beta_request_id,
+    alertId: row.alert_id,
+    severity: row.severity,
+    title: row.title,
+    message: row.message,
+    href: row.href,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    acknowledgedAt: row.acknowledged_at,
+    actedAt: row.acted_at,
+    actor: row.actor,
+    details,
+  }
+}
+
+function serializeBetaRequest(
+  row: WaitlistRow,
+  notification?: OperatorNotificationRow | null,
+) {
+  const attention = getBetaRequestAttention(row)
+  const nextAction = row.next_action ?? getBetaRequestNextStep(row.status)
   return {
     id: row.id,
     email: row.email,
@@ -115,9 +317,17 @@ function serializeBetaRequest(row: WaitlistRow) {
     agentCount: row.agent_count,
     workflowType: row.workflow_type,
     workflowSummary: row.workflow_summary,
-    requestStatus: normalizeBetaRequestStatus(row.status) ?? 'new',
+    requestStatus: attention.stage,
+    stage: attention.stage,
     owner: row.owner,
     operatorNotes: row.operator_notes,
+    nextAction,
+    lastContactAt: row.last_contact_at,
+    stale: attention.stale,
+    staleReason: attention.staleReason,
+    attentionFlags: attention.attentionFlags,
+    notificationId: notification?.id ?? null,
+    notificationStatus: notification?.status ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
@@ -259,8 +469,12 @@ function getBetaRequestWhereClause(filters: {
   }
 
   if (filters.owner) {
-    conditions.push('COALESCE(owner, \'\') LIKE ?')
-    params.push(`%${filters.owner.trim()}%`)
+    if (filters.owner.trim().toLowerCase() === 'unassigned') {
+      conditions.push(`COALESCE(owner, '') = ''`)
+    } else {
+      conditions.push('COALESCE(owner, \'\') LIKE ?')
+      params.push(`%${filters.owner.trim()}%`)
+    }
   }
 
   if (filters.source) {
@@ -285,25 +499,12 @@ function listBetaRequestRows(db: Database, filters: {
   owner?: string
   source?: string
   workflowType?: string
+  attention?: string
+  sort?: string
   limit?: number
-} = {}): { rows: WaitlistRow[]; total: number } {
+} = {}): { rows: WaitlistRow[]; total: number; allRows: WaitlistRow[] } {
   const limit = Math.min(Math.max(Number(filters.limit ?? 200) || 200, 1), 5000)
   const { whereSql, params } = getBetaRequestWhereClause(filters)
-  const orderBy = `
-    ORDER BY CASE status
-      WHEN 'new' THEN 0
-      WHEN 'reviewing' THEN 1
-      WHEN 'contacted' THEN 2
-      WHEN 'scheduled' THEN 3
-      WHEN 'active' THEN 4
-      WHEN 'closed' THEN 5
-      ELSE 6
-    END ASC,
-    datetime(updated_at) DESC,
-    datetime(created_at) DESC,
-    id DESC
-  `
-
   const rows = db.prepare(`
     SELECT
       id,
@@ -316,21 +517,26 @@ function listBetaRequestRows(db: Database, filters: {
       status,
       owner,
       operator_notes,
+      next_action,
+      last_contact_at,
       created_at,
       updated_at
     FROM waitlist
     ${whereSql}
-    ${orderBy}
-    LIMIT ?
-  `).all(...params, limit) as WaitlistRow[]
+  `).all(...params) as WaitlistRow[]
 
-  const total = (db.prepare(`
-    SELECT COUNT(*) AS count
-    FROM waitlist
-    ${whereSql}
-  `).get(...params) as { count: number } | undefined)?.count ?? rows.length
+  const attentionFilter = normalizeBetaRequestAttention(filters.attention)
+  const filteredRows = attentionFilter
+    ? rows.filter((row) => getBetaRequestAttention(row).attentionFlags.includes(attentionFilter))
+    : rows
 
-  return { rows, total }
+  const sort = normalizeBetaRequestSort(filters.sort)
+  const sortedRows = [...filteredRows].sort((left, right) => compareBetaRequestRows(left, right, sort))
+  return {
+    rows: sortedRows.slice(0, limit),
+    total: sortedRows.length,
+    allRows: sortedRows,
+  }
 }
 
 function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
@@ -346,6 +552,8 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
       status,
       owner,
       operator_notes,
+      next_action,
+      last_contact_at,
       created_at,
       updated_at
     FROM waitlist
@@ -356,18 +564,70 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
   return row ?? null
 }
 
+function compareStageOrder(left: BetaRequestStatus, right: BetaRequestStatus): number {
+  return BETA_REQUEST_STATUSES.indexOf(left) - BETA_REQUEST_STATUSES.indexOf(right)
+}
+
+function compareBetaRequestRows(left: WaitlistRow, right: WaitlistRow, sort: BetaRequestSort): number {
+  const leftAttention = getBetaRequestAttention(left)
+  const rightAttention = getBetaRequestAttention(right)
+  const leftStage = leftAttention.stage
+  const rightStage = rightAttention.stage
+  const leftUpdated = Date.parse(left.updated_at) || 0
+  const rightUpdated = Date.parse(right.updated_at) || 0
+  const leftCreated = Date.parse(left.created_at) || 0
+  const rightCreated = Date.parse(right.created_at) || 0
+  const leftContact = Date.parse(getBetaRequestContactTimestamp(left)) || 0
+  const rightContact = Date.parse(getBetaRequestContactTimestamp(right)) || 0
+
+  switch (sort) {
+    case 'owner': {
+      const leftOwner = left.owner?.toLowerCase() ?? ''
+      const rightOwner = right.owner?.toLowerCase() ?? ''
+      if (!leftOwner && rightOwner) return -1
+      if (leftOwner && !rightOwner) return 1
+      return leftOwner.localeCompare(rightOwner) || rightUpdated - leftUpdated
+    }
+    case 'stage':
+      return compareStageOrder(leftStage, rightStage) || rightUpdated - leftUpdated
+    case 'created_desc':
+      return rightCreated - leftCreated
+    case 'last_contact_desc':
+      return rightContact - leftContact
+    case 'updated_desc':
+      return rightUpdated - leftUpdated
+    case 'attention':
+    default: {
+      const leftAttentionScore = Number(leftAttention.attentionFlags.includes('unowned')) * 2 + Number(leftAttention.attentionFlags.includes('stale'))
+      const rightAttentionScore = Number(rightAttention.attentionFlags.includes('unowned')) * 2 + Number(rightAttention.attentionFlags.includes('stale'))
+      return rightAttentionScore - leftAttentionScore
+        || compareStageOrder(leftStage, rightStage)
+        || rightUpdated - leftUpdated
+        || rightCreated - leftCreated
+    }
+  }
+}
+
 function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
   const byStatus = Object.fromEntries(BETA_REQUEST_STATUSES.map((status) => [status, 0])) as Record<BetaRequestStatus, number>
   let unowned = 0
   let active = 0
+  let stale = 0
+  let needsAttention = 0
 
   for (const row of rows) {
-    const status = normalizeBetaRequestStatus(row.status) ?? 'new'
-    byStatus[status] += 1
-    if (!row.owner) {
+    const attention = getBetaRequestAttention(row)
+    byStatus[attention.stage] += 1
+    if (attention.attentionFlags.includes('unowned')) {
       unowned += 1
     }
-    if (status !== 'closed') {
+    if (attention.attentionFlags.includes('stale')) {
+      stale += 1
+    }
+    if (attention.attentionFlags.length > 0) {
+      needsAttention += 1
+    }
+    if (attention.stage !== 'closed') {
       active += 1
     }
   }
@@ -376,11 +636,16 @@ function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
     total,
     active,
     unowned,
+    stale,
+    needsAttention,
     byStatus,
   }
 }
 
-function buildBetaRequestCsv(rows: WaitlistRow[]): string {
+function buildBetaRequestCsv(
+  rows: WaitlistRow[],
+  notificationsBySourceKey = new Map<string, OperatorNotificationRow>(),
+): string {
   const headers = [
     'id',
     'email',
@@ -392,12 +657,19 @@ function buildBetaRequestCsv(rows: WaitlistRow[]): string {
     'status',
     'owner',
     'operator_notes',
+    'next_action',
+    'last_contact_at',
+    'notification_status',
+    'stale',
+    'attention_flags',
     'created_at',
     'updated_at',
   ]
 
   const lines = [headers.join(',')]
   for (const row of rows) {
+    const attention = getBetaRequestAttention(row)
+    const notification = notificationsBySourceKey.get(betaRequestNotificationSourceKey(row.id))
     lines.push([
       row.id,
       row.email,
@@ -409,12 +681,117 @@ function buildBetaRequestCsv(rows: WaitlistRow[]): string {
       row.status,
       row.owner,
       row.operator_notes,
+      row.next_action ?? getBetaRequestNextStep(row.status),
+      row.last_contact_at,
+      notification?.status ?? null,
+      attention.stale ? 'true' : 'false',
+      attention.attentionFlags.join('|'),
       row.created_at,
       row.updated_at,
     ].map((value) => escapeCsvValue(value as string | number | null | undefined)).join(','))
   }
 
   return `${lines.join('\n')}\n`
+}
+
+function getBetaRequestNotifications(
+  db: Database,
+  rows: WaitlistRow[],
+): Map<string, OperatorNotificationRow> {
+  const notifications = listOperatorNotificationsBySourceKeys(
+    db,
+    rows.map((row) => betaRequestNotificationSourceKey(row.id)),
+  )
+
+  return new Map(notifications.map((entry) => [entry.source_key, entry]))
+}
+
+function getBetaRequestNotificationStatus(row: WaitlistRow): OperatorNotificationStatus | null {
+  const stage = normalizeBetaRequestStatus(row.status) ?? 'new'
+  if (stage === 'new') {
+    return 'new'
+  }
+
+  if (row.last_contact_at || row.next_action || stage === 'contacted' || stage === 'scheduled' || stage === 'active' || stage === 'closed') {
+    return 'acted'
+  }
+
+  if (row.owner || stage === 'reviewing') {
+    return 'acknowledged'
+  }
+
+  return 'new'
+}
+
+function ensureBetaRequestNotification(
+  db: Database,
+  row: WaitlistRow,
+  resetStatus = false,
+): OperatorNotificationRow {
+  const companyLabel = row.company ?? row.email
+  const workflowLabel = row.workflow_type
+    ? row.workflow_type.replace(/^hosted-beta-/, '').replaceAll('-', ' ')
+    : 'workflow review'
+  const messageParts = [
+    workflowLabel,
+    row.agent_count != null ? `${row.agent_count} agent${row.agent_count === 1 ? '' : 's'}` : null,
+    row.workflow_summary ?? null,
+  ].filter((part): part is string => Boolean(part))
+
+  return upsertOperatorNotification(db, {
+    sourceType: 'beta_request',
+    sourceKey: betaRequestNotificationSourceKey(row.id),
+    betaRequestId: row.id,
+    severity: 'warning',
+    title: `Hosted beta request from ${companyLabel}`,
+    message: messageParts.join(' · '),
+    href: `/beta-requests?id=${row.id}`,
+    resetStatus,
+    details: {
+      email: row.email,
+      company: row.company,
+      workflowType: row.workflow_type,
+      stage: normalizeBetaRequestStatus(row.status) ?? 'new',
+      nextAction: row.next_action ?? getBetaRequestNextStep(row.status),
+    },
+  })
+}
+
+function syncBetaRequestNotificationStatus(
+  db: Database,
+  row: WaitlistRow,
+  actor: string,
+): OperatorNotificationRow | null {
+  const existing = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(row.id))
+  if (!existing) {
+    return null
+  }
+
+  const targetStatus = getBetaRequestNotificationStatus(row)
+  if (!targetStatus || existing.status === targetStatus) {
+    return existing
+  }
+
+  return updateOperatorNotificationStatus(db, {
+    id: existing.id,
+    status: targetStatus,
+    actor,
+  })
+}
+
+function summarizeOperatorNotifications(rows: OperatorNotificationRow[]) {
+  return {
+    total: rows.length,
+    byStatus: {
+      new: rows.filter((row) => row.status === 'new').length,
+      acknowledged: rows.filter((row) => row.status === 'acknowledged').length,
+      acted: rows.filter((row) => row.status === 'acted').length,
+    },
+    bySource: {
+      beta_request: rows.filter((row) => row.source_type === 'beta_request').length,
+      critical_alert: rows.filter((row) => row.source_type === 'critical_alert').length,
+    },
+  }
 }
 
 function getWaitlistEntries(db: Database): { available: boolean; waitlist: Array<{ email: string; company: string | null; signupDate: string | null; status: string | null; owner: string | null }>; total: number } {
@@ -1006,15 +1383,18 @@ export function createApp(db: Database): Hono {
         owner: c.req.query('owner') ?? undefined,
         source: c.req.query('source') ?? undefined,
         workflowType: c.req.query('workflowType') ?? undefined,
+        attention: c.req.query('attention') ?? undefined,
+        sort: c.req.query('sort') ?? undefined,
         limit: c.req.query('limit') ? Number.parseInt(c.req.query('limit') as string, 10) : undefined,
       }
 
-      const { rows, total } = listBetaRequestRows(db, filters)
+      const { rows, total, allRows } = listBetaRequestRows(db, filters)
+      const notifications = getBetaRequestNotifications(db, rows)
       c.header('Cache-Control', 'no-store')
       return c.json({
-        requests: rows.map((row) => serializeBetaRequest(row)),
+        requests: rows.map((row) => serializeBetaRequest(row, notifications.get(betaRequestNotificationSourceKey(row.id)))),
         total,
-        summary: summarizeBetaRequests(rows, total),
+        summary: summarizeBetaRequests(allRows, total),
       })
     } catch (err) {
       console.error('Admin beta requests error:', err)
@@ -1040,10 +1420,13 @@ export function createApp(db: Database): Hono {
         owner: c.req.query('owner') ?? undefined,
         source: c.req.query('source') ?? undefined,
         workflowType: c.req.query('workflowType') ?? undefined,
+        attention: c.req.query('attention') ?? undefined,
+        sort: c.req.query('sort') ?? undefined,
         limit: c.req.query('limit') ? Number.parseInt(c.req.query('limit') as string, 10) : 5000,
       }
 
-      const { rows, total } = listBetaRequestRows(db, filters)
+      const { rows, total, allRows } = listBetaRequestRows(db, filters)
+      const notifications = getBetaRequestNotifications(db, rows)
       const timestamp = new Date().toISOString().replaceAll(':', '-')
 
       logAuditEvent(db, {
@@ -1062,7 +1445,7 @@ export function createApp(db: Database): Hono {
       if (format === 'csv') {
         c.header('Content-Type', 'text/csv; charset=utf-8')
         c.header('Content-Disposition', `attachment; filename="beam-beta-requests-${timestamp}.csv"`)
-        return c.body(buildBetaRequestCsv(rows))
+        return c.body(buildBetaRequestCsv(rows, notifications))
       }
 
       c.header('Content-Type', 'application/json; charset=utf-8')
@@ -1070,8 +1453,8 @@ export function createApp(db: Database): Hono {
       return c.body(JSON.stringify({
         exportedAt: new Date().toISOString(),
         total,
-        summary: summarizeBetaRequests(rows, total),
-        requests: rows.map((row) => serializeBetaRequest(row)),
+        summary: summarizeBetaRequests(allRows, total),
+        requests: rows.map((row) => serializeBetaRequest(row, notifications.get(betaRequestNotificationSourceKey(row.id)))),
       }, null, 2))
     } catch (err) {
       console.error('Admin beta request export error:', err)
@@ -1095,8 +1478,9 @@ export function createApp(db: Database): Hono {
       if (!row) {
         return c.json({ error: 'Beta request not found', errorCode: 'NOT_FOUND' }, 404)
       }
+      const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(row.id))
       c.header('Cache-Control', 'no-store')
-      return c.json({ request: serializeBetaRequest(row) })
+      return c.json({ request: serializeBetaRequest(row, notification) })
     } catch (err) {
       console.error('Admin beta request detail error:', err)
       return c.json({ error: 'Failed to load beta request', errorCode: 'DB_ERROR' }, 500)
@@ -1144,7 +1528,19 @@ export function createApp(db: Database): Hono {
       patch.operatorNotes = normalizeOptionalString(raw.operatorNotes)
     }
 
-    if (!('status' in patch) && !('owner' in patch) && !('operatorNotes' in patch)) {
+    if ('nextAction' in raw) {
+      patch.nextAction = normalizeOptionalString(raw.nextAction)
+    }
+
+    if ('lastContactAt' in raw) {
+      const lastContactAt = normalizeOptionalIsoDateTime(raw.lastContactAt)
+      if (raw.lastContactAt != null && raw.lastContactAt !== '' && !lastContactAt) {
+        return c.json({ error: 'Invalid lastContactAt timestamp', errorCode: 'INVALID_LAST_CONTACT' }, 400)
+      }
+      patch.lastContactAt = lastContactAt
+    }
+
+    if (!('status' in patch) && !('owner' in patch) && !('operatorNotes' in patch) && !('nextAction' in patch) && !('lastContactAt' in patch)) {
       return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
     }
 
@@ -1157,18 +1553,27 @@ export function createApp(db: Database): Hono {
       const nextStatus = patch.status ?? (normalizeBetaRequestStatus(existing.status) ?? 'new')
       const nextOwner = 'owner' in patch ? patch.owner ?? null : existing.owner
       const nextOperatorNotes = 'operatorNotes' in patch ? patch.operatorNotes ?? null : existing.operator_notes
+      const nextAction = 'nextAction' in patch ? patch.nextAction ?? null : existing.next_action
+      let nextLastContactAt = 'lastContactAt' in patch ? patch.lastContactAt ?? null : existing.last_contact_at
       const updatedAt = new Date().toISOString()
+
+      if (!('lastContactAt' in patch) && ['contacted', 'scheduled', 'active'].includes(nextStatus) && !nextLastContactAt) {
+        nextLastContactAt = updatedAt
+      }
 
       db.prepare(`
         UPDATE waitlist
-        SET status = ?, owner = ?, operator_notes = ?, updated_at = ?
+        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, updated_at = ?
         WHERE id = ?
-      `).run(nextStatus, nextOwner, nextOperatorNotes, updatedAt, id)
+      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, updatedAt, id)
 
       const updated = getBetaRequestById(db, id)
       if (!updated) {
         return c.json({ error: 'Beta request not found after update', errorCode: 'NOT_FOUND' }, 404)
       }
+
+      syncBetaRequestNotificationStatus(db, updated, auth.session.email)
+      const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(updated.id))
 
       logAuditEvent(db, {
         action: 'admin.beta_request.updated',
@@ -1179,18 +1584,110 @@ export function createApp(db: Database): Hono {
           status: nextStatus,
           owner: nextOwner,
           operatorNotesChanged: 'operatorNotes' in patch,
+          nextActionChanged: 'nextAction' in patch,
+          lastContactChanged: 'lastContactAt' in patch,
         },
       })
 
       c.header('Cache-Control', 'no-store')
       return c.json({
         ok: true,
-        request: serializeBetaRequest(updated),
+        request: serializeBetaRequest(updated, notification),
       })
     } catch (err) {
       console.error('Admin beta request update error:', err)
       return c.json({ error: 'Failed to update beta request', errorCode: 'DB_ERROR' }, 500)
     }
+  })
+
+  app.get('/admin/operator-notifications', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    try {
+      const filters: OperatorNotificationFilters = {
+        q: c.req.query('q') ?? undefined,
+        status: normalizeOperatorNotificationStatus(c.req.query('status')) ?? undefined,
+        source: normalizeOperatorNotificationSource(c.req.query('source')) ?? undefined,
+        limit: c.req.query('limit') ? Number.parseInt(c.req.query('limit') as string, 10) : undefined,
+        hours: c.req.query('hours') ? Number.parseInt(c.req.query('hours') as string, 10) : undefined,
+      }
+
+      buildAlertsWithNotificationState(db, Number.isFinite(filters.hours) ? Math.max(1, filters.hours as number) : 24)
+      const rows = listOperatorNotifications(db, {
+        q: filters.q,
+        status: filters.status,
+        sourceType: filters.source,
+        limit: Math.min(Math.max(Number(filters.limit ?? 200) || 200, 1), 5000),
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        notifications: rows.map((row) => serializeOperatorNotification(row)),
+        total: rows.length,
+        summary: summarizeOperatorNotifications(rows),
+      })
+    } catch (err) {
+      console.error('Operator notifications error:', err)
+      return c.json({ error: 'Failed to load operator notifications', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  app.patch('/admin/operator-notifications/:id', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const id = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(id) || id <= 0) {
+      return c.json({ error: 'Invalid operator notification id', errorCode: 'INVALID_NOTIFICATION_ID' }, 400)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const status = normalizeOperatorNotificationStatus((body as Record<string, unknown>).status)
+    if (!status) {
+      return c.json({ error: 'Invalid operator notification status', errorCode: 'INVALID_NOTIFICATION_STATUS' }, 400)
+    }
+
+    const updated = updateOperatorNotificationStatus(db, {
+      id,
+      status,
+      actor: auth.session.email,
+    })
+    if (!updated) {
+      return c.json({ error: 'Operator notification not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.operator_notification.updated',
+      actor: auth.session.email,
+      target: String(id),
+      details: {
+        status,
+        role: auth.session.role,
+        sourceType: updated.source_type,
+        sourceKey: updated.source_key,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ok: true,
+      notification: serializeOperatorNotification(updated),
+    })
   })
 
   app.get('/admin/waitlist', (c) => {
@@ -1528,7 +2025,7 @@ export function createApp(db: Database): Hono {
 
     try {
       const existing = db.prepare(`
-        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, created_at, updated_at
+        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, next_action, last_contact_at, created_at, updated_at
         FROM waitlist
         WHERE email = ?
         ORDER BY created_at DESC, id DESC
@@ -1544,6 +2041,7 @@ export function createApp(db: Database): Hono {
         const nextStatus = (normalizeBetaRequestStatus(existing.status) ?? 'new') === 'closed'
           ? 'new'
           : (normalizeBetaRequestStatus(existing.status) ?? 'new')
+        const resetNotification = nextStatus === 'new' && (normalizeBetaRequestStatus(existing.status) ?? 'new') === 'closed'
 
         db.prepare(`
           UPDATE waitlist
@@ -1555,6 +2053,11 @@ export function createApp(db: Database): Hono {
         if (!updated) {
           return c.json({ error: 'Failed to load updated beta request', errorCode: 'DB_ERROR' }, 500)
         }
+
+        if (resetNotification) {
+          ensureBetaRequestNotification(db, updated, true)
+        }
+        const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(updated.id))
 
         return c.json({
           ok: true,
@@ -1569,10 +2072,12 @@ export function createApp(db: Database): Hono {
           requestStatus: normalizeBetaRequestStatus(updated.status) ?? 'new',
           owner: updated.owner,
           operatorNotes: updated.operator_notes,
+          nextAction: updated.next_action ?? getBetaRequestNextStep(updated.status),
+          lastContactAt: updated.last_contact_at,
           createdAt: updated.created_at,
           updatedAt: updated.updated_at,
-          request: serializeBetaRequest(updated),
-          nextStep: getBetaRequestNextStep(updated.status),
+          request: serializeBetaRequest(updated, notification),
+          nextStep: updated.next_action ?? getBetaRequestNextStep(updated.status),
         }, 200)
       }
 
@@ -1587,10 +2092,12 @@ export function createApp(db: Database): Hono {
           status,
           owner,
           operator_notes,
+          next_action,
+          last_contact_at,
           created_at,
           updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, NULL, NULL, ?, ?)
       `).run(
         signup.email,
         signup.source,
@@ -1621,6 +2128,7 @@ export function createApp(db: Database): Hono {
       if (!created) {
         return c.json({ error: 'Failed to load saved beta request', errorCode: 'DB_ERROR' }, 500)
       }
+      const notification = ensureBetaRequestNotification(db, created, true)
 
       return c.json({
         ok: true,
@@ -1635,10 +2143,12 @@ export function createApp(db: Database): Hono {
         requestStatus: normalizeBetaRequestStatus(created.status) ?? 'new',
         owner: created.owner,
         operatorNotes: created.operator_notes,
+        nextAction: created.next_action ?? getBetaRequestNextStep(created.status),
+        lastContactAt: created.last_contact_at,
         createdAt: created.created_at,
         updatedAt: created.updated_at,
-        request: serializeBetaRequest(created),
-        nextStep: getBetaRequestNextStep(created.status),
+        request: serializeBetaRequest(created, notification),
+        nextStep: created.next_action ?? getBetaRequestNextStep(created.status),
       }, 201)
     } catch (err) {
       console.error('Waitlist signup error:', err)
@@ -1653,14 +2163,15 @@ export function createApp(db: Database): Hono {
     }
 
     try {
-      const { rows, total } = listBetaRequestRows(db, { limit: 5000 })
+      const { rows, total, allRows } = listBetaRequestRows(db, { limit: 5000 })
+      const notifications = getBetaRequestNotifications(db, rows)
 
       return c.json({
-        waitlist: rows.map((row) => serializeBetaRequest(row)),
-        signups: rows.map((row) => serializeBetaRequest(row)),
-        requests: rows.map((row) => serializeBetaRequest(row)),
+        waitlist: rows.map((row) => serializeBetaRequest(row, notifications.get(betaRequestNotificationSourceKey(row.id)))),
+        signups: rows.map((row) => serializeBetaRequest(row, notifications.get(betaRequestNotificationSourceKey(row.id)))),
+        requests: rows.map((row) => serializeBetaRequest(row, notifications.get(betaRequestNotificationSourceKey(row.id)))),
         total,
-        summary: summarizeBetaRequests(rows, total),
+        summary: summarizeBetaRequests(allRows, total),
       })
     } catch (err) {
       console.error('List waitlist error:', err)

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -134,6 +134,29 @@ export interface AuditLogRow {
   details: string
 }
 
+export type OperatorNotificationSource = 'beta_request' | 'critical_alert'
+export type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
+export type OperatorNotificationSeverity = 'info' | 'warning' | 'critical'
+
+export interface OperatorNotificationRow {
+  id: number
+  source_type: OperatorNotificationSource
+  source_key: string
+  beta_request_id: number | null
+  alert_id: string | null
+  severity: OperatorNotificationSeverity
+  title: string
+  message: string
+  href: string | null
+  status: OperatorNotificationStatus
+  created_at: string
+  updated_at: string
+  acknowledged_at: string | null
+  acted_at: string | null
+  actor: string | null
+  details_json: string | null
+}
+
 export interface ShieldAuditLogRow {
   id: number
   nonce: string | null


### PR DESCRIPTION
## Summary
- turn hosted beta requests into a staged operator pipeline with attention sorting, ownership, next action, and last-contact tracking
- add operator notifications for hosted beta requests and critical alerts, plus a dashboard inbox to work signals through new, acknowledged, and acted states
- document the workflow and extend blackbox tests for the public intake, admin pipeline, and critical alert notification path

## Verification
- npm test
- npm run build
- npm run test:e2e
- cd docs && npm run build

Closes #52
Closes #53