### PR TITLE
Add 0.8.0 cut control and fix live dashboard CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.8.0 (draft)
+
+### Buyer Path
+- keep Beam on one plain-language path: landing page -> guided evaluation -> hosted pilot request
+- treat hosted beta as a guided design-partner engagement around one narrow workflow
+
+### Operator Workflow
+- tighten alert, dead-letter, and recovery shortcuts around owner and next action
+- add first-party funnel analytics and repo-visible dry-run evidence for buyer and operator flows
+- fix live CORS allowlists for the real dashboard production URL on both Directory and Message Bus
+
+### Release Control
+- add repo-visible `0.8.0` dry-run reports, cut checklist, and release-notes draft
+- keep `0.8.0` as a no-go until the live operator auth blocker is resolved
+
 ## v0.7.0 (2026-03-30)
 
 ### Hosted Beta

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -62,6 +62,7 @@ Strict allowlist:
 
 ```
 https://beam-dashboard.vercel.app
+https://dashboard-phi-five-73.vercel.app
 https://dashboard.beam.directory
 https://beam.directory
 https://www.beam.directory

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -521,6 +521,7 @@ function escapeCsvValue(value: string | number | null | undefined): string {
 
 const PUBLIC_CORS_ORIGINS = new Set([
   'https://beam-dashboard.vercel.app',
+  'https://dashboard-phi-five-73.vercel.app',
   'https://dashboard.beam.directory',
   'https://beam.directory',
   'https://www.beam.directory',

--- a/packages/message-bus/src/cors.ts
+++ b/packages/message-bus/src/cors.ts
@@ -6,6 +6,7 @@ const DEFAULT_PUBLIC_CORS_ORIGINS = new Set([
   'https://www.beam.directory',
   'https://dashboard.beam.directory',
   'https://beam-dashboard.vercel.app',
+  'https://dashboard-phi-five-73.vercel.app',
 ])
 
 function getConfiguredOrigins(): Set<string> {

--- a/reports/0.8.0-buyer-dry-run.md
+++ b/reports/0.8.0-buyer-dry-run.md
@@ -1,0 +1,130 @@
+# Beam 0.8.0 Buyer Dry Run
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-8-0-cut-control`
+- public refresh candidate already live on:
+  - `https://beam.directory/`
+  - `https://beam.directory/guided-evaluation.html`
+  - `https://beam.directory/hosted-beta.html`
+  - `https://docs.beam.directory/guide/design-partner-onboarding`
+- live API release truth during the run:
+  - version: `0.7.0`
+  - git SHA: `acc7a1d8578ae86c7de62e9b6ba30d5314ffafa0`
+  - deployed at: `2026-03-30T23:24:42Z`
+
+## Surfaces Used
+
+1. `https://beam.directory/`
+2. `https://beam.directory/guided-evaluation.html`
+3. `https://beam.directory/hosted-beta.html`
+4. `https://docs.beam.directory/guide/design-partner-onboarding`
+5. `https://api.beam.directory/analytics/events`
+6. `https://api.beam.directory/waitlist`
+7. `https://api.beam.directory/release`
+8. `https://api.beam.directory/stats`
+
+## Run
+
+### 1. Landing page comprehension
+
+The live landing page opens on the plain-language headline:
+
+- `Beam | Safe AI Work Between Companies`
+
+It pushes the buyer into one obvious next step:
+
+- top navigation CTA: `See guided evaluation`
+- hero CTA: `See the guided evaluation`
+- path CTA: `Open guided evaluation`
+
+The public analytics script is present on the live page:
+
+- `beam.directory` serves `/beam-analytics.js`
+
+### 2. Guided evaluation path
+
+The guided evaluation page is live and consistent with the landing copy:
+
+- primary CTA: `Request a guided pilot`
+- the analytics script is present here as well
+
+This keeps the public funnel narrow: explanation first, then one guided pilot request.
+
+### 3. Hosted beta intake
+
+The hosted beta page is live and correctly framed around one narrow workflow:
+
+- headline: `Request a guided Beam pilot for one real workflow.`
+- the workflow field is present
+- the page still reinforces `one workflow, one owner, one success condition`
+
+### 4. First-party analytics check
+
+A real live analytics event posted successfully to the hosted API with a first-party `Origin` header:
+
+```json
+{
+  "ok": true,
+  "event": {
+    "sessionId": "dryrun-buyer-acc7a1d",
+    "origin": "https://beam.directory",
+    "pageKey": "guided_evaluation",
+    "eventCategory": "cta_click",
+    "ctaKey": "guided_eval_hosted_beta_hero",
+    "targetPage": "hosted_beta"
+  }
+}
+```
+
+This is enough to treat the public funnel instrumentation as live, not just embedded.
+
+### 5. Hosted beta request check
+
+A real hosted beta intake request was accepted on the live API:
+
+```json
+{
+  "status": "registered",
+  "email": "beam-080-buyer-dryrun@northwind.example",
+  "company": "Northwind Example",
+  "workflowType": "hosted-beta-partner-handoff",
+  "requestStatus": "new",
+  "notificationId": 1,
+  "attentionFlags": ["unowned"]
+}
+```
+
+Important detail:
+
+- the request is not dropped on the floor
+- the API returns the canonical request object
+- the response includes the operator-facing next step immediately
+
+### 6. Onboarding pack alignment
+
+The design-partner onboarding page is live and reachable from docs. The pack still aligns with the hosted-beta story and keeps the conversation on a guided workflow instead of a protocol deep dive.
+
+## Result
+
+`PASS`
+
+The buyer-like path is now good enough for a real external first conversation:
+
+- the top-level message is understandable
+- the CTA path is singular instead of scattered
+- the intake is real
+- funnel instrumentation is live
+- the docs pack is aligned with the public path
+
+## Notes
+
+- The request created by this dry run is intentionally left in the queue as a realistic operator signal.
+- The request is correctly marked as attention-worthy because it is still unowned.
+
+## Go / No-Go Implication
+
+From the buyer side, `0.8.0` is no longer blocked by understanding or intake quality.
+
+The remaining cut risk is on the operator side, not the buyer side.

--- a/reports/0.8.0-operator-dry-run.md
+++ b/reports/0.8.0-operator-dry-run.md
@@ -1,0 +1,105 @@
+# Beam 0.8.0 Operator Dry Run
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-8-0-cut-control`
+- live surfaces used:
+  - `https://dashboard-phi-five-73.vercel.app`
+  - `https://api.beam.directory/admin/auth/config`
+  - `https://api.beam.directory/admin/auth/magic-link`
+  - `https://api.beam.directory/health`
+  - `https://api.beam.directory/release`
+  - `https://beam-message-bus.fly.dev/health`
+- live API release truth during the run:
+  - version: `0.7.0`
+  - git SHA: `acc7a1d8578ae86c7de62e9b6ba30d5314ffafa0`
+  - deployed at: `2026-03-30T23:24:42Z`
+
+## Run
+
+### 1. Dashboard production refresh
+
+The real production dashboard URL serves the refreshed dashboard bundle:
+
+- page title: `Beam Dashboard`
+- current JS bundle: `index-CTL2kq1I.js`
+
+This confirms the operator surface refresh is live on the actual production URL.
+
+### 2. Live CORS gate
+
+Initial operator verification exposed a real production bug:
+
+- `dashboard-phi-five-73.vercel.app` was not in the live Directory or Message Bus CORS allowlists
+
+That was fixed immediately during this dry run and redeployed live. After the fix:
+
+- `GET /admin/auth/config` with `Origin: https://dashboard-phi-five-73.vercel.app` returns `Access-Control-Allow-Origin: https://dashboard-phi-five-73.vercel.app`
+- `GET https://beam-message-bus.fly.dev/health` with the same origin returns the same allow-origin header
+
+Result:
+
+- the production dashboard is no longer blocked by a stale dashboard origin
+
+### 3. Admin auth preflight
+
+The remaining live operator gate is visible on the production API:
+
+```json
+{
+  "configured": false,
+  "emailDelivery": false,
+  "localDevMagicLinks": false,
+  "sessionTtlSeconds": 604800
+}
+```
+
+This means:
+
+- live operator sessions are not fully configured
+- there is no working delivery path for production magic links
+
+### 4. Magic-link request check
+
+Two real login attempts were tried:
+
+- a dry-run dashboard email
+- the local repo git email
+
+Both returned:
+
+```json
+{
+  "error": "This email is not authorized for admin access",
+  "errorCode": "UNAUTHORIZED"
+}
+```
+
+So the operator path still stops before the inbox, beta-request queue, or alert loop can be exercised live.
+
+## Result
+
+`NO-GO`
+
+The operator-like path is still blocked in production.
+
+## What Was Resolved During The Dry Run
+
+- stale dashboard production origin allowlist
+
+## What Still Blocks 0.8.0
+
+- live admin auth is not configured end to end
+- live magic-link delivery is not configured
+- no authorized admin could enter the real operator workflow on the live stack
+
+Explicit blocker:
+
+- [#65 Configure live admin auth and delivery for the operator dashboard](https://github.com/Beam-directory/beam-protocol/issues/65)
+
+## Go / No-Go Implication
+
+Do not cut `0.8.0` yet.
+
+Buyer readiness is good enough, but operator readiness is not. The milestone can only be cut after `#65` is resolved and this dry run is repeated successfully against the live dashboard.

--- a/reports/0.8.0-rc1-checklist.md
+++ b/reports/0.8.0-rc1-checklist.md
@@ -1,0 +1,107 @@
+# Beam 0.8.0 RC1 Checklist
+
+## Purpose
+
+This checklist is the explicit cut-control path for `0.8.0`.
+
+The milestone goal is no longer "ship more Beam". It is:
+
+**cut one design-partner-ready release only when the buyer path is clear, the operator path works on the live stack, and the release truth is boring.**
+
+## Current Candidate State
+
+- working branch for release-control artifacts: `codex/0-8-0-cut-control`
+- latest verified live app candidate during this pass:
+  - version: `0.7.0`
+  - live SHA: `acc7a1d8578ae86c7de62e9b6ba30d5314ffafa0`
+  - deployed at: `2026-03-30T23:24:42Z`
+- target tag once the blockers are gone: `v0.8.0`
+
+## Pre-Cut Freeze
+
+- [ ] `main` contains only `0.8.0`-scoped work
+- [ ] every open `0.8.0 Design Partner Beta` issue is either:
+  - closed, or
+  - explicitly moved out of the cut
+- [x] a repo-visible release-notes draft exists:
+  - [0.8.0-release-notes-draft.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-release-notes-draft.md)
+- [x] a repo-visible cut checklist exists:
+  - [0.8.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-rc1-checklist.md)
+
+## Repo Checks
+
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `cd docs && npm run build`
+- [ ] all GitHub Actions checks are green on the final cut commit
+
+## Live-Surface Verification
+
+- [x] `https://api.beam.directory/health` exposes the current release truth
+- [x] `https://api.beam.directory/stats` exposes the same release truth
+- [x] `https://api.beam.directory/release` exposes the same release truth
+- [x] `https://beam.directory/` reflects the buyer-language refresh
+- [x] `https://beam.directory/guided-evaluation.html` reflects the guided evaluation path
+- [x] `https://beam.directory/hosted-beta.html` reflects the one-workflow hosted pilot intake
+- [x] `https://dashboard-phi-five-73.vercel.app` reflects the refreshed dashboard build
+- [x] the real dashboard production URL is allowed by live Directory CORS
+- [x] the real dashboard production URL is allowed by live Message Bus CORS
+
+## Dry-Run Gate
+
+- [x] buyer-like dry run completed after the public refresh:
+  - [0.8.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-buyer-dry-run.md)
+- [x] operator-like dry run completed after the operator-surface refresh:
+  - [0.8.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-operator-dry-run.md)
+- [x] both reports point to exact live surfaces and release truth used during the run
+- [ ] no ambiguous blocker remains from the latest dry runs
+
+Current blocker:
+
+- [#65 Configure live admin auth and delivery for the operator dashboard](https://github.com/Beam-directory/beam-protocol/issues/65)
+
+## Go / No-Go
+
+### Go
+
+Ship `0.8.0` only if all of the following are true:
+
+- repo checks are green on one chosen candidate commit
+- buyer dry run still passes on the live surfaces
+- operator dry run reaches the live inbox / beta-request flow
+- `#65` is closed
+- live release truth agrees across `health`, `stats`, and `/release`
+
+### No-Go
+
+Do not tag if any of the following is true:
+
+- live operator login still stops at auth setup or delivery
+- the dashboard production URL and API allowlists drift again
+- live release truth does not point to one verified candidate
+- there is any blocker that exists only in chat and not as an issue
+
+## Final Cut Sequence
+
+1. merge the remaining `0.8.0` blocker fixes into `main`
+2. choose one final candidate SHA
+3. run local repo verification on that SHA
+4. verify GitHub Actions on that SHA
+5. deploy the hosted API from that SHA
+6. verify `health`, `stats`, and `/release`
+7. deploy the public site from that SHA
+8. verify `beam.directory`
+9. deploy the dashboard from that SHA
+10. rerun the buyer and operator dry runs
+11. update the changelog and release notes draft if the live surfaces forced wording changes
+12. tag `v0.8.0`
+13. publish the GitHub release
+
+## Current Release Decision
+
+`NO-GO`
+
+Reason:
+
+- buyer readiness is now good enough
+- operator readiness is still blocked by live admin auth configuration and delivery

--- a/reports/0.8.0-release-notes-draft.md
+++ b/reports/0.8.0-release-notes-draft.md
@@ -1,0 +1,63 @@
+# Beam 0.8.0 Release Notes Draft
+
+## Headline
+
+Beam `0.8.0` is the design-partner beta release:
+
+**one narrow, verifiable way for one company to hand AI work to another company, with a buyer-readable path and an operator-owned follow-up loop**
+
+## What Changed
+
+### Buyer path
+
+- rewrote the public site around plain-language buyer outcomes instead of protocol-first language
+- kept one dominant CTA path: landing page -> guided evaluation -> hosted pilot request
+- added FAQ and engagement posture so hosted beta feels like a guided pilot, not an open-ended waitlist
+
+### Hosted beta pipeline
+
+- turned hosted-beta requests into a real operator-owned queue with stage, owner, next action, last contact, and export
+- added operator-visible notifications for new beta requests and demo-critical failures
+- kept the request response itself useful by returning the canonical queue object and a clear next step
+
+### Guided evaluation and onboarding
+
+- added a guided evaluation surface for the public path
+- published the design-partner onboarding pack so the first live workflow can be scoped before a deeper technical conversation
+- kept docs, landing page, and intake language aligned around one narrow workflow
+
+### Operator workflow
+
+- tightened alert, dead-letter, and recovery shortcuts
+- added first-party funnel analytics and a dashboard funnel view
+- verified the real dashboard production URL against live Directory and Message Bus CORS
+
+## Release Control Inputs
+
+Use these artifacts as the release-control sources of truth:
+
+- [0.8.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-buyer-dry-run.md)
+- [0.8.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-operator-dry-run.md)
+- [0.8.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-rc1-checklist.md)
+
+## Current Blocker Before Tagging
+
+Do not publish this release yet.
+
+Open blocker:
+
+- [#65 Configure live admin auth and delivery for the operator dashboard](https://github.com/Beam-directory/beam-protocol/issues/65)
+
+## Compatibility Note
+
+- no protocol-family change is planned for this release
+- Beam stays on `beam/1`
+- the signed frame contract remains unchanged
+
+## Publish Notes
+
+Before publishing this text as the GitHub release body:
+
+- replace any remaining draft wording with the final candidate SHA and final live URLs
+- rerun the operator dry run after `#65`
+- remove any bullet that did not actually ship on the final tagged commit


### PR DESCRIPTION
## Summary
- add buyer and operator 0.8.0 dry-run reports, RC checklist, and release-notes draft
- document the current 0.8.0 no-go state clearly instead of relying on chat context
- fix live Directory and Message Bus CORS for the real dashboard production URL

## Verification
- npm run build
- npm test
- cd docs && npm run build
- live refresh on beam.directory, dashboard-phi-five-73.vercel.app, api.beam.directory, and beam-message-bus.fly.dev

## Follow-up
- keeps the remaining live operator blocker explicit in #65

Closes #58
Closes #59