### PR TITLE
Tighten operator shortcuts and add first-party funnel analytics

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   ignoreDeadLinks: true,
   cleanUrls: true,
   lastUpdated: true,
+  head: [
+    ['script', { src: 'https://beam.directory/beam-analytics.js', defer: '' }],
+  ],
   sitemap: {
     hostname: 'https://docs.beam.directory',
   },

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -282,11 +282,56 @@ Example patch:
 
 ```json
 {
-  "status": "acknowledged"
+  "status": "acknowledged",
+  "owner": "ops@beam.directory",
+  "nextAction": "Open the latest failing trace, confirm the downstream condition, then update the runbook ticket."
 }
 ```
 
-Critical alerts from observability reuse the same notification path. The `notificationStatus` and `notificationId` fields also appear on critical alert payloads from `GET /observability/overview` and `GET /observability/alerts`.
+Notification payloads now include:
+
+- `owner`
+- `nextAction`
+
+Critical alerts from observability reuse the same notification path. The `notificationStatus`, `notificationId`, `notificationOwner`, and `notificationNextAction` fields also appear on critical alert payloads from `GET /observability/overview` and `GET /observability/alerts`.
+
+## First-party funnel analytics
+
+The public Beam surfaces send privacy-conscious, first-party funnel events through:
+
+```text
+POST /analytics/events
+GET  /admin/funnel?days=30
+```
+
+Accepted public event categories are:
+
+- `page_view`
+- `cta_click`
+- `request`
+- `demo_milestone`
+
+Example ingest payload:
+
+```json
+{
+  "sessionId": "9f0f6f4f0f2f4c2da55f2f2d9f9b1e44",
+  "pageKey": "landing",
+  "eventCategory": "cta_click",
+  "ctaKey": "landing_guided_eval_hero",
+  "targetPage": "guided_evaluation"
+}
+```
+
+Request events use the same path, but require a compatible `workflowType`. Demo milestones require a compatible `milestoneKey`.
+
+`GET /admin/funnel` returns:
+
+- milestone progression across landing, guided evaluation, hosted beta, request, and demo proof
+- entry pages
+- CTA click summaries
+- request workflow breakdown
+- recent anonymous events for instrumentation validation
 
 All hosted beta admin endpoints require an authenticated admin session and accept either:
 

--- a/docs/guide/operator-runbook.md
+++ b/docs/guide/operator-runbook.md
@@ -29,7 +29,8 @@ The shortest daily loop is:
 1. Open `Inbox`.
 2. Filter to `new`.
 3. Acknowledge or act on each signal.
-4. Jump into `Beta Requests`, `Alerts`, or the linked trace from there.
+4. Record an owner and next action on critical alerts before you leave the inbox.
+5. Jump into `Beta Requests`, `Alerts`, or the linked trace from there.
 
 ## The Default Investigation Loop
 
@@ -90,9 +91,10 @@ Symptoms:
 What to do:
 
 1. Open the dead-letter row and then the trace link for the same nonce.
-2. Read the terminal error and confirm whether it is retryable.
-3. Correct the root cause first.
-4. Requeue only after the downstream condition changed.
+2. Open the recipient agent or the linked alert context if Beam already has a critical signal for the same failure pattern.
+3. Record or confirm the owner and next action in `Inbox` if the fix is not already obvious.
+4. Correct the root cause first.
+5. Requeue only after the downstream condition changed.
 
 ## Failure Mode 4: `FORBIDDEN` Or ACL Denial
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import BetaRequestsPage from './pages/BetaRequestsPage'
 import DeadLetterPage from './pages/DeadLetterPage'
 import ErrorsPage from './pages/ErrorsPage'
 import FederationPage from './pages/FederationPage'
+import FunnelPage from './pages/FunnelPage'
 import IntentsPage from './pages/IntentsPage'
 import LoginPage from './pages/LoginPage'
 import OperatorInboxPage from './pages/OperatorInboxPage'
@@ -54,6 +55,7 @@ export default function App() {
             <Route path="agents" element={<AgentsPage />} />
             <Route path="agents/:beamId" element={<AgentProfilePage />} />
             <Route path="federation" element={<FederationPage />} />
+            <Route path="funnel" element={<FunnelPage />} />
             <Route path="errors" element={<ErrorsPage />} />
             <Route path="alerts" element={<AlertsPage />} />
             <Route path="inbox" element={<OperatorInboxPage />} />

--- a/packages/dashboard/src/components/AlertCard.tsx
+++ b/packages/dashboard/src/components/AlertCard.tsx
@@ -32,6 +32,7 @@ export default function AlertCard({
 }) {
   const visibleLinks = alert.links.slice(0, compact ? 2 : 3)
   const visibleSamples = alert.sampleTraces.slice(0, compact ? 1 : 3)
+  const primaryTrace = visibleSamples[0]
 
   return (
     <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
@@ -61,6 +62,18 @@ export default function AlertCard({
       <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">{alert.thresholdExplanation}</div>
       <div className="mt-1 text-xs font-medium text-slate-700 dark:text-slate-200">{alert.severityReason}</div>
 
+      {alert.notificationOwner || alert.notificationNextAction ? (
+        <div className="mt-4 rounded-xl border border-orange-200 bg-orange-50 px-3 py-3 text-sm text-slate-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-slate-200">
+          <div className="text-[11px] uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">Operator handoff</div>
+          <div className="mt-2 text-sm">
+            <strong>Owner:</strong> {alert.notificationOwner ?? 'unassigned'}
+          </div>
+          <div className="mt-1 text-sm">
+            <strong>Next action:</strong> {alert.notificationNextAction ?? 'Open the inbox signal and record the next recovery step.'}
+          </div>
+        </div>
+      ) : null}
+
       {visibleSamples.length > 0 ? (
         <div className="mt-4">
           <div className="text-[11px] uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">Recent traces</div>
@@ -85,14 +98,22 @@ export default function AlertCard({
         </div>
       ) : null}
 
-      {visibleLinks.length > 0 ? (
+      {visibleLinks.length > 0 || alert.notificationId || primaryTrace ? (
         <div className="mt-4 flex flex-wrap gap-2">
           {alert.notificationId ? (
             <Link
               className="rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-900"
-              to="/inbox"
+              to={`/inbox?id=${alert.notificationId}`}
             >
-              Open inbox signal
+              Open owner and next action
+            </Link>
+          ) : null}
+          {primaryTrace ? (
+            <Link
+              className="rounded-full border border-orange-200 px-3 py-1.5 text-sm text-orange-700 transition hover:border-orange-300 hover:bg-orange-50 dark:border-orange-500/30 dark:text-orange-300 dark:hover:bg-orange-500/10"
+              to={`/intents/${encodeURIComponent(primaryTrace.nonce)}?alert=${encodeURIComponent(alert.id)}`}
+            >
+              Open primary trace
             </Link>
           ) : null}
           {visibleLinks.map((link) => (

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { Activity, BellDot, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, UserPlus, X, Zap } from 'lucide-react'
+import { Activity, BellDot, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, TrendingUp, UserPlus, X, Zap } from 'lucide-react'
 import { useAdminAuth } from '../lib/admin-auth'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { path: '/audit', label: 'Audit', icon: ScrollText },
   { path: '/agents', label: 'Agents', icon: Bot },
   { path: '/federation', label: 'Federation', icon: Globe2 },
+  { path: '/funnel', label: 'Funnel', icon: TrendingUp },
   { path: '/errors', label: 'Errors', icon: TriangleAlert },
   { path: '/alerts', label: 'Alerts', icon: Shield },
   { path: '/inbox', label: 'Inbox', icon: BellDot },

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -206,6 +206,8 @@ export interface AlertItem {
   sampleTraces: AlertTraceSample[]
   notificationId?: number | null
   notificationStatus?: OperatorNotificationStatus | null
+  notificationOwner?: string | null
+  notificationNextAction?: string | null
 }
 
 export interface AlertLink {
@@ -631,6 +633,8 @@ export interface OperatorNotification {
   title: string
   message: string
   href: string | null
+  owner: string | null
+  nextAction: string | null
   status: OperatorNotificationStatus
   createdAt: string
   updatedAt: string
@@ -655,6 +659,84 @@ export interface OperatorNotificationListResponse {
 export interface OperatorNotificationUpdateResponse {
   ok: boolean
   notification: OperatorNotification
+}
+
+export interface FunnelEntryPage {
+  pageKey: string
+  events: number
+  sessions: number
+}
+
+export interface FunnelCtaClick {
+  ctaKey: string
+  targetPage: string | null
+  events: number
+  sessions: number
+}
+
+export interface FunnelMilestone {
+  key: string
+  label: string
+  sessions: number
+  events: number
+  conversionFromPrevious: number | null
+  conversionFromLanding: number | null
+}
+
+export interface FunnelTimelinePoint {
+  day: string
+  landingSessions: number
+  guidedSessions: number
+  requestSessions: number
+  demoSessions: number
+}
+
+export interface FunnelRecentEvent {
+  id: number
+  sessionId: string
+  origin: string
+  pageKey: string
+  eventCategory: string
+  ctaKey: string | null
+  targetPage: string | null
+  workflowType: string | null
+  milestoneKey: string | null
+  createdAt: string
+}
+
+export interface FunnelAnalyticsResponse {
+  days: number
+  generatedAt: string
+  summary: {
+    anonymousSessions: number
+    pageViews: number
+    ctaClicks: number
+    requestEvents: number
+    demoEvents: number
+    landingSessions: number
+    guidedSessions: number
+    hostedBetaSessions: number
+    requestSessions: number
+    demoSessions: number
+    landingToGuidedRate: number | null
+    landingToRequestRate: number | null
+    requestToDemoRate: number | null
+  }
+  milestones: FunnelMilestone[]
+  entryPages: FunnelEntryPage[]
+  ctaClicks: FunnelCtaClick[]
+  demoMilestones: Array<{
+    milestoneKey: string
+    events: number
+    sessions: number
+  }>
+  workflows: Array<{
+    workflowType: string
+    events: number
+    sessions: number
+  }>
+  timeline: FunnelTimelinePoint[]
+  recentEvents: FunnelRecentEvent[]
 }
 
 export interface IntentFeedMessage {
@@ -1012,11 +1094,14 @@ export const directoryApi = {
     hours: params?.hours,
   })}`, undefined, { admin: true }),
   updateOperatorNotification: (id: number, input: {
-    status: OperatorNotificationStatus
+    status?: OperatorNotificationStatus
+    owner?: string | null
+    nextAction?: string | null
   }) => request<OperatorNotificationUpdateResponse>(`/admin/operator-notifications/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(input),
   }, { admin: true }),
+  getFunnelAnalytics: (days = 30) => request<FunnelAnalyticsResponse>(`/admin/funnel?days=${days}`, undefined, { admin: true }),
   createOrg: (input: OrgRegistrationInput) => request<OrgRegistrationResponse>('/orgs', {
     method: 'POST',
     body: JSON.stringify(input),

--- a/packages/dashboard/src/pages/AlertsPage.tsx
+++ b/packages/dashboard/src/pages/AlertsPage.tsx
@@ -147,7 +147,8 @@ export default function AlertsPage() {
       <div className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950/80 dark:text-slate-300">
         <div className="font-medium text-slate-900 dark:text-slate-100">Operator flow</div>
         <div className="mt-1">
-          Alert cards now carry threshold reasoning plus investigation links into filtered intents, trace detail, and audit history.
+          Alert cards now carry threshold reasoning, the current owner and next action when a critical signal is already triaged,
+          plus direct links into the most relevant trace, inbox signal, and audit context.
           Exports are read-only snapshots. Prune is irreversible, so the dashboard requires an admin preview and typed confirmation phrase first.
         </div>
         <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">

--- a/packages/dashboard/src/pages/DeadLetterPage.tsx
+++ b/packages/dashboard/src/pages/DeadLetterPage.tsx
@@ -5,6 +5,8 @@ import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Ob
 import { formatDateTime, formatNumber } from '../lib/utils'
 import { formatIntentLifecycleLabel } from '../lib/intent-lifecycle'
 
+const RUNBOOK_URL = 'https://docs.beam.directory/guide/operator-runbook#dead-letters'
+
 function formatBusTimestamp(value?: number | null): string {
   if (value == null) {
     return '—'
@@ -20,6 +22,24 @@ function previewPayload(payload: Record<string, unknown>): string {
   }
 
   return `${serialized.slice(0, 117)}…`
+}
+
+function getRecoveryGuidance(message: DeadLetterMessage): string {
+  const error = (message.error ?? '').toLowerCase()
+
+  if (error.includes('offline')) {
+    return 'Confirm the recipient is reachable again, then requeue the same nonce.'
+  }
+
+  if (error.includes('rate')) {
+    return 'Wait for downstream pressure to clear, confirm the recipient can accept traffic, then requeue.'
+  }
+
+  if (error.includes('forbidden') || error.includes('acl')) {
+    return 'Inspect the trace and ACL or auth configuration before retrying this nonce.'
+  }
+
+  return 'Open the trace first, confirm why the downstream route failed, then requeue only after the condition is fixed.'
 }
 
 export default function DeadLetterPage() {
@@ -113,6 +133,18 @@ export default function DeadLetterPage() {
         <MetricCard label="Max retry count" value={loading ? '—' : formatNumber(summary.maxRetryCount)} />
       </section>
 
+      <section className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950/80 dark:text-slate-300">
+        <div className="font-medium text-slate-900 dark:text-slate-100">Recovery sequence</div>
+        <div className="mt-1">
+          Dead letters are terminal queue outcomes, not immediate retry buttons. Open the trace, confirm the affected recipient,
+          check whether the failure is still real, then requeue only after someone owns the recovery path.
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link className="btn-secondary" to="/alerts">Open alerts</Link>
+          <a className="btn-secondary" href={RUNBOOK_URL} rel="noreferrer" target="_blank">Open dead-letter runbook</a>
+        </div>
+      </section>
+
       <section className="panel space-y-4">
         <div className="panel-title">Filters</div>
         <div className="grid gap-3 md:grid-cols-4">
@@ -170,6 +202,7 @@ export default function DeadLetterPage() {
                   <th className="table-head">Retries</th>
                   <th className="table-head">Error</th>
                   <th className="table-head">Failed</th>
+                  <th className="table-head">Next action</th>
                   <th className="table-head">Payload</th>
                   <th className="table-head">Action</th>
                 </tr>
@@ -198,12 +231,21 @@ export default function DeadLetterPage() {
                       <div>{formatBusTimestamp(message.failed_at)}</div>
                       <div className="text-xs text-slate-500 dark:text-slate-400">Created {formatBusTimestamp(message.created_at)}</div>
                     </td>
+                    <td className="table-cell text-slate-600 dark:text-slate-300">
+                      {getRecoveryGuidance(message)}
+                    </td>
                     <td className="table-cell font-mono text-xs text-slate-500 dark:text-slate-400">{previewPayload(message.payload)}</td>
                     <td className="table-cell">
                       <div className="flex flex-wrap gap-2">
                         <Link className="btn-secondary" to={`/intents/${encodeURIComponent(message.nonce)}`}>
                           Trace
                         </Link>
+                        <Link className="btn-secondary" to={`/agents/${encodeURIComponent(message.recipient)}`}>
+                          Recipient
+                        </Link>
+                        <a className="btn-secondary" href={RUNBOOK_URL} rel="noreferrer" target="_blank">
+                          Runbook
+                        </a>
                         <button
                           className="btn-secondary"
                           disabled={requeueingId === message.id}

--- a/packages/dashboard/src/pages/FunnelPage.tsx
+++ b/packages/dashboard/src/pages/FunnelPage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from 'react'
+import { ApiError, directoryApi, type FunnelAnalyticsResponse } from '../lib/api'
+import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import { formatDateTime, formatNumber, formatPercent } from '../lib/utils'
+
+const WINDOW_OPTIONS = [7, 14, 30, 90]
+
+export default function FunnelPage() {
+  const [days, setDays] = useState(30)
+  const [data, setData] = useState<FunnelAnalyticsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function load(currentDays: number) {
+    try {
+      setLoading(true)
+      const response = await directoryApi.getFunnelAnalytics(currentDays)
+      setData(response)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load funnel analytics')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load(days)
+  }, [days])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Funnel"
+        description="First-party buyer funnel analytics for the public landing, hosted-beta intake, and demo milestones."
+        actions={(
+          <select className="input-field w-auto min-w-28" value={days} onChange={(event) => setDays(Number(event.target.value))}>
+            {WINDOW_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}d
+              </option>
+            ))}
+          </select>
+        )}
+      />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950/80 dark:text-slate-300">
+        <div className="font-medium text-slate-900 dark:text-slate-100">What this measures</div>
+        <div className="mt-1">
+          Beam records only first-party funnel events with an anonymous session id. No third-party scripts, no ad profiling,
+          and no form contents are stored here. The goal is simple: see whether people move from landing to pilot request and proof.
+        </div>
+        <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Generated {formatDateTime(data?.generatedAt)} for the last {days} days.
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+        <MetricCard label="Anonymous sessions" value={loading ? '—' : formatNumber(data?.summary.anonymousSessions ?? 0)} />
+        <MetricCard label="Landing sessions" value={loading ? '—' : formatNumber(data?.summary.landingSessions ?? 0)} />
+        <MetricCard label="Guided eval" value={loading ? '—' : formatNumber(data?.summary.guidedSessions ?? 0)} tone={(data?.summary.guidedSessions ?? 0) > 0 ? 'success' : 'default'} />
+        <MetricCard label="Hosted beta views" value={loading ? '—' : formatNumber(data?.summary.hostedBetaSessions ?? 0)} />
+        <MetricCard label="Requests" value={loading ? '—' : formatNumber(data?.summary.requestSessions ?? 0)} tone={(data?.summary.requestSessions ?? 0) > 0 ? 'warning' : 'default'} />
+        <MetricCard label="Demo proof" value={loading ? '—' : formatNumber(data?.summary.demoSessions ?? 0)} tone={(data?.summary.demoSessions ?? 0) > 0 ? 'success' : 'default'} />
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <MetricCard label="Landing → guided eval" value={formatPercent(data?.summary.landingToGuidedRate ?? null, 0)} hint="Unique-session conversion from landing view to guided evaluation." />
+        <MetricCard label="Landing → request" value={formatPercent(data?.summary.landingToRequestRate ?? null, 0)} hint="Unique-session conversion from landing view to hosted-beta request." />
+        <MetricCard label="Request → demo proof" value={formatPercent(data?.summary.requestToDemoRate ?? null, 0)} hint="How many request sessions also reached a demo milestone in the same window." />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel overflow-hidden p-0">
+          <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <div className="panel-title">Milestone progression</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">This is the go or no-go read for the public funnel.</p>
+          </div>
+
+          {loading ? (
+            <div className="p-5">
+              <EmptyPanel label="Loading funnel milestones…" />
+            </div>
+          ) : !data || data.milestones.length === 0 ? (
+            <div className="p-5">
+              <EmptyPanel label="No funnel milestones were recorded in the selected window." />
+            </div>
+          ) : (
+            <div className="divide-y divide-slate-200 dark:divide-slate-800">
+              {data.milestones.map((milestone) => (
+                <div key={milestone.key} className="px-5 py-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{milestone.label}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{milestone.events} event(s)</div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-lg font-semibold text-slate-900 dark:text-slate-100">{formatNumber(milestone.sessions)}</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">unique sessions</div>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                    <StatusPill label={`from previous ${formatPercent(milestone.conversionFromPrevious ?? null, 0)}`} tone="default" />
+                    <StatusPill label={`from landing ${formatPercent(milestone.conversionFromLanding ?? null, 0)}`} tone="warning" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-6">
+          <div className="panel">
+            <div className="panel-title">Top entry pages</div>
+            <div className="mt-4 space-y-3">
+              {loading ? (
+                <EmptyPanel label="Loading entry pages…" />
+              ) : !data || data.entryPages.length === 0 ? (
+                <EmptyPanel label="No page-view data was recorded." />
+              ) : (
+                data.entryPages.slice(0, 6).map((entry) => (
+                  <div key={entry.pageKey} className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 text-sm dark:border-slate-800">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">{entry.pageKey}</div>
+                    <div className="text-right text-slate-500 dark:text-slate-400">
+                      <div>{formatNumber(entry.sessions)} sessions</div>
+                      <div>{formatNumber(entry.events)} views</div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="panel">
+            <div className="panel-title">CTA clicks</div>
+            <div className="mt-4 space-y-3">
+              {loading ? (
+                <EmptyPanel label="Loading CTA clicks…" />
+              ) : !data || data.ctaClicks.length === 0 ? (
+                <EmptyPanel label="No tracked CTA clicks were recorded." />
+              ) : (
+                data.ctaClicks.slice(0, 8).map((entry) => (
+                  <div key={entry.ctaKey} className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 text-sm dark:border-slate-800">
+                    <div>
+                      <div className="font-medium text-slate-900 dark:text-slate-100">{entry.ctaKey}</div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">target {entry.targetPage ?? '—'}</div>
+                    </div>
+                    <div className="text-right text-slate-500 dark:text-slate-400">
+                      <div>{formatNumber(entry.sessions)} sessions</div>
+                      <div>{formatNumber(entry.events)} clicks</div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1fr,1fr]">
+        <div className="panel">
+          <div className="panel-title">Demo milestones</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading demo milestones…" />
+            ) : !data || data.demoMilestones.length === 0 ? (
+              <EmptyPanel label="No demo milestones were recorded." />
+            ) : (
+              data.demoMilestones.map((entry) => (
+                <div key={entry.milestoneKey} className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 text-sm dark:border-slate-800">
+                  <div className="font-medium text-slate-900 dark:text-slate-100">{entry.milestoneKey}</div>
+                  <div className="text-right text-slate-500 dark:text-slate-400">
+                    <div>{formatNumber(entry.sessions)} sessions</div>
+                    <div>{formatNumber(entry.events)} events</div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Request workflows</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading request workflows…" />
+            ) : !data || data.workflows.length === 0 ? (
+              <EmptyPanel label="No hosted-beta requests were recorded." />
+            ) : (
+              data.workflows.map((entry) => (
+                <div key={entry.workflowType} className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 px-3 py-3 text-sm dark:border-slate-800">
+                  <div className="font-medium text-slate-900 dark:text-slate-100">{entry.workflowType}</div>
+                  <div className="text-right text-slate-500 dark:text-slate-400">
+                    <div>{formatNumber(entry.sessions)} sessions</div>
+                    <div>{formatNumber(entry.events)} requests</div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="panel overflow-hidden p-0">
+        <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+          <div className="panel-title">Recent tracked events</div>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Anonymous only. Useful for validating that the public surfaces are instrumented correctly.</p>
+        </div>
+        {loading ? (
+          <div className="p-5">
+            <EmptyPanel label="Loading recent events…" />
+          </div>
+        ) : !data || data.recentEvents.length === 0 ? (
+          <div className="p-5">
+            <EmptyPanel label="No recent events were recorded." />
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 dark:bg-slate-950">
+                <tr>
+                  <th className="table-head">Time</th>
+                  <th className="table-head">Page</th>
+                  <th className="table-head">Category</th>
+                  <th className="table-head">Key</th>
+                  <th className="table-head">Origin</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.recentEvents.map((entry) => (
+                  <tr key={entry.id} className="border-t border-slate-200 dark:border-slate-800">
+                    <td className="table-cell">{formatDateTime(entry.createdAt)}</td>
+                    <td className="table-cell">{entry.pageKey}</td>
+                    <td className="table-cell">{entry.eventCategory}</td>
+                    <td className="table-cell">{entry.ctaKey ?? entry.milestoneKey ?? entry.workflowType ?? 'page_view'}</td>
+                    <td className="table-cell">{entry.origin}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/packages/dashboard/src/pages/OperatorInboxPage.tsx
+++ b/packages/dashboard/src/pages/OperatorInboxPage.tsx
@@ -1,7 +1,8 @@
-import { BellDot, RefreshCw, Search } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { BellDot, RefreshCw, Search, Save } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import { useAdminAuth } from '../lib/admin-auth'
 import {
   ApiError,
   directoryApi,
@@ -25,6 +26,7 @@ const SOURCE_OPTIONS: Array<{ value: '' | OperatorNotificationSource; label: str
 ]
 
 export default function OperatorInboxPage() {
+  const { session } = useAdminAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const [notifications, setNotifications] = useState<OperatorNotification[]>([])
   const [total, setTotal] = useState(0)
@@ -41,6 +43,17 @@ export default function OperatorInboxPage() {
   const query = searchParams.get('q') ?? ''
   const status = (searchParams.get('status') ?? '') as '' | OperatorNotificationStatus
   const source = (searchParams.get('source') ?? '') as '' | OperatorNotificationSource
+  const selectedId = Number.parseInt(searchParams.get('id') ?? '', 10)
+  const canEdit = session?.role === 'admin' || session?.role === 'operator'
+
+  const selectedNotification = useMemo(
+    () => notifications.find((entry) => entry.id === selectedId) ?? notifications[0] ?? null,
+    [notifications, selectedId],
+  )
+
+  const [draftStatus, setDraftStatus] = useState<OperatorNotificationStatus>('new')
+  const [draftOwner, setDraftOwner] = useState('')
+  const [draftNextAction, setDraftNextAction] = useState('')
 
   function updateSearchParam(key: string, value: string) {
     const next = new URLSearchParams(searchParams)
@@ -51,6 +64,31 @@ export default function OperatorInboxPage() {
     }
     setSearchParams(next, { replace: true })
   }
+
+  useEffect(() => {
+    if (!selectedNotification) {
+      return
+    }
+
+    if (!selectedId || selectedId !== selectedNotification.id) {
+      const next = new URLSearchParams(searchParams)
+      next.set('id', String(selectedNotification.id))
+      setSearchParams(next, { replace: true })
+    }
+  }, [searchParams, selectedId, selectedNotification, setSearchParams])
+
+  useEffect(() => {
+    if (!selectedNotification) {
+      setDraftStatus('new')
+      setDraftOwner('')
+      setDraftNextAction('')
+      return
+    }
+
+    setDraftStatus(selectedNotification.status)
+    setDraftOwner(selectedNotification.owner ?? '')
+    setDraftNextAction(selectedNotification.nextAction ?? '')
+  }, [selectedNotification])
 
   async function load() {
     try {
@@ -76,15 +114,23 @@ export default function OperatorInboxPage() {
     void load()
   }, [query, source, status])
 
-  async function updateSignal(id: number, nextStatus: OperatorNotificationStatus) {
+  async function saveNotification(
+    id: number,
+    input: {
+      status?: OperatorNotificationStatus
+      owner?: string | null
+      nextAction?: string | null
+    },
+    successMessage: string,
+  ) {
     try {
       setSavingId(id)
       setNotice(null)
-      const response = await directoryApi.updateOperatorNotification(id, { status: nextStatus })
+      const response = await directoryApi.updateOperatorNotification(id, input)
       setNotifications((current) => current.map((entry) => (
         entry.id === response.notification.id ? response.notification : entry
       )))
-      setNotice(`Signal marked ${nextStatus}.`)
+      setNotice(successMessage)
       await load()
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to update operator signal')
@@ -93,11 +139,23 @@ export default function OperatorInboxPage() {
     }
   }
 
+  async function saveSelectedNotification() {
+    if (!selectedNotification || !canEdit || selectedNotification.sourceType !== 'critical_alert') {
+      return
+    }
+
+    await saveNotification(selectedNotification.id, {
+      status: draftStatus,
+      owner: draftOwner || null,
+      nextAction: draftNextAction || null,
+    }, 'Critical alert handoff saved.')
+  }
+
   return (
     <div className="space-y-6">
       <PageHeader
         title="Operator Inbox"
-        description="New hosted beta requests and critical demo or evaluation failures land here until someone acknowledges or acts on them."
+        description="Critical alerts and hosted beta requests land here until someone owns them and records the next action."
         actions={(
           <button className="btn-secondary" onClick={() => void load()} type="button">
             <RefreshCw size={16} />
@@ -122,7 +180,7 @@ export default function OperatorInboxPage() {
             <Search size={16} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
             <input
               className="input-field pl-10"
-              placeholder="Search title, message, alert id, actor"
+              placeholder="Search title, message, owner, actor, alert id"
               value={query}
               onChange={(event) => updateSearchParam('q', event.target.value)}
             />
@@ -156,94 +214,211 @@ export default function OperatorInboxPage() {
         </div>
       ) : null}
 
-      <section className="panel overflow-hidden p-0">
-        <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
-          <div className="panel-title">Signals</div>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{total} signal(s) match the current filters.</p>
+      <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+        <div className="panel overflow-hidden p-0">
+          <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <div className="panel-title">Signals</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{total} signal(s) match the current filters.</p>
+          </div>
+
+          {loading ? (
+            <div className="p-5 text-sm text-slate-500 dark:text-slate-400">Loading operator signals…</div>
+          ) : notifications.length === 0 ? (
+            <div className="p-5">
+              <EmptyPanel label="No operator signals matched the current filters." />
+            </div>
+          ) : (
+            <div className="divide-y divide-slate-200 dark:divide-slate-800">
+              {notifications.map((notification) => {
+                const active = selectedNotification?.id === notification.id
+
+                return (
+                  <div
+                    key={notification.id}
+                    className={`flex w-full cursor-pointer flex-col gap-3 px-5 py-4 text-left transition ${active ? 'bg-orange-50 dark:bg-orange-500/10' : 'hover:bg-slate-50 dark:hover:bg-slate-900'}`}
+                    onClick={() => updateSearchParam('id', String(notification.id))}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault()
+                        updateSearchParam('id', String(notification.id))
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill label={notification.status} tone={notificationTone(notification.status)} />
+                      <StatusPill label={notification.sourceType === 'beta_request' ? 'beta request' : 'critical failure'} tone={notification.sourceType === 'critical_alert' ? 'critical' : 'warning'} />
+                      <StatusPill label={notification.severity} tone={severityTone(notification.severity)} />
+                      <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(notification.createdAt)}</span>
+                    </div>
+
+                    <div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{notification.title}</div>
+                      <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{notification.message}</div>
+                    </div>
+
+                    <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2 lg:grid-cols-4">
+                      <span>Owner: {notification.owner ?? 'unassigned'}</span>
+                      <span>Updated {formatRelativeTime(notification.updatedAt)}</span>
+                      <span>Actor: {notification.actor ?? '—'}</span>
+                      <span>Next: {notification.nextAction ?? 'not recorded'}</span>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2" onClick={(event) => event.stopPropagation()}>
+                      {notification.status !== 'acknowledged' ? (
+                        <button
+                          className="btn-secondary"
+                          disabled={savingId === notification.id}
+                          onClick={() => void saveNotification(notification.id, { status: 'acknowledged' }, 'Signal marked acknowledged.')}
+                          type="button"
+                        >
+                          <BellDot size={16} />
+                          <span>{savingId === notification.id ? 'Saving…' : 'Acknowledge'}</span>
+                        </button>
+                      ) : null}
+                      {notification.status !== 'acted' ? (
+                        <button
+                          className="btn-secondary"
+                          disabled={savingId === notification.id}
+                          onClick={() => void saveNotification(notification.id, { status: 'acted' }, 'Signal marked acted.')}
+                          type="button"
+                        >
+                          <BellDot size={16} />
+                          <span>{savingId === notification.id ? 'Saving…' : 'Mark acted'}</span>
+                        </button>
+                      ) : null}
+                      {notification.status !== 'new' ? (
+                        <button
+                          className="btn-secondary"
+                          disabled={savingId === notification.id}
+                          onClick={() => void saveNotification(notification.id, { status: 'new' }, 'Signal reset to new.')}
+                          type="button"
+                        >
+                          <BellDot size={16} />
+                          <span>{savingId === notification.id ? 'Saving…' : 'Reset to new'}</span>
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
         </div>
 
-        {loading ? (
-          <div className="p-5 text-sm text-slate-500 dark:text-slate-400">Loading operator signals…</div>
-        ) : notifications.length === 0 ? (
-          <div className="p-5">
-            <EmptyPanel label="No operator signals matched the current filters." />
-          </div>
-        ) : (
-          <div className="divide-y divide-slate-200 dark:divide-slate-800">
-            {notifications.map((notification) => (
-              <div key={notification.id} className="space-y-4 px-5 py-4">
-                <div className="flex flex-wrap items-center gap-2">
-                  <StatusPill label={notification.status} tone={notificationTone(notification.status)} />
-                  <StatusPill label={notification.sourceType === 'beta_request' ? 'beta request' : 'critical failure'} tone={notification.sourceType === 'critical_alert' ? 'critical' : 'warning'} />
-                  <StatusPill label={notification.severity} tone={severityTone(notification.severity)} />
-                  <span className="text-xs text-slate-500 dark:text-slate-400">{formatDateTime(notification.createdAt)}</span>
-                </div>
-
-                <div>
-                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{notification.title}</div>
-                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{notification.message}</div>
-                </div>
-
-                <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2 lg:grid-cols-4">
-                  <span>Updated {formatRelativeTime(notification.updatedAt)}</span>
-                  <span>Acknowledged: {formatDateTime(notification.acknowledgedAt)}</span>
-                  <span>Acted: {formatDateTime(notification.actedAt)}</span>
-                  <span>Actor: {notification.actor ?? '—'}</span>
-                </div>
-
-                <div className="flex flex-wrap gap-2">
-                  {notification.status !== 'acknowledged' ? (
-                    <button
-                      className="btn-secondary"
-                      disabled={savingId === notification.id}
-                      onClick={() => void updateSignal(notification.id, 'acknowledged')}
-                      type="button"
-                    >
-                      <BellDot size={16} />
-                      <span>{savingId === notification.id ? 'Saving…' : 'Acknowledge'}</span>
-                    </button>
-                  ) : null}
-                  {notification.status !== 'acted' ? (
-                    <button
-                      className="btn-secondary"
-                      disabled={savingId === notification.id}
-                      onClick={() => void updateSignal(notification.id, 'acted')}
-                      type="button"
-                    >
-                      <BellDot size={16} />
-                      <span>{savingId === notification.id ? 'Saving…' : 'Mark acted'}</span>
-                    </button>
-                  ) : null}
-                  {notification.status !== 'new' ? (
-                    <button
-                      className="btn-secondary"
-                      disabled={savingId === notification.id}
-                      onClick={() => void updateSignal(notification.id, 'new')}
-                      type="button"
-                    >
-                      <BellDot size={16} />
-                      <span>{savingId === notification.id ? 'Saving…' : 'Reset to new'}</span>
-                    </button>
-                  ) : null}
-                  {notification.href ? (
-                    <Link className="btn-secondary" to={notification.href}>
-                      Open context
-                    </Link>
-                  ) : notification.betaRequestId ? (
-                    <Link className="btn-secondary" to={`/beta-requests?id=${notification.betaRequestId}`}>
-                      Open beta request
-                    </Link>
-                  ) : (
-                    <Link className="btn-secondary" to="/alerts">
-                      Open alerts
-                    </Link>
-                  )}
-                </div>
+        <div className="panel">
+          <div className="panel-title">Selected Signal</div>
+          {!selectedNotification ? (
+            <div className="mt-4">
+              <EmptyPanel label="Select a signal to assign an owner, inspect context, and record the next action." />
+            </div>
+          ) : (
+            <div className="mt-4 space-y-5">
+              <div className="space-y-3">
+                <InfoRow label="Title" value={selectedNotification.title} />
+                <InfoRow label="Source" value={selectedNotification.sourceType === 'beta_request' ? 'Hosted beta request' : 'Critical alert'} />
+                <InfoRow label="Severity" value={selectedNotification.severity} />
+                <InfoRow label="Status" value={selectedNotification.status} />
+                <InfoRow label="Owner" value={selectedNotification.owner ?? 'unassigned'} />
+                <InfoRow label="Updated" value={formatDateTime(selectedNotification.updatedAt)} />
+                <InfoRow label="Acknowledged" value={formatDateTime(selectedNotification.acknowledgedAt)} />
+                <InfoRow label="Acted" value={formatDateTime(selectedNotification.actedAt)} />
               </div>
-            ))}
-          </div>
-        )}
+
+              <div className="rounded-xl bg-slate-50 px-4 py-4 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                <div className="font-medium text-slate-900 dark:text-slate-100">Current next action</div>
+                <div className="mt-2">{selectedNotification.nextAction ?? 'No next action has been recorded yet.'}</div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {selectedNotification.href ? (
+                  <Link className="btn-secondary" to={selectedNotification.href}>
+                    Open linked context
+                  </Link>
+                ) : null}
+                {selectedNotification.betaRequestId ? (
+                  <Link className="btn-secondary" to={`/beta-requests?id=${selectedNotification.betaRequestId}`}>
+                    Open beta request
+                  </Link>
+                ) : (
+                  <Link className="btn-secondary" to="/alerts">
+                    Open alerts
+                  </Link>
+                )}
+              </div>
+
+              {selectedNotification.sourceType === 'critical_alert' ? (
+                <div className="space-y-4 rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="font-medium text-slate-900 dark:text-slate-100">Ownership and recovery</div>
+                  <div className="grid gap-3">
+                    <select className="input-field" value={draftStatus} onChange={(event) => setDraftStatus(event.target.value as OperatorNotificationStatus)}>
+                      {STATUS_OPTIONS.filter((option) => option.value).map((option) => (
+                        <option key={option.label} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      className="input-field"
+                      placeholder="Owner"
+                      value={draftOwner}
+                      onChange={(event) => setDraftOwner(event.target.value)}
+                    />
+                    <textarea
+                      className="input-field min-h-28"
+                      placeholder="Next action"
+                      value={draftNextAction}
+                      onChange={(event) => setDraftNextAction(event.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      className="btn-secondary"
+                      disabled={!canEdit || savingId === selectedNotification.id}
+                      onClick={() => void saveSelectedNotification()}
+                      type="button"
+                    >
+                      <Save size={16} />
+                      <span>{savingId === selectedNotification.id ? 'Saving…' : 'Save handoff'}</span>
+                    </button>
+                    <a className="btn-secondary" href="https://docs.beam.directory/guide/operator-runbook#alerts" rel="noreferrer" target="_blank">
+                      Open alert runbook
+                    </a>
+                  </div>
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-slate-200 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                  Beta-request ownership lives in the beta request queue so the workflow stage, owner, and next action stay in one place.
+                  <div className="mt-3">
+                    <Link className="btn-secondary" to={`/beta-requests?id=${selectedNotification.betaRequestId ?? ''}`}>
+                      Open beta request queue
+                    </Link>
+                  </div>
+                </div>
+              )}
+
+              {selectedNotification.details ? (
+                <div>
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Signal details</div>
+                  <pre className="mt-3 overflow-x-auto rounded-xl bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                    {JSON.stringify(selectedNotification.details, null, 2)}
+                  </pre>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
       </section>
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-slate-200 pb-3 text-sm last:border-b-0 last:pb-0 dark:border-slate-800">
+      <div className="text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="text-right text-slate-900 dark:text-slate-100">{value}</div>
     </div>
   )
 }

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -288,10 +288,24 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.ok(notificationColumns.some((column) => column.name === 'source_type'))
     assert.ok(notificationColumns.some((column) => column.name === 'source_key'))
     assert.ok(notificationColumns.some((column) => column.name === 'status'))
+    assert.ok(notificationColumns.some((column) => column.name === 'owner'))
+    assert.ok(notificationColumns.some((column) => column.name === 'next_action'))
 
     const notificationIndexes = db.prepare("PRAGMA index_list('operator_notifications')").all() as Array<{ name: string }>
     assert.ok(notificationIndexes.some((index) => index.name === 'idx_operator_notifications_status'))
     assert.ok(notificationIndexes.some((index) => index.name === 'idx_operator_notifications_source'))
+    assert.ok(notificationIndexes.some((index) => index.name === 'idx_operator_notifications_owner'))
+
+    const funnelColumns = db.prepare('PRAGMA table_info(funnel_events)').all() as Array<{ name: string }>
+    assert.ok(funnelColumns.some((column) => column.name === 'session_id'))
+    assert.ok(funnelColumns.some((column) => column.name === 'page_key'))
+    assert.ok(funnelColumns.some((column) => column.name === 'event_category'))
+    assert.ok(funnelColumns.some((column) => column.name === 'milestone_key'))
+
+    const funnelIndexes = db.prepare("PRAGMA index_list('funnel_events')").all() as Array<{ name: string }>
+    assert.ok(funnelIndexes.some((index) => index.name === 'idx_funnel_events_created_at'))
+    assert.ok(funnelIndexes.some((index) => index.name === 'idx_funnel_events_category'))
+    assert.ok(funnelIndexes.some((index) => index.name === 'idx_funnel_events_session'))
   } finally {
     db.close()
     rmSync(root, { force: true, recursive: true })

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -12,6 +12,7 @@ import type {
   DirectoryRoleRow,
   DnsCacheRow,
   FederatedAgentRow,
+  FunnelEventRow,
   FederatedTrustRow,
   IntentFrame,
   IntentLogRow,
@@ -182,6 +183,8 @@ function initSchema(db: DB): void {
       title TEXT NOT NULL,
       message TEXT NOT NULL,
       href TEXT,
+      owner TEXT,
+      next_action TEXT,
       status TEXT NOT NULL DEFAULT 'new' CHECK(status IN ('new', 'acknowledged', 'acted')),
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -199,6 +202,28 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_operator_notifications_beta_request
       ON operator_notifications(beta_request_id, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS funnel_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      origin TEXT NOT NULL,
+      page_key TEXT NOT NULL,
+      event_category TEXT NOT NULL CHECK(event_category IN ('page_view', 'cta_click', 'request', 'demo_milestone')),
+      cta_key TEXT,
+      target_page TEXT,
+      workflow_type TEXT,
+      milestone_key TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_created_at
+      ON funnel_events(created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_category
+      ON funnel_events(event_category, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_funnel_events_session
+      ON funnel_events(session_id, created_at DESC);
 
     CREATE TABLE IF NOT EXISTS intent_log (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -524,6 +549,24 @@ function initSchema(db: DB): void {
   db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_status ON operator_notifications(status, updated_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_source ON operator_notifications(source_type, created_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_beta_request ON operator_notifications(beta_request_id, created_at DESC)')
+  ensureColumn(db, 'operator_notifications', 'owner', 'TEXT')
+  ensureColumn(db, 'operator_notifications', 'next_action', 'TEXT')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_operator_notifications_owner ON operator_notifications(owner, updated_at DESC)')
+  db.exec(`CREATE TABLE IF NOT EXISTS funnel_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    origin TEXT NOT NULL,
+    page_key TEXT NOT NULL,
+    event_category TEXT NOT NULL CHECK(event_category IN ('page_view', 'cta_click', 'request', 'demo_milestone')),
+    cta_key TEXT,
+    target_page TEXT,
+    workflow_type TEXT,
+    milestone_key TEXT,
+    created_at TEXT NOT NULL
+  )`)
+  db.exec('CREATE INDEX IF NOT EXISTS idx_funnel_events_created_at ON funnel_events(created_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_funnel_events_category ON funnel_events(event_category, created_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_funnel_events_session ON funnel_events(session_id, created_at DESC)')
   ensureIntentLogSchema(db)
   ensureColumn(db, 'intent_trace_events', 'nonce', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_intent_trace_nonce ON intent_trace_events(nonce, timestamp ASC, id ASC)')
@@ -2245,10 +2288,12 @@ export function listOperatorNotifications(
       title LIKE ?
       OR message LIKE ?
       OR COALESCE(actor, '') LIKE ?
+      OR COALESCE(owner, '') LIKE ?
+      OR COALESCE(next_action, '') LIKE ?
       OR COALESCE(alert_id, '') LIKE ?
       OR COALESCE(source_key, '') LIKE ?
     )`)
-    params.push(needle, needle, needle, needle, needle)
+    params.push(needle, needle, needle, needle, needle, needle, needle)
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
@@ -2304,6 +2349,9 @@ export function upsertOperatorNotification(
     title: string
     message: string
     href?: string | null
+    owner?: string | null
+    nextAction?: string | null
+    defaultNextAction?: string | null
     details?: unknown
     resetStatus?: boolean
   },
@@ -2327,6 +2375,8 @@ export function upsertOperatorNotification(
           title = ?,
           message = ?,
           href = ?,
+          owner = ?,
+          next_action = ?,
           status = ?,
           updated_at = ?,
           acknowledged_at = ?,
@@ -2342,6 +2392,8 @@ export function upsertOperatorNotification(
       input.title,
       input.message,
       input.href ?? existing.href,
+      input.owner ?? existing.owner,
+      input.nextAction ?? existing.next_action ?? input.defaultNextAction ?? null,
       nextStatus,
       now,
       acknowledgedAt,
@@ -2364,6 +2416,8 @@ export function upsertOperatorNotification(
       title,
       message,
       href,
+      owner,
+      next_action,
       status,
       created_at,
       updated_at,
@@ -2372,7 +2426,7 @@ export function upsertOperatorNotification(
       actor,
       details_json
     )
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'new', ?, ?, NULL, NULL, NULL, ?)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'new', ?, ?, NULL, NULL, NULL, ?)
   `).run(
     input.sourceType,
     input.sourceKey,
@@ -2382,6 +2436,8 @@ export function upsertOperatorNotification(
     input.title,
     input.message,
     input.href ?? null,
+    input.owner ?? null,
+    input.nextAction ?? input.defaultNextAction ?? null,
     now,
     now,
     details,
@@ -2394,8 +2450,10 @@ export function updateOperatorNotificationStatus(
   db: DB,
   input: {
     id: number
-    status: OperatorNotificationRow['status']
+    status?: OperatorNotificationRow['status']
     actor: string
+    owner?: string | null
+    nextAction?: string | null
   },
 ): OperatorNotificationRow | null {
   const existing = getOperatorNotificationById(db, input.id)
@@ -2404,25 +2462,111 @@ export function updateOperatorNotificationStatus(
   }
 
   const now = nowIso()
-  const acknowledgedAt = input.status === 'new'
+  const nextStatus = input.status ?? existing.status
+  const acknowledgedAt = nextStatus === 'new'
     ? null
-    : input.status === 'acknowledged'
+    : nextStatus === 'acknowledged'
       ? (existing.acknowledged_at ?? now)
       : (existing.acknowledged_at ?? now)
-  const actedAt = input.status === 'acted' ? now : null
-  const actor = input.status === 'new' ? null : input.actor
+  const actedAt = nextStatus === 'acted' ? now : null
+  const actor = nextStatus === 'new' ? null : input.actor
+  const owner = input.owner === undefined ? existing.owner : input.owner
+  const nextAction = input.nextAction === undefined ? existing.next_action : input.nextAction
 
   db.prepare(`
     UPDATE operator_notifications
     SET status = ?,
+        owner = ?,
+        next_action = ?,
         updated_at = ?,
         acknowledged_at = ?,
         acted_at = ?,
         actor = ?
     WHERE id = ?
-  `).run(input.status, now, acknowledgedAt, actedAt, actor, input.id)
+  `).run(nextStatus, owner, nextAction, now, acknowledgedAt, actedAt, actor, input.id)
 
   return getOperatorNotificationById(db, input.id)
+}
+
+export function insertFunnelEvent(
+  db: DB,
+  input: {
+    sessionId: string
+    origin: string
+    pageKey: string
+    eventCategory: FunnelEventRow['event_category']
+    ctaKey?: string | null
+    targetPage?: string | null
+    workflowType?: string | null
+    milestoneKey?: string | null
+    createdAt?: string
+  },
+): FunnelEventRow {
+  const createdAt = input.createdAt ?? nowIso()
+  const result = db.prepare(`
+    INSERT INTO funnel_events (
+      session_id,
+      origin,
+      page_key,
+      event_category,
+      cta_key,
+      target_page,
+      workflow_type,
+      milestone_key,
+      created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.sessionId,
+    input.origin,
+    input.pageKey,
+    input.eventCategory,
+    input.ctaKey ?? null,
+    input.targetPage ?? null,
+    input.workflowType ?? null,
+    input.milestoneKey ?? null,
+    createdAt,
+  )
+
+  return db.prepare('SELECT * FROM funnel_events WHERE id = ?').get(Number(result.lastInsertRowid)) as FunnelEventRow
+}
+
+export function listFunnelEvents(
+  db: DB,
+  query: {
+    since?: string
+    limit?: number
+    eventCategory?: FunnelEventRow['event_category']
+    pageKey?: string
+  } = {},
+): FunnelEventRow[] {
+  const limit = Math.max(1, Math.min(10000, Math.trunc(query.limit ?? 5000)))
+  const conditions: string[] = []
+  const params: Array<string | number> = []
+
+  if (query.since) {
+    conditions.push('created_at >= ?')
+    params.push(query.since)
+  }
+
+  if (query.eventCategory) {
+    conditions.push('event_category = ?')
+    params.push(query.eventCategory)
+  }
+
+  if (query.pageKey) {
+    conditions.push('page_key = ?')
+    params.push(query.pageKey)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  return db.prepare(`
+    SELECT *
+    FROM funnel_events
+    ${where}
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `).all(...params) as FunnelEventRow[]
 }
 
 export function listShieldAuditLog(

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
-import { assignDirectoryRole, createDatabase } from './db.js'
+import { assignDirectoryRole, createDatabase, upsertOperatorNotification } from './db.js'
 import { getLocalDirectoryUrl } from './federation.js'
 
 function createAdminHeaders(
@@ -34,6 +34,11 @@ test('cors allows production public-site and loopback dashboard origins', async 
     }))
     assert.equal(beamOriginResponse.headers.get('access-control-allow-origin'), 'https://beam.directory')
 
+    const docsOriginResponse = await app.request(new Request('http://localhost/health', {
+      headers: { Origin: 'https://docs.beam.directory' },
+    }))
+    assert.equal(docsOriginResponse.headers.get('access-control-allow-origin'), 'https://docs.beam.directory')
+
     const localOriginResponse = await app.request(new Request('http://localhost/health', {
       headers: { Origin: 'http://localhost:43173' },
     }))
@@ -43,6 +48,136 @@ test('cors allows production public-site and loopback dashboard origins', async 
       headers: { Origin: 'https://evil.example' },
     }))
     assert.equal(unknownOriginResponse.headers.get('access-control-allow-origin'), null)
+  } finally {
+    db.close()
+  }
+})
+
+test('critical operator signals can capture owner and next action through the admin API', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const app = createApp(db)
+    const created = upsertOperatorNotification(db, {
+      sourceType: 'critical_alert',
+      sourceKey: 'critical-alert:network-error-rate',
+      alertId: 'network-error-rate',
+      severity: 'critical',
+      title: 'Error rate exceeded threshold',
+      message: '25% of completed intents failed.',
+      href: '/alerts?alert=network-error-rate',
+      nextAction: 'Open the latest failing trace.',
+    })
+
+    const response = await app.request(new Request(`http://localhost/admin/operator-notifications/${created.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'acknowledged',
+        owner: 'ops@example.com',
+        nextAction: 'Confirm the downstream route, then decide whether to requeue.',
+      }),
+    }))
+
+    assert.equal(response.status, 200)
+    const body = await response.json() as {
+      ok: boolean
+      notification: {
+        status: string
+        owner: string | null
+        nextAction: string | null
+      }
+    }
+    assert.equal(body.ok, true)
+    assert.equal(body.notification.status, 'acknowledged')
+    assert.equal(body.notification.owner, 'ops@example.com')
+    assert.match(body.notification.nextAction ?? '', /requeue/i)
+  } finally {
+    db.close()
+  }
+})
+
+test('first-party funnel analytics ingest and summary stay available through the admin API', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const app = createApp(db)
+
+    const events = [
+      {
+        sessionId: 'sessionlanding123',
+        pageKey: 'landing',
+        eventCategory: 'page_view',
+      },
+      {
+        sessionId: 'sessionlanding123',
+        pageKey: 'landing',
+        eventCategory: 'cta_click',
+        ctaKey: 'landing_guided_eval_hero',
+        targetPage: 'guided_evaluation',
+      },
+      {
+        sessionId: 'sessionlanding123',
+        pageKey: 'guided_evaluation',
+        eventCategory: 'page_view',
+      },
+      {
+        sessionId: 'sessionlanding123',
+        pageKey: 'guided_evaluation',
+        eventCategory: 'demo_milestone',
+        milestoneKey: 'guided_evaluation_view',
+      },
+      {
+        sessionId: 'sessionrequest456',
+        pageKey: 'hosted_beta',
+        eventCategory: 'request',
+        workflowType: 'hosted-beta-partner-handoff',
+        milestoneKey: 'hosted_beta_request_submitted',
+      },
+    ]
+
+    for (const payload of events) {
+      const response = await app.request(new Request('http://localhost/analytics/events', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          Origin: 'https://beam.directory',
+        },
+        body: JSON.stringify(payload),
+      }))
+      assert.equal(response.status, 202)
+      assert.equal(response.headers.get('access-control-allow-origin'), 'https://beam.directory')
+    }
+
+    const summaryResponse = await app.request(new Request('http://localhost/admin/funnel?days=30', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+
+    assert.equal(summaryResponse.status, 200)
+    const summary = await summaryResponse.json() as {
+      summary: {
+        anonymousSessions: number
+        landingSessions: number
+        guidedSessions: number
+        requestSessions: number
+        demoSessions: number
+      }
+      ctaClicks: Array<{ ctaKey: string; sessions: number }>
+      workflows: Array<{ workflowType: string; sessions: number }>
+    }
+
+    assert.equal(summary.summary.anonymousSessions, 2)
+    assert.equal(summary.summary.landingSessions, 1)
+    assert.equal(summary.summary.guidedSessions, 1)
+    assert.equal(summary.summary.requestSessions, 1)
+    assert.equal(summary.summary.demoSessions, 1)
+    assert.equal(summary.ctaClicks[0]?.ctaKey, 'landing_guided_eval_hero')
+    assert.equal(summary.workflows[0]?.workflowType, 'hosted-beta-partner-handoff')
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -71,6 +71,8 @@ export type AlertItem = {
   sampleTraces: AlertTraceSample[]
   notificationId?: number | null
   notificationStatus?: OperatorNotificationStatus | null
+  notificationOwner?: string | null
+  notificationNextAction?: string | null
 }
 
 type IntentQuery = {
@@ -1339,6 +1341,27 @@ function criticalAlertNotificationSourceKey(alertId: string): string {
   return `critical-alert:${alertId}`
 }
 
+function getAlertNextAction(alert: AlertItem): string {
+  switch (alert.id) {
+    case 'network-error-rate':
+      return 'Open the latest failing trace, confirm whether the recipient or route is broken, and assign an owner before retrying affected traffic.'
+    case 'network-latency-p95':
+      return 'Open the slowest recent trace, confirm whether the delay is downstream or queue-related, and record who owns the recovery path.'
+    case 'network-in-flight-backlog':
+      return 'Open the oldest in-flight trace, check whether the recipient is stalled, and only requeue after the downstream condition is understood.'
+    case 'federation-stale-peers':
+      return 'Inspect federation health, confirm which peer is stale, and assign an operator to restore sync or disable the peer deliberately.'
+    case 'shield-review-load':
+      return 'Open the latest flagged trace and Shield audit history, then decide whether this is abuse pressure or a false positive that needs policy changes.'
+    default:
+      if (alert.id.startsWith('error-hotspot-')) {
+        return 'Open the latest hotspot trace, inspect the affected recipient, and capture the next recovery action before retrying.'
+      }
+
+      return 'Open the linked context, assign an owner, and record the next recovery action before changing queue state.'
+  }
+}
+
 export function buildAlertsWithNotificationState(db: Database, windowHours: number): AlertItem[] {
   const alerts = buildAlerts(db, windowHours)
   const criticalAlerts = alerts.filter((alert) => alert.severity === 'critical')
@@ -1352,6 +1375,7 @@ export function buildAlertsWithNotificationState(db: Database, windowHours: numb
       title: alert.title,
       message: alert.message,
       href: alert.links[0]?.href ?? '/alerts',
+      defaultNextAction: getAlertNextAction(alert),
       details: {
         scope: alert.scope,
         metric: alert.metric,
@@ -1375,6 +1399,8 @@ export function buildAlertsWithNotificationState(db: Database, windowHours: numb
         ...alert,
         notificationId: notification.id,
         notificationStatus: notification.status,
+        notificationOwner: notification.owner,
+        notificationNextAction: notification.next_action,
       }
       : alert
   })

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -41,8 +41,10 @@ import {
   getAgent,
   getDIDDocument,
   getOperatorNotificationBySourceKey,
+  insertFunnelEvent,
   listAgentKeys,
   listAuditLog,
+  listFunnelEvents,
   listDirectoryRoles,
   listOperatorNotifications,
   listOperatorNotificationsBySourceKeys,
@@ -76,6 +78,21 @@ type BetaRequestAttention = 'unowned' | 'stale'
 type BetaRequestSort = 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
 type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 type OperatorNotificationSource = 'beta_request' | 'critical_alert'
+type FunnelEventCategory = 'page_view' | 'cta_click' | 'request' | 'demo_milestone'
+type FunnelPageKey =
+  | 'landing'
+  | 'guided_evaluation'
+  | 'hosted_beta'
+  | 'playground'
+  | 'register'
+  | 'status'
+  | 'privacy'
+  | 'terms'
+  | 'docs_home'
+  | 'docs_partner_handoff'
+  | 'docs_design_partner_onboarding'
+  | 'docs_hosted_quickstart'
+  | 'docs_other'
 
 type BetaRequestUpdateInput = {
   status?: BetaRequestStatus
@@ -104,6 +121,16 @@ type OperatorNotificationFilters = {
   hours?: number
 }
 
+type FunnelEventInput = {
+  sessionId: string
+  pageKey: FunnelPageKey
+  eventCategory: FunnelEventCategory
+  ctaKey?: string | null
+  targetPage?: FunnelPageKey | null
+  workflowType?: string | null
+  milestoneKey?: string | null
+}
+
 type WaitlistRow = {
   id: number
   email: string
@@ -130,6 +157,39 @@ const OPERATOR_NOTIFICATION_STATUSES: OperatorNotificationStatus[] = ['new', 'ac
 const OPERATOR_NOTIFICATION_STATUS_SET = new Set<string>(OPERATOR_NOTIFICATION_STATUSES)
 const OPERATOR_NOTIFICATION_SOURCES: OperatorNotificationSource[] = ['beta_request', 'critical_alert']
 const OPERATOR_NOTIFICATION_SOURCE_SET = new Set<string>(OPERATOR_NOTIFICATION_SOURCES)
+const FUNNEL_EVENT_CATEGORIES: FunnelEventCategory[] = ['page_view', 'cta_click', 'request', 'demo_milestone']
+const FUNNEL_EVENT_CATEGORY_SET = new Set<string>(FUNNEL_EVENT_CATEGORIES)
+const FUNNEL_PAGE_KEYS: FunnelPageKey[] = [
+  'landing',
+  'guided_evaluation',
+  'hosted_beta',
+  'playground',
+  'register',
+  'status',
+  'privacy',
+  'terms',
+  'docs_home',
+  'docs_partner_handoff',
+  'docs_design_partner_onboarding',
+  'docs_hosted_quickstart',
+  'docs_other',
+]
+const FUNNEL_PAGE_KEY_SET = new Set<string>(FUNNEL_PAGE_KEYS)
+const FUNNEL_WORKFLOW_TYPES = new Set<string>([
+  'hosted-beta-partner-handoff',
+  'hosted-beta-operator-eval',
+  'hosted-beta-managed-rollout',
+  'hosted-beta-compliance',
+])
+const FUNNEL_MILESTONE_KEYS = new Set<string>([
+  'guided_evaluation_view',
+  'hosted_beta_view',
+  'design_partner_onboarding_view',
+  'hosted_quickstart_view',
+  'playground_identity_ready',
+  'playground_echo_success',
+  'hosted_beta_request_submitted',
+])
 const BETA_REQUEST_STALE_HOURS: Record<BetaRequestStatus, number | null> = {
   new: 24,
   reviewing: 24,
@@ -230,6 +290,100 @@ function normalizeOperatorNotificationSource(value: unknown): OperatorNotificati
   return normalized as OperatorNotificationSource
 }
 
+function normalizeFunnelEventCategory(value: unknown): FunnelEventCategory | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (!FUNNEL_EVENT_CATEGORY_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as FunnelEventCategory
+}
+
+function normalizeFunnelPageKey(value: unknown): FunnelPageKey | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase().replaceAll('-', '_')
+  if (!FUNNEL_PAGE_KEY_SET.has(normalized)) {
+    return null
+  }
+
+  return normalized as FunnelPageKey
+}
+
+function normalizeSessionId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim()
+  if (!/^[a-zA-Z0-9_-]{8,128}$/.test(normalized)) {
+    return null
+  }
+
+  return normalized
+}
+
+function normalizeFunnelKey(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase().replaceAll(' ', '_')
+  if (!/^[a-z0-9:_-]{2,80}$/.test(normalized)) {
+    return null
+  }
+
+  return normalized
+}
+
+function normalizeWorkflowType(value: unknown): string | null {
+  const normalized = normalizeOptionalString(value)
+  if (!normalized) {
+    return null
+  }
+
+  return FUNNEL_WORKFLOW_TYPES.has(normalized) ? normalized : null
+}
+
+function normalizeMilestoneKey(value: unknown): string | null {
+  const normalized = normalizeFunnelKey(value)
+  if (!normalized) {
+    return null
+  }
+
+  return FUNNEL_MILESTONE_KEYS.has(normalized) ? normalized : null
+}
+
+function ratio(part: number, total: number): number | null {
+  if (!total) {
+    return null
+  }
+
+  return Number((part / total).toFixed(4))
+}
+
+function intersectionSize(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 || right.size === 0) {
+    return 0
+  }
+
+  let count = 0
+  const [small, large] = left.size <= right.size ? [left, right] : [right, left]
+  for (const value of small) {
+    if (large.has(value)) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
 function betaRequestNotificationSourceKey(id: number): string {
   return `beta-request:${id}`
 }
@@ -293,6 +447,8 @@ function serializeOperatorNotification(row: OperatorNotificationRow) {
     title: row.title,
     message: row.message,
     href: row.href,
+    owner: row.owner,
+    nextAction: row.next_action,
     status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -368,6 +524,7 @@ const PUBLIC_CORS_ORIGINS = new Set([
   'https://dashboard.beam.directory',
   'https://beam.directory',
   'https://www.beam.directory',
+  'https://docs.beam.directory',
 ])
 
 function resolveCorsOrigin(origin?: string | null): string | null {
@@ -746,6 +903,8 @@ function ensureBetaRequestNotification(
     title: `Hosted beta request from ${companyLabel}`,
     message: messageParts.join(' · '),
     href: `/beta-requests?id=${row.id}`,
+    owner: row.owner,
+    nextAction: row.next_action ?? getBetaRequestNextStep(row.status),
     resetStatus,
     details: {
       email: row.email,
@@ -791,6 +950,231 @@ function summarizeOperatorNotifications(rows: OperatorNotificationRow[]) {
       beta_request: rows.filter((row) => row.source_type === 'beta_request').length,
       critical_alert: rows.filter((row) => row.source_type === 'critical_alert').length,
     },
+  }
+}
+
+function serializeFunnelEvent(row: {
+  id: number
+  session_id: string
+  origin: string
+  page_key: string
+  event_category: string
+  cta_key: string | null
+  target_page: string | null
+  workflow_type: string | null
+  milestone_key: string | null
+  created_at: string
+}) {
+  return {
+    id: row.id,
+    sessionId: row.session_id,
+    origin: row.origin,
+    pageKey: row.page_key,
+    eventCategory: row.event_category,
+    ctaKey: row.cta_key,
+    targetPage: row.target_page,
+    workflowType: row.workflow_type,
+    milestoneKey: row.milestone_key,
+    createdAt: row.created_at,
+  }
+}
+
+function summarizeFunnel(rows: Array<{
+  id: number
+  session_id: string
+  origin: string
+  page_key: string
+  event_category: string
+  cta_key: string | null
+  target_page: string | null
+  workflow_type: string | null
+  milestone_key: string | null
+  created_at: string
+}>) {
+  const pageViews = rows.filter((row) => row.event_category === 'page_view')
+  const ctaClicks = rows.filter((row) => row.event_category === 'cta_click')
+  const requests = rows.filter((row) => row.event_category === 'request')
+  const demos = rows.filter((row) => row.event_category === 'demo_milestone')
+  const sessions = new Set(rows.map((row) => row.session_id))
+  const milestoneSets = [
+    {
+      key: 'landing_visit',
+      label: 'Landing visited',
+      sessionSet: new Set(rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'landing').map((row) => row.session_id)),
+      events: rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'landing').length,
+    },
+    {
+      key: 'guided_evaluation',
+      label: 'Guided evaluation viewed',
+      sessionSet: new Set(rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'guided_evaluation').map((row) => row.session_id)),
+      events: rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'guided_evaluation').length,
+    },
+    {
+      key: 'hosted_beta_view',
+      label: 'Hosted beta viewed',
+      sessionSet: new Set(rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'hosted_beta').map((row) => row.session_id)),
+      events: rows.filter((row) => row.event_category === 'page_view' && row.page_key === 'hosted_beta').length,
+    },
+    {
+      key: 'hosted_beta_request',
+      label: 'Hosted beta requested',
+      sessionSet: new Set(requests.map((row) => row.session_id)),
+      events: requests.length,
+    },
+    {
+      key: 'demo_milestone',
+      label: 'Demo milestone reached',
+      sessionSet: new Set(demos.map((row) => row.session_id)),
+      events: demos.length,
+    },
+  ]
+  const landingSet = milestoneSets[0]?.sessionSet ?? new Set<string>()
+  const milestoneRows = milestoneSets.map((entry, index, all) => {
+    const previousSet = index === 0 ? null : (all[index - 1]?.sessionSet ?? new Set<string>())
+    return {
+      key: entry.key,
+      label: entry.label,
+      sessions: entry.sessionSet.size,
+      events: entry.events,
+      conversionFromPrevious: previousSet ? ratio(intersectionSize(entry.sessionSet, previousSet), previousSet.size) : null,
+      conversionFromLanding: ratio(intersectionSize(entry.sessionSet, landingSet), landingSet.size),
+    }
+  })
+
+  const entryPages = Array.from(
+    pageViews.reduce((map, row) => {
+      const current = map.get(row.page_key) ?? { pageKey: row.page_key, events: 0, sessions: new Set<string>() }
+      current.events += 1
+      current.sessions.add(row.session_id)
+      map.set(row.page_key, current)
+      return map
+    }, new Map<string, { pageKey: string; events: number; sessions: Set<string> }>() ).values(),
+  )
+    .map((entry) => ({
+      pageKey: entry.pageKey,
+      events: entry.events,
+      sessions: entry.sessions.size,
+    }))
+    .sort((left, right) => right.sessions - left.sessions || right.events - left.events)
+
+  const ctaSummary = Array.from(
+    ctaClicks.reduce((map, row) => {
+      const key = row.cta_key ?? 'unknown'
+      const current = map.get(key) ?? { ctaKey: key, targetPage: row.target_page, events: 0, sessions: new Set<string>() }
+      current.events += 1
+      current.sessions.add(row.session_id)
+      if (!current.targetPage && row.target_page) {
+        current.targetPage = row.target_page
+      }
+      map.set(key, current)
+      return map
+    }, new Map<string, { ctaKey: string; targetPage: string | null; events: number; sessions: Set<string> }>() ).values(),
+  )
+    .map((entry) => ({
+      ctaKey: entry.ctaKey,
+      targetPage: entry.targetPage,
+      events: entry.events,
+      sessions: entry.sessions.size,
+    }))
+    .sort((left, right) => right.sessions - left.sessions || right.events - left.events)
+
+  const milestones = Array.from(
+    demos.reduce((map, row) => {
+      const key = row.milestone_key ?? 'unknown'
+      const current = map.get(key) ?? { milestoneKey: key, events: 0, sessions: new Set<string>() }
+      current.events += 1
+      current.sessions.add(row.session_id)
+      map.set(key, current)
+      return map
+    }, new Map<string, { milestoneKey: string; events: number; sessions: Set<string> }>() ).values(),
+  )
+    .map((entry) => ({
+      milestoneKey: entry.milestoneKey,
+      events: entry.events,
+      sessions: entry.sessions.size,
+    }))
+    .sort((left, right) => right.sessions - left.sessions || right.events - left.events)
+
+  const requestsByWorkflow = Array.from(
+    requests.reduce((map, row) => {
+      const key = row.workflow_type ?? 'unknown'
+      const current = map.get(key) ?? { workflowType: key, events: 0, sessions: new Set<string>() }
+      current.events += 1
+      current.sessions.add(row.session_id)
+      map.set(key, current)
+      return map
+    }, new Map<string, { workflowType: string; events: number; sessions: Set<string> }>() ).values(),
+  )
+    .map((entry) => ({
+      workflowType: entry.workflowType,
+      events: entry.events,
+      sessions: entry.sessions.size,
+    }))
+    .sort((left, right) => right.sessions - left.sessions || right.events - left.events)
+
+  const daily = new Map<string, { day: string; landing: Set<string>; guided: Set<string>; request: Set<string>; demo: Set<string> }>()
+  for (const row of rows) {
+    const day = row.created_at.slice(0, 10)
+    const bucket = daily.get(day) ?? {
+      day,
+      landing: new Set<string>(),
+      guided: new Set<string>(),
+      request: new Set<string>(),
+      demo: new Set<string>(),
+    }
+
+    if (row.event_category === 'page_view' && row.page_key === 'landing') {
+      bucket.landing.add(row.session_id)
+    }
+    if (row.event_category === 'page_view' && row.page_key === 'guided_evaluation') {
+      bucket.guided.add(row.session_id)
+    }
+    if (row.event_category === 'request') {
+      bucket.request.add(row.session_id)
+    }
+    if (row.event_category === 'demo_milestone') {
+      bucket.demo.add(row.session_id)
+    }
+
+    daily.set(day, bucket)
+  }
+
+  const timeline = Array.from(daily.values())
+    .sort((left, right) => left.day.localeCompare(right.day))
+    .map((entry) => ({
+      day: entry.day,
+      landingSessions: entry.landing.size,
+      guidedSessions: entry.guided.size,
+      requestSessions: entry.request.size,
+      demoSessions: entry.demo.size,
+    }))
+
+  return {
+    summary: {
+      anonymousSessions: sessions.size,
+      pageViews: pageViews.length,
+      ctaClicks: ctaClicks.length,
+      requestEvents: requests.length,
+      demoEvents: demos.length,
+      landingSessions: milestoneRows[0]?.sessions ?? 0,
+      guidedSessions: milestoneRows[1]?.sessions ?? 0,
+      hostedBetaSessions: milestoneRows[2]?.sessions ?? 0,
+      requestSessions: milestoneRows[3]?.sessions ?? 0,
+      demoSessions: milestoneRows[4]?.sessions ?? 0,
+      landingToGuidedRate: milestoneRows[1]?.conversionFromLanding ?? null,
+      landingToRequestRate: milestoneRows[3]?.conversionFromLanding ?? null,
+      requestToDemoRate: ratio(
+        intersectionSize(milestoneSets[4]?.sessionSet ?? new Set<string>(), milestoneSets[3]?.sessionSet ?? new Set<string>()),
+        milestoneSets[3]?.sessionSet.size ?? 0,
+      ),
+    },
+    milestones: milestoneRows,
+    entryPages,
+    ctaClicks: ctaSummary,
+    demoMilestones: milestones,
+    workflows: requestsByWorkflow,
+    timeline,
+    recentEvents: rows.slice(0, 40).map((row) => serializeFunnelEvent(row)),
   }
 }
 
@@ -1572,6 +1956,7 @@ export function createApp(db: Database): Hono {
         return c.json({ error: 'Beta request not found after update', errorCode: 'NOT_FOUND' }, 404)
       }
 
+      ensureBetaRequestNotification(db, updated)
       syncBetaRequestNotificationStatus(db, updated, auth.session.email)
       const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(updated.id))
 
@@ -1657,15 +2042,24 @@ export function createApp(db: Database): Hono {
       return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
     }
 
-    const status = normalizeOperatorNotificationStatus((body as Record<string, unknown>).status)
-    if (!status) {
+    const raw = body as Record<string, unknown>
+    const status = 'status' in raw ? (normalizeOperatorNotificationStatus(raw.status) ?? undefined) : undefined
+    if ('status' in raw && !status) {
       return c.json({ error: 'Invalid operator notification status', errorCode: 'INVALID_NOTIFICATION_STATUS' }, 400)
+    }
+    const owner = 'owner' in raw ? normalizeOptionalString(raw.owner) : undefined
+    const nextAction = 'nextAction' in raw ? normalizeOptionalString(raw.nextAction) : undefined
+
+    if (!('status' in raw) && !('owner' in raw) && !('nextAction' in raw)) {
+      return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
     }
 
     const updated = updateOperatorNotificationStatus(db, {
       id,
       status,
       actor: auth.session.email,
+      owner,
+      nextAction,
     })
     if (!updated) {
       return c.json({ error: 'Operator notification not found', errorCode: 'NOT_FOUND' }, 404)
@@ -1677,6 +2071,8 @@ export function createApp(db: Database): Hono {
       target: String(id),
       details: {
         status,
+        owner,
+        nextAction,
         role: auth.session.role,
         sourceType: updated.source_type,
         sourceKey: updated.source_key,
@@ -1688,6 +2084,33 @@ export function createApp(db: Database): Hono {
       ok: true,
       notification: serializeOperatorNotification(updated),
     })
+  })
+
+  app.get('/admin/funnel', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const days = Math.max(1, Math.min(180, Number.parseInt(c.req.query('days') ?? '30', 10) || 30))
+
+    try {
+      const rows = listFunnelEvents(db, {
+        since: new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString(),
+        limit: 10000,
+      })
+      const summary = summarizeFunnel(rows)
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        days,
+        generatedAt: new Date().toISOString(),
+        ...summary,
+      })
+    } catch (err) {
+      console.error('Funnel summary error:', err)
+      return c.json({ error: 'Failed to load funnel analytics', errorCode: 'DB_ERROR' }, 500)
+    }
   })
 
   app.get('/admin/waitlist', (c) => {
@@ -2011,6 +2434,8 @@ export function createApp(db: Database): Hono {
           : null
       )
     const workflowSummary = normalizeOptionalString(raw.workflowSummary) ?? normalizeOptionalString(raw.notes)
+    const analyticsSessionId = normalizeSessionId(raw.analyticsSessionId ?? raw.sessionId)
+    const analyticsPageKey = normalizeFunnelPageKey(raw.pageKey) ?? 'hosted_beta'
 
     const signup: WaitlistSignupInput = {
       email,
@@ -2058,6 +2483,16 @@ export function createApp(db: Database): Hono {
           ensureBetaRequestNotification(db, updated, true)
         }
         const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(updated.id))
+        if (analyticsSessionId && workflowType) {
+          insertFunnelEvent(db, {
+            sessionId: analyticsSessionId,
+            origin: resolveCorsOrigin(c.req.header('origin')) ?? 'https://beam.directory',
+            pageKey: analyticsPageKey,
+            eventCategory: 'request',
+            workflowType,
+            milestoneKey: 'hosted_beta_request_submitted',
+          })
+        }
 
         return c.json({
           ok: true,
@@ -2129,6 +2564,16 @@ export function createApp(db: Database): Hono {
         return c.json({ error: 'Failed to load saved beta request', errorCode: 'DB_ERROR' }, 500)
       }
       const notification = ensureBetaRequestNotification(db, created, true)
+      if (analyticsSessionId && workflowType) {
+        insertFunnelEvent(db, {
+          sessionId: analyticsSessionId,
+          origin: resolveCorsOrigin(c.req.header('origin')) ?? 'https://beam.directory',
+          pageKey: analyticsPageKey,
+          eventCategory: 'request',
+          workflowType,
+          milestoneKey: 'hosted_beta_request_submitted',
+        })
+      }
 
       return c.json({
         ok: true,
@@ -2176,6 +2621,80 @@ export function createApp(db: Database): Hono {
     } catch (err) {
       console.error('List waitlist error:', err)
       return c.json({ error: 'Failed to list waitlist signups', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  app.post('/analytics/events', async (c) => {
+    const requestOrigin = c.req.header('origin') ?? null
+    const origin = resolveCorsOrigin(requestOrigin)
+    if (!origin) {
+      return c.json({ error: 'Origin not allowed', errorCode: 'FORBIDDEN_ORIGIN' }, 403)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const sessionId = normalizeSessionId(raw.sessionId)
+    if (!sessionId) {
+      return c.json({ error: 'Invalid sessionId', errorCode: 'INVALID_SESSION_ID' }, 400)
+    }
+
+    const pageKey = normalizeFunnelPageKey(raw.pageKey)
+    if (!pageKey) {
+      return c.json({ error: 'Invalid pageKey', errorCode: 'INVALID_PAGE_KEY' }, 400)
+    }
+
+    const eventCategory = normalizeFunnelEventCategory(raw.eventCategory)
+    if (!eventCategory) {
+      return c.json({ error: 'Invalid eventCategory', errorCode: 'INVALID_EVENT_CATEGORY' }, 400)
+    }
+
+    const ctaKey = 'ctaKey' in raw ? normalizeFunnelKey(raw.ctaKey) : null
+    const targetPage = 'targetPage' in raw ? normalizeFunnelPageKey(raw.targetPage) : null
+    const workflowType = 'workflowType' in raw ? normalizeWorkflowType(raw.workflowType) : null
+    const milestoneKey = 'milestoneKey' in raw ? normalizeMilestoneKey(raw.milestoneKey) : null
+
+    if (eventCategory === 'cta_click' && !ctaKey) {
+      return c.json({ error: 'ctaKey is required for cta_click events', errorCode: 'INVALID_CTA_KEY' }, 400)
+    }
+
+    if (eventCategory === 'request' && !workflowType) {
+      return c.json({ error: 'workflowType is required for request events', errorCode: 'INVALID_WORKFLOW_TYPE' }, 400)
+    }
+
+    if (eventCategory === 'demo_milestone' && !milestoneKey) {
+      return c.json({ error: 'milestoneKey is required for demo_milestone events', errorCode: 'INVALID_MILESTONE_KEY' }, 400)
+    }
+
+    try {
+      const event = insertFunnelEvent(db, {
+        sessionId,
+        origin,
+        pageKey,
+        eventCategory,
+        ctaKey,
+        targetPage,
+        workflowType,
+        milestoneKey,
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        event: serializeFunnelEvent(event),
+      }, 202)
+    } catch (err) {
+      console.error('Analytics ingest error:', err)
+      return c.json({ error: 'Failed to record analytics event', errorCode: 'DB_ERROR' }, 500)
     }
   })
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -148,6 +148,8 @@ export interface OperatorNotificationRow {
   title: string
   message: string
   href: string | null
+  owner: string | null
+  next_action: string | null
   status: OperatorNotificationStatus
   created_at: string
   updated_at: string
@@ -155,6 +157,21 @@ export interface OperatorNotificationRow {
   acted_at: string | null
   actor: string | null
   details_json: string | null
+}
+
+export type FunnelEventCategory = 'page_view' | 'cta_click' | 'request' | 'demo_milestone'
+
+export interface FunnelEventRow {
+  id: number
+  session_id: string
+  origin: string
+  page_key: string
+  event_category: FunnelEventCategory
+  cta_key: string | null
+  target_page: string | null
+  workflow_type: string | null
+  milestone_key: string | null
+  created_at: string
 }
 
 export interface ShieldAuditLogRow {

--- a/packages/public-site/beam-analytics.js
+++ b/packages/public-site/beam-analytics.js
@@ -1,0 +1,213 @@
+(function () {
+  const DNT = navigator.doNotTrack === '1' || window.doNotTrack === '1' || navigator.msDoNotTrack === '1'
+  if (DNT) {
+    window.beamAnalytics = {
+      disabled: true,
+      pageKey: null,
+      sessionId: null,
+      track() {},
+    }
+    return
+  }
+
+  const STORAGE_KEY = 'beam_analytics_session_id'
+  const COOKIE_KEY = 'beam_analytics_session_id'
+  const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+
+  function resolveApiBase() {
+    if (window.location.hostname === 'localhost') {
+      return 'http://localhost:43100'
+    }
+    if (window.location.hostname === '127.0.0.1') {
+      return 'http://127.0.0.1:43100'
+    }
+    return 'https://api.beam.directory'
+  }
+
+  function getCookie(name) {
+    const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+    return match ? decodeURIComponent(match[1]) : null
+  }
+
+  function setCookie(name, value) {
+    const parts = [
+      `${name}=${encodeURIComponent(value)}`,
+      'Path=/',
+      `Max-Age=${SESSION_MAX_AGE_SECONDS}`,
+      'SameSite=Lax',
+    ]
+
+    if (window.location.hostname.endsWith('.beam.directory') || window.location.hostname === 'beam.directory') {
+      parts.push('Domain=.beam.directory')
+      parts.push('Secure')
+    }
+
+    document.cookie = parts.join('; ')
+  }
+
+  function makeSessionId() {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return window.crypto.randomUUID().replace(/-/g, '')
+    }
+    return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 12)}`
+  }
+
+  function getSessionId() {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        setCookie(COOKIE_KEY, stored)
+        return stored
+      }
+    } catch {
+    }
+
+    const cookieValue = getCookie(COOKIE_KEY)
+    if (cookieValue) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, cookieValue)
+      } catch {
+      }
+      return cookieValue
+    }
+
+    const generated = makeSessionId()
+    try {
+      window.localStorage.setItem(STORAGE_KEY, generated)
+    } catch {
+    }
+    setCookie(COOKIE_KEY, generated)
+    return generated
+  }
+
+  function cleanPath(pathname) {
+    return pathname.replace(/\/+$/, '') || '/'
+  }
+
+  function pageKeyForLocation() {
+    const host = window.location.hostname
+    const path = cleanPath(window.location.pathname)
+
+    if (host === 'docs.beam.directory') {
+      if (path === '/') return 'docs_home'
+      if (path === '/guide/design-partner-onboarding') return 'docs_design_partner_onboarding'
+      if (path === '/guide/hosted-quickstart') return 'docs_hosted_quickstart'
+      if (path === '/guide/partner-handoff') return 'docs_partner_handoff'
+      return 'docs_other'
+    }
+
+    const pageMap = {
+      '/': 'landing',
+      '/guided-evaluation.html': 'guided_evaluation',
+      '/hosted-beta.html': 'hosted_beta',
+      '/playground.html': 'playground',
+      '/register.html': 'register',
+      '/status.html': 'status',
+      '/privacy.html': 'privacy',
+      '/terms.html': 'terms',
+    }
+
+    return pageMap[path] || 'landing'
+  }
+
+  function inferTargetPage(href) {
+    if (!href) return null
+
+    try {
+      const url = new URL(href, window.location.origin)
+      const path = cleanPath(url.pathname)
+      if (url.hostname === 'docs.beam.directory') {
+        if (path === '/') return 'docs_home'
+        if (path === '/guide/design-partner-onboarding') return 'docs_design_partner_onboarding'
+        if (path === '/guide/hosted-quickstart') return 'docs_hosted_quickstart'
+        if (path === '/guide/partner-handoff') return 'docs_partner_handoff'
+        return 'docs_other'
+      }
+
+      if (path === '/') return 'landing'
+      if (path === '/guided-evaluation.html') return 'guided_evaluation'
+      if (path === '/hosted-beta.html') return 'hosted_beta'
+      if (path === '/playground.html') return 'playground'
+      if (path === '/register.html') return 'register'
+      if (path === '/status.html') return 'status'
+      return null
+    } catch {
+      return null
+    }
+  }
+
+  function send(payload) {
+    const body = JSON.stringify(payload)
+    const url = `${resolveApiBase()}/analytics/events`
+    if (navigator.sendBeacon) {
+      const blob = new Blob([body], { type: 'application/json' })
+      navigator.sendBeacon(url, blob)
+      return
+    }
+
+    void fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+      keepalive: true,
+    }).catch(() => {})
+  }
+
+  const sessionId = getSessionId()
+  const pageKey = pageKeyForLocation()
+
+  function track(event) {
+    const payload = {
+      sessionId,
+      pageKey: event.pageKey || pageKey,
+      eventCategory: event.category,
+      ctaKey: event.ctaKey || null,
+      targetPage: event.targetPage || null,
+      workflowType: event.workflowType || null,
+      milestoneKey: event.milestoneKey || null,
+    }
+
+    send(payload)
+  }
+
+  track({ category: 'page_view' })
+
+  if (pageKey === 'guided_evaluation') {
+    track({ category: 'demo_milestone', milestoneKey: 'guided_evaluation_view' })
+  }
+  if (pageKey === 'hosted_beta') {
+    track({ category: 'demo_milestone', milestoneKey: 'hosted_beta_view' })
+  }
+  if (pageKey === 'docs_design_partner_onboarding') {
+    track({ category: 'demo_milestone', milestoneKey: 'design_partner_onboarding_view' })
+  }
+  if (pageKey === 'docs_hosted_quickstart') {
+    track({ category: 'demo_milestone', milestoneKey: 'hosted_quickstart_view' })
+  }
+
+  document.addEventListener('click', (event) => {
+    const target = event.target instanceof Element ? event.target.closest('[data-beam-cta]') : null
+    if (!target) {
+      return
+    }
+
+    const ctaKey = target.getAttribute('data-beam-cta')
+    if (!ctaKey) {
+      return
+    }
+
+    const href = target instanceof HTMLAnchorElement ? target.href : target.getAttribute('href')
+    track({
+      category: 'cta_click',
+      ctaKey,
+      targetPage: inferTargetPage(href),
+    })
+  })
+
+  window.beamAnalytics = {
+    disabled: false,
+    pageKey,
+    sessionId,
+    track,
+  }
+})()

--- a/packages/public-site/guided-evaluation.html
+++ b/packages/public-site/guided-evaluation.html
@@ -711,8 +711,8 @@
 
         <div class="top-links">
           <a href="/">Home</a>
-          <a href="/hosted-beta.html">Request pilot</a>
-          <a class="primary" href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
+          <a data-beam-cta="guided_eval_hosted_beta_nav" href="/hosted-beta.html">Request pilot</a>
+          <a class="primary" data-beam-cta="guided_eval_onboarding_nav" href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
         </div>
       </nav>
     </div>
@@ -731,8 +731,8 @@
           </p>
 
           <div class="hero-actions">
-            <a class="btn btn-primary" href="/hosted-beta.html">Request a guided pilot</a>
-            <a class="btn btn-secondary" href="https://docs.beam.directory/guide/design-partner-onboarding">Open the onboarding pack</a>
+            <a class="btn btn-primary" data-beam-cta="guided_eval_hosted_beta_hero" href="/hosted-beta.html">Request a guided pilot</a>
+            <a class="btn btn-secondary" data-beam-cta="guided_eval_onboarding_hero" href="https://docs.beam.directory/guide/design-partner-onboarding">Open the onboarding pack</a>
           </div>
 
           <div class="hero-points">
@@ -923,8 +923,8 @@
           </div>
 
           <div class="proof-links">
-            <a class="btn btn-primary" href="/hosted-beta.html">Request a guided pilot</a>
-            <a class="btn btn-ghost" href="https://docs.beam.directory/guide/design-partner-onboarding">Open full onboarding pack</a>
+            <a class="btn btn-primary" data-beam-cta="guided_eval_hosted_beta_proof" href="/hosted-beta.html">Request a guided pilot</a>
+            <a class="btn btn-ghost" data-beam-cta="guided_eval_onboarding_proof" href="https://docs.beam.directory/guide/design-partner-onboarding">Open full onboarding pack</a>
           </div>
         </div>
       </section>
@@ -937,7 +937,7 @@
           matters. If the fit is not there yet, stop at the evaluation and keep the scope honest.
         </p>
         <div class="closing-actions">
-          <a class="btn btn-primary" href="/hosted-beta.html">Request hosted beta</a>
+          <a class="btn btn-primary" data-beam-cta="guided_eval_hosted_beta_closing" href="/hosted-beta.html">Request hosted beta</a>
           <a class="btn btn-ghost" href="/">Back to the landing page</a>
         </div>
       </section>
@@ -954,5 +954,6 @@
       </div>
     </div>
   </footer>
+  <script src="/beam-analytics.js"></script>
 </body>
 </html>

--- a/packages/public-site/hosted-beta.html
+++ b/packages/public-site/hosted-beta.html
@@ -707,7 +707,7 @@
         </a>
 
         <div class="top-links">
-          <a href="/guided-evaluation.html">Guided evaluation</a>
+          <a data-beam-cta="hosted_beta_guided_eval_nav" href="/guided-evaluation.html">Guided evaluation</a>
           <a href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
           <a class="primary" href="#faq">Common questions</a>
         </div>
@@ -796,7 +796,7 @@
 
             <div class="submit-row">
               <button class="btn primary" id="submit-button" type="submit">Request hosted beta</button>
-              <a class="btn ghost" href="/guided-evaluation.html">See the guided evaluation first</a>
+              <a class="btn ghost" data-beam-cta="hosted_beta_guided_eval_form" href="/guided-evaluation.html">See the guided evaluation first</a>
             </div>
           </form>
 
@@ -941,6 +941,7 @@
     </div>
   </main>
 
+  <script src="/beam-analytics.js"></script>
   <script>
     function resolveDirectoryApiBase() {
       if (window.location.hostname === 'localhost') {
@@ -999,6 +1000,8 @@
             agentCount: Number.isFinite(agentCount) ? agentCount : null,
             workflowType: workflow,
             workflowSummary: notes || null,
+            analyticsSessionId: window.beamAnalytics?.sessionId || null,
+            pageKey: window.beamAnalytics?.pageKey || 'hosted_beta',
           }),
         })
 

--- a/packages/public-site/index.html
+++ b/packages/public-site/index.html
@@ -1644,8 +1644,8 @@
       </ul>
 
       <div class="nav-actions">
-        <a class="btn btn-ghost" href="/hosted-beta.html">Request hosted beta</a>
-        <a class="btn btn-primary" href="/guided-evaluation.html">See guided evaluation</a>
+        <a class="btn btn-ghost" data-beam-cta="landing_hosted_beta_nav" href="/hosted-beta.html">Request hosted beta</a>
+        <a class="btn btn-primary" data-beam-cta="landing_guided_eval_nav" href="/guided-evaluation.html">See guided evaluation</a>
       </div>
     </nav>
   </div>
@@ -1663,8 +1663,8 @@
             inspect the proof, then decide whether Beam deserves a bigger footprint.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="/guided-evaluation.html">See the guided evaluation</a>
-            <a class="btn btn-secondary" href="/hosted-beta.html">Request hosted beta</a>
+            <a class="btn btn-primary" data-beam-cta="landing_guided_eval_hero" href="/guided-evaluation.html">See the guided evaluation</a>
+            <a class="btn btn-secondary" data-beam-cta="landing_hosted_beta_hero" href="/hosted-beta.html">Request hosted beta</a>
           </div>
           <div class="hero-proof">
             <div class="proof-item">
@@ -1939,7 +1939,7 @@
               <li>The same onboarding pack and operator docs power the follow-up workflow.</li>
             </ul>
             <div class="stack-actions">
-              <a class="btn btn-primary" href="/guided-evaluation.html">Open guided evaluation</a>
+              <a class="btn btn-primary" data-beam-cta="landing_guided_eval_paths" href="/guided-evaluation.html">Open guided evaluation</a>
               <a class="btn btn-secondary" href="https://docs.beam.directory/guide/design-partner-onboarding">Open onboarding pack</a>
             </div>
             <div class="stack-note">Best first stop if you want proof before deciding whether Beam is worth a live workflow.</div>
@@ -1969,7 +1969,7 @@
               <li>Guided design-partner engagement with operator proof, rollout guidance, and follow-up.</li>
             </ul>
             <div class="stack-actions">
-              <a class="btn btn-secondary" href="/hosted-beta.html">Request hosted beta</a>
+              <a class="btn btn-secondary" data-beam-cta="landing_hosted_beta_paths" href="/hosted-beta.html">Request hosted beta</a>
               <a class="btn btn-secondary" href="https://docs.beam.directory/guide/partner-handoff">Read the handoff</a>
             </div>
             <div class="stack-note">Best for teams that want a guided rollout around one live workflow.</div>
@@ -2122,9 +2122,9 @@
               or it does not. If it does, the next step is one real workflow and one clear owner.
             </p>
             <div class="closing-actions">
-              <a class="btn btn-primary" href="/guided-evaluation.html">See guided evaluation</a>
-              <a class="btn btn-secondary" href="/hosted-beta.html">Request hosted beta</a>
-              <a class="btn btn-secondary" href="https://docs.beam.directory/guide/hosted-quickstart">Run the demo</a>
+              <a class="btn btn-primary" data-beam-cta="landing_guided_eval_closing" href="/guided-evaluation.html">See guided evaluation</a>
+              <a class="btn btn-secondary" data-beam-cta="landing_hosted_beta_closing" href="/hosted-beta.html">Request hosted beta</a>
+              <a class="btn btn-secondary" data-beam-cta="landing_run_demo" href="https://docs.beam.directory/guide/hosted-quickstart">Run the demo</a>
             </div>
           </div>
         </div>
@@ -2145,6 +2145,7 @@
     </div>
   </footer>
 
+  <script src="/beam-analytics.js"></script>
   <script>
     const toggle = document.getElementById('menuToggle')
     const navLinks = document.getElementById('navLinks')

--- a/packages/public-site/playground.html
+++ b/packages/public-site/playground.html
@@ -436,8 +436,8 @@
       </a>
       <div class="top-actions">
         <a class="link-btn" href="https://docs.beam.directory" target="_blank" rel="noreferrer">Docs</a>
-        <a class="link-btn" href="/register.html">Register your own agent</a>
-        <a class="link-btn primary" href="https://docs.beam.directory/guide/hosted-quickstart" target="_blank" rel="noreferrer">Run full hosted demo</a>
+        <a class="link-btn" data-beam-cta="playground_register_nav" href="/register.html">Register your own agent</a>
+        <a class="link-btn primary" data-beam-cta="playground_run_demo_nav" href="https://docs.beam.directory/guide/hosted-quickstart" target="_blank" rel="noreferrer">Run full hosted demo</a>
         <a class="link-btn" href="/">Back to landing</a>
       </div>
     </div>
@@ -451,8 +451,8 @@
           sends your message to Beam's public demo responder, and shows the reply.
         </p>
         <div class="hero-actions">
-          <a class="link-btn primary" href="https://docs.beam.directory/guide/hosted-quickstart" target="_blank" rel="noreferrer">See the full product demo</a>
-          <a class="link-btn" href="/register.html">Register a real agent</a>
+          <a class="link-btn primary" data-beam-cta="playground_run_demo_hero" href="https://docs.beam.directory/guide/hosted-quickstart" target="_blank" rel="noreferrer">See the full product demo</a>
+          <a class="link-btn" data-beam-cta="playground_register_hero" href="/register.html">Register a real agent</a>
         </div>
         <div class="hero-points">
           <div><strong>Best for:</strong> getting a feel for Beam in under a minute.</div>
@@ -541,6 +541,7 @@
     </section>
   </div>
 
+  <script src="/beam-analytics.js"></script>
   <script>
     const API_BASE_URL = 'https://api.beam.directory';
     const WS_BASE_URL = 'wss://api.beam.directory/ws';
@@ -718,6 +719,10 @@
       elements.identityValue.textContent = sessionState.publicKeyBase64;
       elements.beamIdValue.textContent = sessionState.beamId;
       setStatus(elements.directoryState, 'ok', 'Registered');
+      window.beamAnalytics?.track({
+        category: 'demo_milestone',
+        milestoneKey: 'playground_identity_ready',
+      });
 
       addEvent('registered', formatJson({
         beamId: sessionState.beamId,
@@ -892,6 +897,12 @@
         : (result.error || 'Intent failed');
 
       addEvent('result', formatJson({ latencyMs: latency, frame: result }), result.success ? 'ok' : 'err');
+      if (result.success) {
+        window.beamAnalytics?.track({
+          category: 'demo_milestone',
+          milestoneKey: 'playground_echo_success',
+        });
+      }
     }
 
     async function cleanupPlayground() {

--- a/packages/public-site/privacy.html
+++ b/packages/public-site/privacy.html
@@ -75,9 +75,18 @@
       <ul>
         <li>No advertising technology.</li>
         <li>No behavioral profiling.</li>
-        <li>No third-party analytics scripts on the public landing pages.</li>
-        <li>No cookies except session or strictly necessary technical storage where required for the service to function.</li>
+        <li>No third-party analytics scripts on the public landing pages or docs.</li>
+        <li>No behavioral ad cookies.</li>
       </ul>
+
+      <h2>First-party measurement</h2>
+      <p>
+        Beam uses a small first-party measurement layer on <strong>beam.directory</strong> and
+        <strong>docs.beam.directory</strong> to understand whether people move from the landing page
+        to guided evaluation, hosted beta intake, and demo proof points. This measurement stores an
+        anonymous session identifier, page or milestone keys, and timestamps. It does not store ad profiles,
+        form notes, or third-party tracking identifiers.
+      </p>
 
       <h2>Why we process this data</h2>
       <ul>


### PR DESCRIPTION
## Summary
- tighten operator shortcuts from alerts and dead letters into trace and recovery flows
- add owner and next action handling for critical operator signals
- add first-party funnel analytics across the landing, intake, demo, and docs surfaces

## Verification
- npm run build
- npm test
- cd docs && npm run build

Closes #56
Closes #57