### PR TITLE
Add guided evaluation path and onboarding pack

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     sidebar: [
       { text: 'Guide', items: [
         { text: 'Verified Partner Handoff', link: '/guide/partner-handoff' },
+        { text: 'Design-Partner Onboarding Pack', link: '/guide/design-partner-onboarding' },
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Hosted Quickstart', link: '/guide/hosted-quickstart' },
         { text: 'Compatibility', link: '/guide/compatibility' },

--- a/docs/guide/design-partner-onboarding.md
+++ b/docs/guide/design-partner-onboarding.md
@@ -1,0 +1,254 @@
+# Design-Partner Onboarding Pack
+
+Use this pack when a hosted Beam evaluation moves from "interesting" to "worth a real conversation."
+
+The public proof path stays here:
+
+- [Guided Evaluation](https://beam.directory/guided-evaluation.html)
+- [Hosted Beta Intake](https://beam.directory/hosted-beta.html)
+
+This page is the reusable operator and buyer pack that should support every external evaluation before the call starts.
+
+## What This Pack Is For
+
+Use it to make sure the first Beam conversation stays narrow and honest:
+
+1. one workflow,
+2. one sender and one recipient,
+3. one operator owner,
+4. one proof expectation,
+5. one next step if the fit is real.
+
+Do not use Beam's first conversation as a broad "agent platform" tour. The first job is to decide whether one cross-company handoff deserves a pilot.
+
+## Buyer Expectations Before The Evaluation
+
+Before the call starts, the external team should already know:
+
+- Beam is for one company handing work to another company's AI with a visible paper trail.
+- The first evaluation is scoped to one real workflow, not a broad rollout.
+- The goal is to inspect the proof and decide whether one hosted pilot is justified.
+- The likely next step after a good call is a narrow hosted pilot, not an open-ended beta promise.
+
+## What We Need Before Scheduling
+
+Collect these five inputs before the first session:
+
+1. The first workflow in one sentence.
+2. The sender and receiver sides.
+3. The operator who will care when the handoff stalls.
+4. The success condition for the first pilot.
+5. The blocker or risk that makes visibility matter.
+
+### Intake Checklist
+
+- Company name
+- Primary team email
+- Workflow type
+- One-paragraph workflow summary
+- Estimated number of agents or systems involved
+- Internal owner on the buyer side
+- Clear reason this workflow matters now
+
+## What The Guided Evaluation Should Cover
+
+The canonical sequence is:
+
+1. Restate the buyer workflow in plain language.
+2. Show the healthy Beam overview baseline.
+3. Open one request trace and walk stage by stage.
+4. Explain what happens when follow-up is async or delayed.
+5. Confirm what a hosted pilot would look like if the fit is real.
+
+## Proof Checklist
+
+The evaluation is only good if the proof is clear enough for a normal buyer to repeat back.
+
+Show all of these:
+
+- a healthy operator baseline,
+- one request trace from arrival to reply,
+- one explicit owner and next action,
+- what happens when the handoff needs follow-up later,
+- where an operator would look if the flow stalled.
+
+## What The Buyer Should Leave With
+
+At the end of the evaluation, the buyer should have:
+
+- a clear answer on whether Beam fits one workflow,
+- a shared understanding of what the first pilot would cover,
+- one named owner on both sides,
+- one concrete next action,
+- no confusion about whether self-hosting or repo setup is required first.
+
+## Operator Preparation Checklist
+
+Before the call:
+
+- confirm the public guided evaluation page still reflects the current proof path,
+- make sure the screenshots and operator evidence are current,
+- open the dashboard and confirm the system baseline is healthy,
+- know which follow-up template matches the likely request stage,
+- have the onboarding pack and hosted beta intake open in the same browser session.
+
+After the call:
+
+- update the request stage,
+- assign or confirm owner,
+- record the next action,
+- record last contact time,
+- send the correct follow-up template.
+
+## Follow-Up Templates
+
+These templates are intentionally short. The goal is clarity and next action, not marketing copy.
+
+<a id="template-new"></a>
+## Template: New Request Acknowledgement
+
+```text
+Subject: Beam evaluation request received
+
+Hi {{name}},
+
+We received your Beam request for {{company}}.
+
+The next step on our side is a quick workflow review so we can confirm whether one narrow pilot makes sense. We will use the workflow summary you sent to assign an operator owner and send the right proof path before the call.
+
+What we need from you:
+- the first workflow in one sentence
+- who sends the work
+- who receives it
+- what a good outcome looks like
+
+Reference:
+- Guided evaluation: https://beam.directory/guided-evaluation.html
+- Hosted beta intake: https://beam.directory/hosted-beta.html
+
+Best,
+{{operator}}
+```
+
+<a id="template-reviewing"></a>
+## Template: Reviewing / Clarification Needed
+
+```text
+Subject: Beam workflow clarification
+
+Hi {{name}},
+
+We reviewed the request and want to keep the first evaluation narrow.
+
+Before we schedule anything, please reply with:
+- the first sender and receiver in the workflow
+- the one handoff that matters most
+- the person who owns the result if it stalls
+
+Beam works best when the first evaluation stays focused on one real partner handoff instead of a broad platform rollout.
+
+Reference pack:
+- https://docs.beam.directory/guide/design-partner-onboarding
+
+Best,
+{{operator}}
+```
+
+<a id="template-contacted"></a>
+## Template: Contacted / Next Action Sent
+
+```text
+Subject: Beam evaluation next step
+
+Hi {{name}},
+
+Thanks for the context. The next step is {{next_action}}.
+
+Before the session, please review:
+- the guided evaluation path: https://beam.directory/guided-evaluation.html
+- the onboarding pack: https://docs.beam.directory/guide/design-partner-onboarding
+
+The call will stay focused on one workflow, the proof Beam shows for it, and whether that workflow deserves a hosted pilot.
+
+Best,
+{{operator}}
+```
+
+<a id="template-scheduled"></a>
+## Template: Scheduled Evaluation
+
+```text
+Subject: Beam evaluation scheduled
+
+Hi {{name}},
+
+Your Beam evaluation is scheduled for {{date_time}}.
+
+What we will cover:
+- the workflow in plain language
+- the Beam proof path for one request
+- what a narrow hosted pilot would include if the fit is real
+
+Please bring:
+- the business owner for the workflow
+- the operator or technical owner who will care when it stalls
+- the success condition for the first pilot
+
+Reference pack:
+- https://docs.beam.directory/guide/design-partner-onboarding
+
+Best,
+{{operator}}
+```
+
+<a id="template-active"></a>
+## Template: Active Pilot Follow-Up
+
+```text
+Subject: Beam pilot is active
+
+Hi {{name}},
+
+Beam is now active for the scoped workflow we agreed on.
+
+Current owner: {{owner}}
+Current next action: {{next_action}}
+
+If the workflow stalls, we will use the operator path to inspect the trace, confirm the current stage, and decide the next recovery step. We will keep follow-up attached to the same request instead of starting a new thread.
+
+Best,
+{{operator}}
+```
+
+<a id="template-closed"></a>
+## Template: Closed / Not The Right Fit Right Now
+
+```text
+Subject: Beam evaluation follow-up
+
+Hi {{name}},
+
+Thanks again for the conversation.
+
+We are closing the current Beam request for now because the first workflow is not narrow enough yet or the timing is not right for a hosted pilot.
+
+If that changes, the best restart is:
+- one workflow
+- one sender
+- one recipient
+- one success condition
+
+When that exists, you can reopen the conversation through:
+- https://beam.directory/guided-evaluation.html
+- https://beam.directory/hosted-beta.html
+
+Best,
+{{operator}}
+```
+
+## Pack Links
+
+- [Guided Evaluation](https://beam.directory/guided-evaluation.html)
+- [Hosted Beta Intake](https://beam.directory/hosted-beta.html)
+- [Operator Runbook](/guide/operator-runbook)
+- [Hosted Quickstart](/guide/hosted-quickstart)

--- a/docs/guide/operator-runbook.md
+++ b/docs/guide/operator-runbook.md
@@ -5,6 +5,7 @@ This runbook is the shortest path from "something looks wrong" to a concrete Bea
 Use it together with:
 
 - [Hosted Quickstart](/guide/hosted-quickstart) for a local seeded demo stack
+- [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) for buyer expectations, evaluation prep, and follow-up templates
 - [Operator Observability](/guide/operator-observability) for dashboards, exports, and retention controls
 - [Intent Lifecycle](/guide/intent-lifecycle) for status semantics
 
@@ -20,6 +21,8 @@ Use the inbox for two classes of work:
 
 - hosted beta requests that still need assignment, contact, or a next action
 - critical alerts that need triage, acknowledgement, and an explicit follow-up
+
+When the signal is a hosted beta request, pair the inbox with the [Design-Partner Onboarding Pack](/guide/design-partner-onboarding). The pack gives you the shared expectations and reply templates for `new`, `reviewing`, `contacted`, `scheduled`, `active`, and `closed` request states.
 
 The shortest daily loop is:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,14 +6,14 @@ hero:
   tagline: "Beam helps one company's AI ask another company to do work without losing who asked, who answered, or where it got stuck. Start with one real handoff and a visible paper trail."
   actions:
     - theme: brand
-      text: Launch Hosted Demo
-      link: /guide/hosted-quickstart
+      text: Guided Evaluation
+      link: https://beam.directory/guided-evaluation.html
     - theme: alt
       text: Request Hosted Beta
       link: https://beam.directory/hosted-beta.html
     - theme: alt
-      text: Register a Real Agent
-      link: https://beam.directory/register.html
+      text: Hosted Quickstart
+      link: /guide/hosted-quickstart
 features:
   - icon: 🤝
     title: One Real Workflow
@@ -31,38 +31,26 @@ features:
     title: Recovery Built In
     details: "Retries, restart recovery, and dead-letter handling are part of the product surface, not hidden glue code."
   - icon: 🧩
-    title: Demo First, Depth Second
-    details: "Start with the hosted demo and only go deeper into SDKs, compatibility, and rollout details once the use case is real."
+    title: Proof First, Depth Second
+    details: "Start with the guided evaluation and only go deeper into quickstart, SDKs, compatibility, and rollout details once the use case is real."
 ---
 
 ## Start Here
 
-If you only do one thing, run the [Hosted Quickstart](/guide/hosted-quickstart). It shows the exact Acme to Northwind workflow used in dogfood, observability, and the operator runbook.
+If you only do one thing, open the public [Guided Evaluation](https://beam.directory/guided-evaluation.html). That is now the canonical buyer path from landing page to proof and hosted pilot intake.
 
-```typescript
-import { BeamClient, BeamIdentity } from 'beam-protocol-sdk'
+Use the docs when you need one of these supporting paths:
 
-const identity = BeamIdentity.generate({ agentName: 'procurement', orgName: 'acme' })
-const client = new BeamClient({
-  identity: identity.export(),
-  directoryUrl: 'https://api.beam.directory',
-})
-
-await client.register('Acme Procurement Desk', ['conversation.message', 'quote.request'])
-
-const reply = await client.talk(
-  'partner-desk@northwind.beam.directory',
-  'Need 240 inverters for Mannheim by Friday. Include delivery window and stock confidence.',
-)
-
-console.log(reply.message)
-```
+1. The [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) for prerequisites, evaluation expectations, and operator follow-up templates.
+2. The [Hosted Quickstart](/guide/hosted-quickstart) if you want to run the same proof stack locally.
+3. The [Register page](https://beam.directory/register.html) once the use case is real and you want to wire your own agent.
 
 ## Choose Your Path
 
-1. **See the proof first.** Run the [Hosted Quickstart](/guide/hosted-quickstart), inspect the dashboard trace, and verify the async finance preflight before you decide Beam is worth more time.
-2. **Wire a real agent.** Use the [Register page](https://beam.directory/register.html) when the demo already landed and you want a Beam ID, keys, and smoke-test snippets for your own setup.
+1. **See the proof first.** Open the [Guided Evaluation](https://beam.directory/guided-evaluation.html), inspect the real screenshots and operator evidence, then decide whether Beam is worth more time.
+2. **Prepare the evaluation properly.** Use the [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) to align prerequisites, proof expectations, and next-step language before the call starts.
 3. **Request hosted beta.** If you want a guided rollout around one real partner workflow, use the [Hosted Beta page](https://beam.directory/hosted-beta.html).
+4. **Run the technical proof yourself.** Use the [Hosted Quickstart](/guide/hosted-quickstart) when you want to self-run the same baseline locally.
 
 ## What Beam Is For
 
@@ -76,6 +64,8 @@ If that is your problem, Beam is aimed directly at it. If it is not, Beam should
 
 ## Continue
 
+- [Guided Evaluation](https://beam.directory/guided-evaluation.html)
+- [Design-Partner Onboarding Pack](/guide/design-partner-onboarding)
 - [Hosted Quickstart](/guide/hosted-quickstart)
 - [Register a Real Agent](https://beam.directory/register.html)
 - [Partner Handoff Guide](/guide/partner-handoff)

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -40,6 +40,9 @@ const SORT_OPTIONS = [
 
 type SortOption = typeof SORT_OPTIONS[number]['value']
 
+const ONBOARDING_PACK_URL = 'https://docs.beam.directory/guide/design-partner-onboarding'
+const GUIDED_EVALUATION_URL = 'https://beam.directory/guided-evaluation.html'
+
 export default function BetaRequestsPage() {
   const { session } = useAdminAuth()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -479,6 +482,41 @@ export default function BetaRequestsPage() {
               </>
             )}
           </div>
+
+          <div className="panel space-y-4">
+            <div className="panel-title">Onboarding pack</div>
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              Keep external evaluations on the same script: public proof first, then the onboarding pack, then the stage-specific follow-up template.
+            </p>
+            <div className="grid gap-3">
+              <a
+                className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
+                href={GUIDED_EVALUATION_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open guided evaluation
+              </a>
+              <a
+                className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
+                href={ONBOARDING_PACK_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open onboarding pack
+              </a>
+              {selectedRequest ? (
+                <a
+                  className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
+                  href={`${ONBOARDING_PACK_URL}${templateAnchorForStage(selectedRequest.stage)}`}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Open template for {selectedRequest.stage}
+                </a>
+              ) : null}
+            </div>
+          </div>
         </div>
       </section>
     </div>
@@ -543,4 +581,22 @@ function toDateTimeLocalValue(value?: string | null): string {
   const offset = date.getTimezoneOffset()
   const localDate = new Date(date.getTime() - offset * 60_000)
   return localDate.toISOString().slice(0, 16)
+}
+
+function templateAnchorForStage(stage: BetaRequestStatus): string {
+  switch (stage) {
+    case 'reviewing':
+      return '#template-reviewing'
+    case 'contacted':
+      return '#template-contacted'
+    case 'scheduled':
+      return '#template-scheduled'
+    case 'active':
+      return '#template-active'
+    case 'closed':
+      return '#template-closed'
+    case 'new':
+    default:
+      return '#template-new'
+  }
 }

--- a/packages/public-site/guided-evaluation.html
+++ b/packages/public-site/guided-evaluation.html
@@ -1,0 +1,958 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Guided Beam Evaluation — Beam Protocol</title>
+  <meta
+    name="description"
+    content="See the guided Beam evaluation path from first proof to hosted pilot, without starting in the repo."
+  />
+  <meta property="og:title" content="Guided Beam Evaluation — Beam Protocol" />
+  <meta
+    property="og:description"
+    content="One public path from Beam landing page to real proof: see the handoff, inspect the operator evidence, then decide whether one live workflow deserves a pilot."
+  />
+  <meta property="og:image" content="https://beam.directory/og-image.png" />
+  <meta property="og:url" content="https://beam.directory/guided-evaluation.html" />
+  <meta property="og:type" content="website" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Guided Beam Evaluation — Beam Protocol" />
+  <meta
+    name="twitter:description"
+    content="See how Beam proves one cross-company AI handoff before asking you for a broader rollout."
+  />
+  <meta name="twitter:image" content="https://beam.directory/og-image.png" />
+  <link rel="canonical" href="https://beam.directory/guided-evaluation.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    rel="preload"
+    as="style"
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap"
+  />
+  <link
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap"
+    rel="stylesheet"
+    media="print"
+    onload="this.media='all'"
+  />
+  <noscript>
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </noscript>
+  <style>
+    :root {
+      --paper: #f6f0e7;
+      --paper-strong: #fff8f0;
+      --ink: #1c130d;
+      --ink-soft: #4f4337;
+      --ink-muted: #7d7065;
+      --line: rgba(42, 26, 16, 0.12);
+      --line-strong: rgba(42, 26, 16, 0.22);
+      --surface: rgba(255, 252, 247, 0.88);
+      --surface-strong: rgba(255, 252, 247, 0.96);
+      --surface-dark: #231711;
+      --accent: #f15a24;
+      --accent-soft: #ff8d58;
+      --accent-fog: rgba(241, 90, 36, 0.14);
+      --green: #1f8f5f;
+      --green-fog: rgba(31, 143, 95, 0.12);
+      --amber: #b86b0f;
+      --amber-fog: rgba(184, 107, 15, 0.12);
+      --shadow-soft: 0 28px 80px rgba(56, 29, 11, 0.08);
+      --shadow-hero: 0 56px 140px rgba(70, 33, 10, 0.16);
+      --radius-xl: 34px;
+      --radius-lg: 24px;
+      --radius-md: 18px;
+      --radius-sm: 12px;
+      --font-display: "Space Grotesk", sans-serif;
+      --font-body: "Space Grotesk", sans-serif;
+      --font-mono: "IBM Plex Mono", monospace;
+      --max: 1180px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    html {
+      scroll-behavior: smooth;
+      background: var(--paper);
+    }
+
+    body {
+      min-height: 100vh;
+      font-family: var(--font-body);
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 10% 14%, rgba(255, 203, 161, 0.38), transparent 24%),
+        radial-gradient(circle at 86% 12%, rgba(241, 90, 36, 0.12), transparent 20%),
+        linear-gradient(180deg, #f8f3ec 0%, #f4eee6 48%, #f6f0e7 100%);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(28, 19, 13, 0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(28, 19, 13, 0.03) 1px, transparent 1px);
+      background-size: 42px 42px;
+      mask-image: radial-gradient(circle at center, black 18%, transparent 88%);
+      opacity: 0.5;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    img {
+      display: block;
+      max-width: 100%;
+    }
+
+    .container {
+      width: min(var(--max), calc(100% - 40px));
+      margin: 0 auto;
+    }
+
+    .topbar-shell {
+      padding: 22px 0 0;
+    }
+
+    .topbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 14px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.26);
+      background: rgba(36, 24, 17, 0.82);
+      color: #fff8f1;
+      box-shadow: 0 20px 44px rgba(34, 18, 8, 0.12);
+      backdrop-filter: blur(16px);
+    }
+
+    .brand {
+      display: inline-flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+    }
+
+    .brand-mark {
+      width: 42px;
+      height: 42px;
+      border-radius: 12px;
+      display: grid;
+      place-items: center;
+      background: linear-gradient(140deg, var(--accent-soft), var(--accent));
+      color: white;
+      font-weight: 700;
+      box-shadow: 0 14px 30px rgba(241, 90, 36, 0.25);
+    }
+
+    .brand-copy {
+      display: grid;
+      gap: 2px;
+      line-height: 1;
+    }
+
+    .brand-copy strong {
+      font-size: 1rem;
+      letter-spacing: -0.03em;
+    }
+
+    .brand-copy span {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: rgba(255, 248, 241, 0.7);
+    }
+
+    .top-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .top-links a {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 42px;
+      padding: 0 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      color: rgba(255, 248, 241, 0.88);
+      font-size: 0.88rem;
+      transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    }
+
+    .top-links a:hover {
+      transform: translateY(-1px);
+      border-color: rgba(255, 255, 255, 0.24);
+    }
+
+    .top-links a.primary {
+      background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+      border-color: transparent;
+      color: white;
+      font-weight: 700;
+    }
+
+    main {
+      padding: 28px 0 100px;
+    }
+
+    .hero-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 0.88fr) minmax(360px, 1.12fr);
+      gap: 26px;
+      align-items: stretch;
+    }
+
+    .hero-copy,
+    .hero-visual,
+    .section-panel,
+    .closing-panel {
+      border-radius: var(--radius-xl);
+      border: 1px solid var(--line);
+      box-shadow: var(--shadow-soft);
+    }
+
+    .hero-copy {
+      padding: 38px;
+      background:
+        radial-gradient(circle at top left, rgba(255, 205, 167, 0.36), transparent 26%),
+        linear-gradient(162deg, #241711 0%, #3d2215 44%, #6f3518 100%);
+      color: #fff8f1;
+    }
+
+    .hero-visual {
+      padding: 22px;
+      background:
+        linear-gradient(180deg, rgba(255, 252, 247, 0.96), rgba(255, 252, 247, 0.9)),
+        radial-gradient(circle at top right, rgba(241, 90, 36, 0.12), transparent 26%);
+    }
+
+    .eyebrow,
+    .section-kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .eyebrow {
+      margin-bottom: 16px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      color: rgba(255, 248, 241, 0.86);
+    }
+
+    .eyebrow::before,
+    .section-kicker::before {
+      content: "";
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--accent-soft);
+      box-shadow: 0 0 0 7px rgba(255, 141, 89, 0.12);
+    }
+
+    .section-kicker {
+      margin-bottom: 14px;
+      border: 1px solid rgba(241, 90, 36, 0.12);
+      background: rgba(241, 90, 36, 0.08);
+      color: var(--accent);
+    }
+
+    h1,
+    h2,
+    h3,
+    strong {
+      font-family: var(--font-display);
+      letter-spacing: -0.04em;
+    }
+
+    h1 {
+      font-size: clamp(2.7rem, 5vw, 4.9rem);
+      line-height: 0.92;
+      max-width: 11ch;
+    }
+
+    .hero-copy p {
+      max-width: 34rem;
+      margin-top: 18px;
+      color: rgba(255, 248, 241, 0.84);
+      font-size: 1.04rem;
+    }
+
+    .hero-actions,
+    .closing-actions,
+    .proof-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 24px;
+    }
+
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 50px;
+      padding: 0 18px;
+      border-radius: 999px;
+      font-weight: 600;
+      transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, var(--accent), var(--accent-soft));
+      color: white;
+      box-shadow: 0 18px 34px rgba(241, 90, 36, 0.24);
+    }
+
+    .btn-secondary {
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      color: #fff8f1;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .btn-ghost {
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.7);
+      color: var(--ink);
+    }
+
+    .hero-points {
+      display: grid;
+      gap: 12px;
+      margin-top: 26px;
+    }
+
+    .hero-point {
+      display: grid;
+      gap: 4px;
+      padding: 14px 16px;
+      border-radius: var(--radius-md);
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .hero-point strong {
+      font-size: 1rem;
+      color: white;
+    }
+
+    .hero-point span {
+      color: rgba(255, 248, 241, 0.78);
+      font-size: 0.94rem;
+    }
+
+    .visual-grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .visual-shot {
+      overflow: hidden;
+      border-radius: calc(var(--radius-lg) + 2px);
+      border: 1px solid var(--line-strong);
+      background: white;
+      box-shadow: var(--shadow-hero);
+    }
+
+    .visual-shot img {
+      width: 100%;
+      height: auto;
+    }
+
+    .visual-copy {
+      display: grid;
+      gap: 8px;
+      padding: 18px;
+    }
+
+    .visual-copy strong {
+      font-size: 1.16rem;
+      color: var(--ink);
+    }
+
+    .visual-copy p {
+      color: var(--ink-soft);
+      font-size: 0.96rem;
+    }
+
+    .proof-strip {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .proof-pill {
+      display: grid;
+      gap: 5px;
+      padding: 14px 15px;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--line);
+      background: var(--surface);
+    }
+
+    .proof-pill strong {
+      font-size: 0.94rem;
+    }
+
+    .proof-pill span {
+      color: var(--ink-soft);
+      font-size: 0.88rem;
+    }
+
+    .section {
+      margin-top: 34px;
+    }
+
+    .section-panel {
+      padding: 30px;
+      background: var(--surface-strong);
+    }
+
+    .section-head {
+      display: grid;
+      gap: 12px;
+      margin-bottom: 24px;
+    }
+
+    .section-head h2 {
+      font-size: clamp(2.1rem, 4.2vw, 3.4rem);
+      line-height: 0.95;
+      max-width: 12ch;
+    }
+
+    .section-head p {
+      max-width: 48rem;
+      color: var(--ink-soft);
+      font-size: 1rem;
+    }
+
+    .steps-grid,
+    .evidence-grid,
+    .expect-grid,
+    .pack-grid {
+      display: grid;
+      gap: 16px;
+    }
+
+    .steps-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .evidence-grid {
+      grid-template-columns: minmax(0, 1.06fr) minmax(0, 0.94fr);
+      align-items: start;
+    }
+
+    .expect-grid,
+    .pack-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .step-card,
+    .expect-card,
+    .pack-card,
+    .evidence-card {
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.64);
+      padding: 20px;
+    }
+
+    .step-card .count,
+    .expect-card .count {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 12px;
+    }
+
+    .step-card h3,
+    .expect-card h3,
+    .pack-card h3,
+    .evidence-card h3 {
+      font-size: 1.34rem;
+      line-height: 1.02;
+      margin-bottom: 10px;
+    }
+
+    .step-card p,
+    .expect-card p,
+    .pack-card p,
+    .evidence-card p {
+      color: var(--ink-soft);
+      font-size: 0.96rem;
+    }
+
+    .step-card ul,
+    .expect-card ul,
+    .pack-card ul,
+    .evidence-card ul {
+      margin-top: 14px;
+      display: grid;
+      gap: 10px;
+      padding-left: 18px;
+      color: var(--ink-soft);
+    }
+
+    .evidence-side {
+      display: grid;
+      gap: 16px;
+    }
+
+    .evidence-card {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 249, 243, 0.78));
+    }
+
+    .status-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 14px;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-family: var(--font-mono);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .status-pill.success {
+      background: var(--green-fog);
+      color: var(--green);
+    }
+
+    .status-pill.warning {
+      background: var(--amber-fog);
+      color: var(--amber);
+    }
+
+    .status-pill.default {
+      background: rgba(28, 19, 13, 0.06);
+      color: var(--ink-soft);
+    }
+
+    .timeline {
+      display: grid;
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .timeline-row {
+      display: grid;
+      grid-template-columns: 118px minmax(0, 1fr);
+      gap: 14px;
+      align-items: start;
+      padding: 14px 0;
+      border-top: 1px solid var(--line);
+    }
+
+    .timeline-row:first-child {
+      border-top: none;
+      padding-top: 0;
+    }
+
+    .timeline-row strong {
+      font-size: 0.82rem;
+      font-family: var(--font-mono);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    .timeline-row span {
+      color: var(--ink-soft);
+      font-size: 0.94rem;
+    }
+
+    .closing-panel {
+      margin-top: 34px;
+      padding: 32px;
+      background:
+        linear-gradient(160deg, rgba(255, 252, 247, 0.92), rgba(255, 247, 240, 0.86)),
+        radial-gradient(circle at top right, rgba(241, 90, 36, 0.12), transparent 26%);
+    }
+
+    .closing-panel h2 {
+      font-size: clamp(2rem, 4vw, 3.2rem);
+      line-height: 0.96;
+      max-width: 12ch;
+    }
+
+    .closing-panel p {
+      margin-top: 14px;
+      max-width: 42rem;
+      color: var(--ink-soft);
+    }
+
+    footer {
+      padding: 0 0 24px;
+    }
+
+    .footer-inner {
+      width: min(var(--max), calc(100% - 40px));
+      margin: 0 auto;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 12px;
+      color: var(--ink-muted);
+      font-size: 0.9rem;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    @media (max-width: 1080px) {
+      .hero-shell,
+      .evidence-grid,
+      .expect-grid,
+      .pack-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .steps-grid,
+      .proof-strip {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 720px) {
+      .container,
+      .footer-inner {
+        width: min(var(--max), calc(100% - 28px));
+      }
+
+      .topbar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .top-links {
+        width: 100%;
+      }
+
+      .top-links a {
+        flex: 1 1 160px;
+      }
+
+      .hero-copy,
+      .hero-visual,
+      .section-panel,
+      .closing-panel {
+        padding: 22px;
+      }
+
+      .timeline-row {
+        grid-template-columns: 1fr;
+      }
+
+      .hero-actions .btn,
+      .closing-actions .btn,
+      .proof-links .btn {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar-shell">
+    <div class="container">
+      <nav class="topbar">
+        <a class="brand" href="/">
+          <div class="brand-mark">B</div>
+          <div class="brand-copy">
+            <strong>beam.directory</strong>
+            <span>Guided evaluation</span>
+          </div>
+        </a>
+
+        <div class="top-links">
+          <a href="/">Home</a>
+          <a href="/hosted-beta.html">Request pilot</a>
+          <a class="primary" href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
+        </div>
+      </nav>
+    </div>
+  </div>
+
+  <main>
+    <div class="container">
+      <section class="hero-shell">
+        <div class="hero-copy">
+          <div class="eyebrow">One public evaluation path</div>
+          <h1>See the Beam proof before you commit to a pilot.</h1>
+          <p>
+            This is the shortest public path from curiosity to evidence. In one guided evaluation,
+            you see one company hand work to another, inspect the operator proof, and decide whether
+            one live workflow is worth a hosted pilot.
+          </p>
+
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="/hosted-beta.html">Request a guided pilot</a>
+            <a class="btn btn-secondary" href="https://docs.beam.directory/guide/design-partner-onboarding">Open the onboarding pack</a>
+          </div>
+
+          <div class="hero-points">
+            <div class="hero-point">
+              <strong>No repo detour required</strong>
+              <span>The buyer path stays on Beam surfaces from first read to first proof.</span>
+            </div>
+            <div class="hero-point">
+              <strong>Real operator evidence</strong>
+              <span>The screenshots and evidence blocks below come from the actual seeded Beam environment.</span>
+            </div>
+            <div class="hero-point">
+              <strong>One workflow, one owner, one next step</strong>
+              <span>The goal is not a platform tour. The goal is to decide whether one handoff deserves a real pilot.</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="hero-visual">
+          <div class="visual-grid">
+            <figure class="visual-shot">
+              <img src="/assets/dashboard-overview.png" alt="Beam dashboard overview showing a healthy baseline with no active alerts and no stuck work." />
+              <figcaption class="visual-copy">
+                <strong>Healthy baseline before the first live workflow</strong>
+                <p>The current seeded Beam path starts with a clean operating surface: visible agents, low latency, and no hidden failure pressure.</p>
+              </figcaption>
+            </figure>
+
+            <div class="proof-strip">
+              <div class="proof-pill">
+                <strong>0 active alerts</strong>
+                <span>Operators start from a clean baseline instead of an unknown system state.</span>
+              </div>
+              <div class="proof-pill">
+                <strong>1 traceable handoff</strong>
+                <span>The same request can be inspected from sender to reply.</span>
+              </div>
+              <div class="proof-pill">
+                <strong>Shared proof</strong>
+                <span>Both sides can point to the same request, status, and next action.</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-panel">
+          <div class="section-head">
+            <div class="section-kicker">What happens in the evaluation</div>
+            <h2>Fifteen minutes to decide whether Beam is worth a real pilot.</h2>
+            <p>
+              The path is intentionally narrow. Beam works best when the first conversation stays
+              grounded in one concrete handoff and one visible proof surface.
+            </p>
+          </div>
+
+          <div class="steps-grid">
+            <div class="step-card">
+              <div class="count">01 · understand the job</div>
+              <h3>Name the first handoff.</h3>
+              <p>Start with one company asking another company to do one piece of work that actually matters.</p>
+              <ul>
+                <li>Who sends the work</li>
+                <li>Who receives it</li>
+                <li>What “done” looks like</li>
+              </ul>
+            </div>
+
+            <div class="step-card">
+              <div class="count">02 · inspect the proof</div>
+              <h3>See the operator evidence.</h3>
+              <p>Beam should show the baseline, the trace, and the next action clearly enough that a non-developer can follow it.</p>
+              <ul>
+                <li>Healthy overview before the handoff</li>
+                <li>Trace detail for one request</li>
+                <li>Follow-up and async status still attached</li>
+              </ul>
+            </div>
+
+            <div class="step-card">
+              <div class="count">03 · decide the next step</div>
+              <h3>Either stop or scope one pilot.</h3>
+              <p>If the proof does not map to your workflow, stop. If it does, scope one narrow hosted pilot with one operator owner.</p>
+              <ul>
+                <li>No vague platform rollout</li>
+                <li>No multi-team project plan first</li>
+                <li>One owner and one next action</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-panel">
+          <div class="section-head">
+            <div class="section-kicker">Proof assets</div>
+            <h2>This is the evidence Beam should keep intact.</h2>
+            <p>
+              The screenshots are real. The evidence blocks below are the reusable proof pack we
+              expect to survive from demo into design-partner conversations.
+            </p>
+          </div>
+
+          <div class="evidence-grid">
+            <figure class="visual-shot">
+              <img src="/assets/dashboard-trace.png" alt="Beam dashboard trace showing a quote request from arrival to completion." />
+              <figcaption class="visual-copy">
+                <strong>Request-level trace from the canonical Acme to Northwind handoff</strong>
+                <p>One request stays legible from arrival to reply. The same operator surface is what Beam carries into a hosted pilot.</p>
+              </figcaption>
+            </figure>
+
+            <div class="evidence-side">
+              <div class="evidence-card">
+                <h3>What a buyer should be able to say back</h3>
+                <p>“Beam helps one company’s AI hand work to another company’s AI, and if it stalls, we can still see what happened.”</p>
+                <div class="status-row">
+                  <div class="status-pill success">shared proof</div>
+                  <div class="status-pill default">known sender</div>
+                  <div class="status-pill default">known receiver</div>
+                </div>
+              </div>
+
+              <div class="evidence-card">
+                <h3>What the operator evidence should prove</h3>
+                <div class="timeline">
+                  <div class="timeline-row">
+                    <strong>baseline</strong>
+                    <span>Healthy system with no active alert pressure before the live handoff starts.</span>
+                  </div>
+                  <div class="timeline-row">
+                    <strong>trace</strong>
+                    <span>One request visible from first send to final reply, including async follow-up.</span>
+                  </div>
+                  <div class="timeline-row">
+                    <strong>ownership</strong>
+                    <span>One operator can tell who owns the next step and whether the request is new, acknowledged, or acted on.</span>
+                  </div>
+                </div>
+              </div>
+
+              <div class="evidence-card">
+                <h3>What you get after the evaluation</h3>
+                <ul>
+                  <li>A decision on whether one live workflow deserves a pilot.</li>
+                  <li>A shared description of sender, receiver, owner, and success condition.</li>
+                  <li>A concrete next action instead of an open-ended beta conversation.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-panel">
+          <div class="section-head">
+            <div class="section-kicker">Before the call</div>
+            <h2>What we need before we schedule anything.</h2>
+            <p>
+              Beam gets sharper when the onboarding expectations are explicit. The pack below is
+              what design-partner calls should use before the first walkthrough starts.
+            </p>
+          </div>
+
+          <div class="pack-grid">
+            <div class="pack-card">
+              <h3>Bring one workflow, not a wishlist.</h3>
+              <p>Tell us the first cross-company handoff that matters enough to deserve a paper trail.</p>
+              <ul>
+                <li>One sender and one recipient</li>
+                <li>One business reason the handoff matters</li>
+                <li>One person who owns the outcome</li>
+              </ul>
+            </div>
+
+            <div class="pack-card">
+              <h3>Know what a “good first win” looks like.</h3>
+              <p>The evaluation is not complete when a message moves. It is complete when the proof surface answers whether Beam helped.</p>
+              <ul>
+                <li>What should the receiving side return</li>
+                <li>What would count as operator proof</li>
+                <li>What the next action would be if the fit is real</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="proof-links">
+            <a class="btn btn-primary" href="/hosted-beta.html">Request a guided pilot</a>
+            <a class="btn btn-ghost" href="https://docs.beam.directory/guide/design-partner-onboarding">Open full onboarding pack</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="closing-panel">
+        <div class="section-kicker">Next step</div>
+        <h2>If the proof maps cleanly to your workflow, scope one pilot.</h2>
+        <p>
+          The right Beam next step is small: one hosted pilot, one operator owner, one workflow that
+          matters. If the fit is not there yet, stop at the evaluation and keep the scope honest.
+        </p>
+        <div class="closing-actions">
+          <a class="btn btn-primary" href="/hosted-beta.html">Request hosted beta</a>
+          <a class="btn btn-ghost" href="/">Back to the landing page</a>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <div>Beam Protocol · guided evaluation path for cross-company AI work</div>
+      <div class="footer-links">
+        <a href="/hosted-beta.html">Hosted beta</a>
+        <a href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
+        <a href="https://docs.beam.directory">Docs</a>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>

--- a/packages/public-site/hosted-beta.html
+++ b/packages/public-site/hosted-beta.html
@@ -707,8 +707,8 @@
         </a>
 
         <div class="top-links">
-          <a href="https://docs.beam.directory/guide/hosted-quickstart">Hosted Demo</a>
-          <a href="https://docs.beam.directory">Docs</a>
+          <a href="/guided-evaluation.html">Guided evaluation</a>
+          <a href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
           <a class="primary" href="#faq">Common questions</a>
         </div>
       </nav>
@@ -723,7 +723,8 @@
           <h1>Request a guided Beam pilot for one real workflow.</h1>
           <p>
             If your AI needs another company's AI to do something real, Beam can scope a small
-            pilot around that handoff. We start narrow, prove it, and only expand if it works.
+            pilot around that handoff. We start narrow, prove it, set expectations up front, and
+            only expand if it works.
           </p>
           <ul>
             <li>One workflow first, not a platform rollout.</li>
@@ -745,7 +746,7 @@
             </div>
             <div class="metric">
               <strong>Guided rollout</strong>
-              <span>Beam helps scope the first evaluation and the next concrete step after it.</span>
+              <span>Beam helps scope the first evaluation, shares the onboarding pack, and sets the next concrete step after it.</span>
             </div>
           </div>
         </div>
@@ -795,7 +796,7 @@
 
             <div class="submit-row">
               <button class="btn primary" id="submit-button" type="submit">Request hosted beta</button>
-              <a class="btn ghost" href="https://docs.beam.directory/guide/hosted-quickstart">See the demo first</a>
+              <a class="btn ghost" href="/guided-evaluation.html">See the guided evaluation first</a>
             </div>
           </form>
 
@@ -844,7 +845,7 @@
           <h2>Use hosted beta for one narrow rollout, then widen only after it works.</h2>
         </div>
 
-        <div class="expect-grid">
+          <div class="expect-grid">
           <div class="expect-card">
             <div class="section-kicker">01 · what you get</div>
             <h3>Managed Beam surfaces</h3>
@@ -877,7 +878,23 @@
               <li>Treat pricing and rollout as workflow-scoped, not as an open-ended beta promise.</li>
             </ul>
           </div>
-        </div>
+          </div>
+
+          <div class="proof-grid" style="margin-top: 18px;">
+            <div class="expect-card">
+              <div class="section-kicker">Before the call</div>
+              <h3>Every serious evaluation starts with the same pack.</h3>
+              <p>The onboarding pack sets scope, prerequisites, proof expectations, and common operator follow-up states before anyone is on a call.</p>
+              <ul>
+                <li>One workflow, one owner, one success condition</li>
+                <li>What proof Beam should show during the walkthrough</li>
+                <li>What happens after the call if the fit is real</li>
+              </ul>
+              <div class="submit-row" style="margin-top: 18px;">
+                <a class="btn ghost" href="https://docs.beam.directory/guide/design-partner-onboarding">Open onboarding pack</a>
+              </div>
+            </div>
+          </div>
       </section>
 
       <section class="faq-section" id="faq">
@@ -996,7 +1013,7 @@
           dateStyle: 'medium',
           timeStyle: 'short',
         }) : null
-        const nextStep = payload.nextStep || 'Beam will review the workflow and follow up with the next concrete step.'
+        const nextStep = payload.nextStep || 'Beam will review the workflow, send the onboarding pack, and follow up with the next concrete step.'
 
         if (payload.status === 'already_registered') {
           setStatus(
@@ -1004,6 +1021,7 @@
             `<strong>You are already on the hosted beta list.</strong><br />` +
             `Beam refreshed the latest workflow context for <code>${email}</code> and kept the original intake.` +
             `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Reference pack: <a href="https://docs.beam.directory/guide/design-partner-onboarding" target="_blank" rel="noreferrer">design-partner onboarding</a></span>` +
             (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Original intake: ${createdAt}</span>` : ''),
           )
         } else {
@@ -1012,6 +1030,7 @@
             `<strong>Hosted beta request recorded.</strong><br />` +
             `Beam queued <strong>${workflowLabel}</strong> for <strong>${company}</strong>.` +
             `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Reference pack: <a href="https://docs.beam.directory/guide/design-partner-onboarding" target="_blank" rel="noreferrer">design-partner onboarding</a></span>` +
             (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Recorded: ${createdAt}</span>` : ''),
           )
           form.reset()

--- a/packages/public-site/index.html
+++ b/packages/public-site/index.html
@@ -1638,14 +1638,14 @@
         <li><a href="#operators">Why Beam</a></li>
         <li><a href="#paths">Next step</a></li>
         <li><a href="#faq">FAQ</a></li>
-        <li><a href="#start">Demo</a></li>
+        <li><a href="/guided-evaluation.html">Guided eval</a></li>
         <li><a href="https://docs.beam.directory" target="_blank" rel="noreferrer">Docs</a></li>
         <li><a href="https://github.com/Beam-directory/beam-protocol" target="_blank" rel="noreferrer">GitHub</a></li>
       </ul>
 
       <div class="nav-actions">
         <a class="btn btn-ghost" href="/hosted-beta.html">Request hosted beta</a>
-        <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Run the demo</a>
+        <a class="btn btn-primary" href="/guided-evaluation.html">See guided evaluation</a>
       </div>
     </nav>
   </div>
@@ -1659,11 +1659,11 @@
           <h1>Let your AI work with another company without losing the paper trail.</h1>
           <p>
             Beam helps two companies move work between their AI systems without losing who asked,
-            who answered, what changed, or where it stalled. Start with one workflow, prove it
-            quickly, then decide whether Beam deserves a bigger footprint.
+            who answered, what changed, or where it stalled. Start with one guided evaluation,
+            inspect the proof, then decide whether Beam deserves a bigger footprint.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Run the 15-minute demo</a>
+            <a class="btn btn-primary" href="/guided-evaluation.html">See the guided evaluation</a>
             <a class="btn btn-secondary" href="/hosted-beta.html">Request hosted beta</a>
           </div>
           <div class="hero-proof">
@@ -1680,8 +1680,8 @@
               <span>Beam shows retries, stuck work, and recovery context instead of hiding failure in glue code.</span>
             </div>
             <div class="proof-item">
-              <strong>Start with one workflow</strong>
-              <span>Run the demo first, then decide whether one real partner workflow is worth a guided rollout.</span>
+              <strong>Start with one guided proof path</strong>
+              <span>See the evaluation first, then decide whether one real partner workflow is worth a guided rollout.</span>
             </div>
           </div>
         </div>
@@ -1758,8 +1758,8 @@
           <span>Operators can check traces, alerts, audit history, and recovery context in one surface.</span>
         </div>
         <div>
-          <strong>Demo before rollout</strong>
-          <span>The fastest way to judge Beam is still the demo, not a long architecture pitch.</span>
+          <strong>Proof before rollout</strong>
+          <span>The fastest way to judge Beam is now the guided evaluation, not a long architecture pitch.</span>
         </div>
       </div>
     </div>
@@ -1931,18 +1931,18 @@
         <div class="stack-layout">
           <div class="stack-column reveal">
             <div class="stack-kicker">01 · prove the handoff</div>
-            <h3>Start with the hosted demo.</h3>
-            <p>Use the demo when you want to understand Beam quickly and judge it by one concrete workflow.</p>
+            <h3>Start with the guided evaluation.</h3>
+            <p>Use the guided path when you want to understand Beam quickly and judge it by one concrete workflow without diving into the repo first.</p>
             <ul>
-              <li>All core Beam surfaces and demo agents boot together.</li>
-              <li>The canonical quote request, warehouse check, and finance preflight are already seeded.</li>
-              <li>Observability and operator docs point at the exact same baseline flow.</li>
+              <li>One public path from landing page to proof and hosted pilot intake.</li>
+              <li>Real screenshots and operator evidence from the seeded Beam baseline.</li>
+              <li>The same onboarding pack and operator docs power the follow-up workflow.</li>
             </ul>
             <div class="stack-actions">
-              <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Launch hosted demo</a>
-              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/operator-runbook">See operator runbook</a>
+              <a class="btn btn-primary" href="/guided-evaluation.html">Open guided evaluation</a>
+              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/design-partner-onboarding">Open onboarding pack</a>
             </div>
-            <div class="stack-note">Best first stop if you just want to know whether Beam makes sense.</div>
+            <div class="stack-note">Best first stop if you want proof before deciding whether Beam is worth a live workflow.</div>
           </div>
           <div class="stack-column reveal">
             <div class="stack-kicker">02 · wire your own agent</div>
@@ -2042,8 +2042,8 @@
           <div class="faq-card reveal">
             <h3>Do I need to self-host Beam to evaluate it?</h3>
             <p>
-              No. The easiest path is the hosted demo first, then the hosted-beta path if the use
-              case is real. Self-hosting is available when you want deeper control later.
+              No. The easiest path is the guided evaluation first, then the hosted-beta path if the
+              use case is real. Self-hosting is available when you want deeper control later.
             </p>
           </div>
           <div class="faq-card reveal">
@@ -2076,12 +2076,12 @@
         <div class="start-shell reveal">
           <div class="start-copy">
             <div class="section-head" style="margin-bottom: 0;">
-              <div class="kicker">Fastest path</div>
-              <h2>Start with the demo, not with theory.</h2>
+              <div class="kicker">Technical path</div>
+              <h2>If you want to self-run the same proof, the demo is here.</h2>
             </div>
             <p>
-              The fastest way to judge Beam is still a seeded local environment that proves the
-              end-to-end story in minutes.
+              The buyer path is the guided evaluation above. The local demo stays here for technical
+              teams that want to run the same proof path on their own machine.
             </p>
             <ul>
               <li>Boot the full demo stack and hosted demo agents together.</li>
@@ -2114,17 +2114,17 @@
       <div class="container">
         <div class="closing-panel reveal">
           <div>
-            <h2>Run the demo first. If it fits, bring us one workflow.</h2>
+            <h2>See the proof first. If it fits, bring us one workflow.</h2>
           </div>
           <div>
             <p>
-              Beam should be easy to judge: either the demo makes your use case obvious, or it
-              does not. If it does, the next step is one real workflow and one clear owner.
+              Beam should be easy to judge: either the guided evaluation makes your use case obvious,
+              or it does not. If it does, the next step is one real workflow and one clear owner.
             </p>
             <div class="closing-actions">
-              <a class="btn btn-primary" href="https://docs.beam.directory/guide/hosted-quickstart">Run the demo</a>
+              <a class="btn btn-primary" href="/guided-evaluation.html">See guided evaluation</a>
               <a class="btn btn-secondary" href="/hosted-beta.html">Request hosted beta</a>
-              <a class="btn btn-secondary" href="/register.html">Register your agent</a>
+              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/hosted-quickstart">Run the demo</a>
             </div>
           </div>
         </div>
@@ -2136,6 +2136,7 @@
     <div class="footer-inner">
       <div>Beam Protocol · safe AI work between companies</div>
       <div class="footer-links">
+        <a href="/guided-evaluation.html">Guided evaluation</a>
         <a href="https://docs.beam.directory/guide/hosted-quickstart">Hosted Quickstart</a>
         <a href="https://docs.beam.directory/guide/partner-handoff">Partner Handoff</a>
         <a href="https://docs.beam.directory/guide/compatibility">Compatibility</a>


### PR DESCRIPTION
## Summary
- add a public guided evaluation page that turns the Beam proof into one buyer-facing path from landing to hosted pilot
- align the landing page, hosted-beta page, and docs home around that same proof-first flow
- ship a reusable design-partner onboarding pack and link it from the operator workflow with stage-based follow-up templates

## Verification
- npm run build
- cd docs && npm run build
- npm test

Closes #54
Closes #55