### PR TITLE
Fix live admin auth delivery for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@
 - tighten alert, dead-letter, and recovery shortcuts around owner and next action
 - add first-party funnel analytics and repo-visible dry-run evidence for buyer and operator flows
 - fix live CORS allowlists for the real dashboard production URL on both Directory and Message Bus
+- enable live admin magic-link delivery for the real dashboard with explicit admin emails, dashboard URL, and Resend-backed delivery
 
 ### Release Control
 - add repo-visible `0.8.0` dry-run reports, cut checklist, and release-notes draft
-- keep `0.8.0` as a no-go until the live operator auth blocker is resolved
+- record the live operator-auth fix and keep `0.8.0` gated behind one final integrated cut pass
 
 ## v0.7.0 (2026-03-30)
 

--- a/docs/guide/operator-observability.md
+++ b/docs/guide/operator-observability.md
@@ -42,6 +42,7 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=beam
 SMTP_PASS=replace-me
+# or: SMTP_PASSWORD=replace-me
 SMTP_FROM=beam@example.com
 ```
 

--- a/packages/directory/README.md
+++ b/packages/directory/README.md
@@ -50,7 +50,7 @@ Default local endpoints:
 
 ### Verification and email
 
-- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` (or `SMTP_PASSWORD`), `SMTP_FROM`
 - `RESEND_API_KEY`
 - `COMPANIES_HOUSE_API_KEY`
 

--- a/packages/directory/src/email.test.ts
+++ b/packages/directory/src/email.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { getSmtpConfig, isEmailDeliveryConfigured } from './email.js'
+
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+test('getSmtpConfig prefers SMTP_PASS but falls back to SMTP_PASSWORD', () => {
+  const snapshot = {
+    SMTP_HOST: process.env['SMTP_HOST'],
+    SMTP_PORT: process.env['SMTP_PORT'],
+    SMTP_USER: process.env['SMTP_USER'],
+    SMTP_PASS: process.env['SMTP_PASS'],
+    SMTP_PASSWORD: process.env['SMTP_PASSWORD'],
+    SMTP_FROM: process.env['SMTP_FROM'],
+  }
+
+  try {
+    process.env['SMTP_HOST'] = 'smtp.example.com'
+    process.env['SMTP_PORT'] = '587'
+    process.env['SMTP_USER'] = 'beam@example.com'
+    process.env['SMTP_FROM'] = 'Beam <beam@example.com>'
+    delete process.env['SMTP_PASS']
+    process.env['SMTP_PASSWORD'] = 'fallback-secret'
+
+    const fallbackConfig = getSmtpConfig()
+    assert.equal(fallbackConfig.host, 'smtp.example.com')
+    assert.equal(fallbackConfig.pass, 'fallback-secret')
+    assert.equal(fallbackConfig.secure, false)
+    assert.equal(isEmailDeliveryConfigured(), true)
+
+    process.env['SMTP_PASS'] = 'preferred-secret'
+    const preferredConfig = getSmtpConfig()
+    assert.equal(preferredConfig.pass, 'preferred-secret')
+
+    process.env['SMTP_PORT'] = '465'
+    const secureConfig = getSmtpConfig()
+    assert.equal(secureConfig.secure, true)
+  } finally {
+    restoreEnv(snapshot)
+  }
+})

--- a/packages/directory/src/email.ts
+++ b/packages/directory/src/email.ts
@@ -8,24 +8,49 @@ type MailTransport = {
   }): Promise<unknown>
 }
 
+export type SmtpConfig = {
+  host: string | null
+  port: number
+  secure: boolean
+  user: string | null
+  pass: string | null
+  from: string | null
+}
+
+export function getSmtpConfig(): SmtpConfig {
+  const host = process.env['SMTP_HOST']?.trim() || null
+  const port = Number(process.env['SMTP_PORT'] ?? '587')
+  const user = process.env['SMTP_USER']?.trim() || null
+  const pass = process.env['SMTP_PASS']?.trim() || process.env['SMTP_PASSWORD']?.trim() || null
+  const from = process.env['SMTP_FROM']?.trim() || null
+
+  return {
+    host,
+    port,
+    secure: port === 465,
+    user,
+    pass,
+    from,
+  }
+}
+
 export function isEmailDeliveryConfigured(): boolean {
-  return Boolean(process.env['SMTP_HOST'] || process.env['RESEND_API_KEY'])
+  return Boolean(getSmtpConfig().host || process.env['RESEND_API_KEY'])
 }
 
 async function createTransport(): Promise<MailTransport> {
   const nodemailerModule = await import('nodemailer')
   const nodemailer = 'default' in nodemailerModule ? nodemailerModule.default : nodemailerModule
-  const smtpUser = process.env['SMTP_USER']
-  const smtpPass = process.env['SMTP_PASS']
+  const smtp = getSmtpConfig()
 
   return nodemailer.createTransport({
-    host: process.env['SMTP_HOST'],
-    port: Number(process.env['SMTP_PORT'] ?? '587'),
-    secure: Number(process.env['SMTP_PORT'] ?? '587') === 465,
-    auth: smtpUser || smtpPass
+    host: smtp.host ?? undefined,
+    port: smtp.port,
+    secure: smtp.secure,
+    auth: smtp.user || smtp.pass
       ? {
-          user: smtpUser,
-          pass: smtpPass,
+          user: smtp.user ?? undefined,
+          pass: smtp.pass ?? undefined,
         }
       : undefined,
   })
@@ -73,14 +98,14 @@ export async function sendAgentVerificationEmail(input: {
   verificationUrl.searchParams.set('token', input.token)
 
   const message = {
-    from: process.env['SMTP_FROM'],
+    from: getSmtpConfig().from ?? undefined,
     to: input.email,
     subject: `Verify your Beam Directory email for ${input.beamId}`,
     text: `Verify your Beam Directory email for ${input.beamId}: ${verificationUrl.toString()}`,
     html: `<p>Verify your Beam Directory email for <strong>${input.beamId}</strong>.</p><p><a href="${verificationUrl.toString()}">Verify email</a></p>`,
   }
 
-  if (process.env['SMTP_HOST']) {
+  if (getSmtpConfig().host) {
     const transporter = await createTransport()
     await transporter.sendMail(message)
     return true
@@ -101,14 +126,14 @@ export async function sendAdminMagicLinkEmail(input: {
   role: 'admin' | 'operator' | 'viewer'
 }): Promise<boolean> {
   const message = {
-    from: process.env['SMTP_FROM'],
+    from: getSmtpConfig().from ?? undefined,
     to: input.email,
     subject: 'Beam admin sign-in link',
     text: `Use this Beam admin sign-in link to continue as ${input.role}: ${input.url}`,
     html: `<p>Use this Beam admin sign-in link to continue as <strong>${input.role}</strong>.</p><p><a href="${input.url}">Sign in to Beam Dashboard</a></p>`,
   }
 
-  if (process.env['SMTP_HOST']) {
+  if (getSmtpConfig().host) {
     const transporter = await createTransport()
     await transporter.sendMail(message)
     return true

--- a/reports/0.8.0-live-admin-auth-fix.md
+++ b/reports/0.8.0-live-admin-auth-fix.md
@@ -1,0 +1,83 @@
+# Beam 0.8.0 Live Admin Auth Fix
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/live-admin-auth-delivery`
+- live surfaces used:
+  - `https://api.beam.directory/admin/auth/config`
+  - `https://api.beam.directory/admin/auth/magic-link`
+  - `https://api.beam.directory/admin/auth/verify`
+  - `https://api.beam.directory/admin/auth/session`
+  - `https://dashboard-phi-five-73.vercel.app`
+- live API release truth during the run:
+  - version: `0.7.0`
+  - git SHA: `acc7a1d8578ae86c7de62e9b6ba30d5314ffafa0`
+  - deployed at: `2026-03-30T23:24:42Z`
+
+## What Changed
+
+The live Directory app was updated with the missing production admin-auth configuration:
+
+- `BEAM_ADMIN_EMAILS` now authorizes the real operator email
+- `BEAM_DASHBOARD_URL` now points to `https://dashboard-phi-five-73.vercel.app`
+- Resend-backed delivery is now configured for production magic links
+
+The repo-side SMTP compatibility fix for `SMTP_PASSWORD` vs `SMTP_PASS` is tracked on this branch so self-hosted installs can use either name consistently.
+
+## Verification
+
+### 1. Admin-auth preflight
+
+`GET /admin/auth/config` now returns:
+
+```json
+{
+  "configured": true,
+  "emailDelivery": true,
+  "localDevMagicLinks": false,
+  "sessionTtlSeconds": 604800
+}
+```
+
+This confirms production no longer stops at missing auth configuration or missing delivery.
+
+### 2. Production magic-link request
+
+`POST /admin/auth/magic-link` for the real admin email now returns:
+
+```json
+{
+  "ok": true,
+  "email": "tobias.kub@appfor.de",
+  "role": "admin",
+  "expiresAt": "2026-03-31T00:14:32.861Z",
+  "dev": false
+}
+```
+
+This confirms the live API accepts the real admin identity and uses the production delivery path.
+
+### 3. Session verification
+
+The freshly issued magic-link token was consumed against the live API, and the resulting admin session was checked with `GET /admin/auth/session`.
+
+Observed live session state:
+
+```json
+{
+  "email": "tobias.kub@appfor.de",
+  "role": "admin",
+  "expiresAt": "2026-04-07T00:00:13.981Z"
+}
+```
+
+This confirms the production operator auth flow is valid end to end.
+
+## Result
+
+`PASS`
+
+Issue resolved:
+
+- [#65 Configure live admin auth and delivery for the operator dashboard](https://github.com/Beam-directory/beam-protocol/issues/65)

--- a/reports/0.8.0-rc1-checklist.md
+++ b/reports/0.8.0-rc1-checklist.md
@@ -40,6 +40,8 @@ The milestone goal is no longer "ship more Beam". It is:
 - [x] `https://api.beam.directory/health` exposes the current release truth
 - [x] `https://api.beam.directory/stats` exposes the same release truth
 - [x] `https://api.beam.directory/release` exposes the same release truth
+- [x] `https://api.beam.directory/admin/auth/config` reports `configured: true` and `emailDelivery: true`
+- [x] the real admin email can request, verify, and introspect a live operator session
 - [x] `https://beam.directory/` reflects the buyer-language refresh
 - [x] `https://beam.directory/guided-evaluation.html` reflects the guided evaluation path
 - [x] `https://beam.directory/hosted-beta.html` reflects the one-workflow hosted pilot intake
@@ -53,10 +55,12 @@ The milestone goal is no longer "ship more Beam". It is:
   - [0.8.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-buyer-dry-run.md)
 - [x] operator-like dry run completed after the operator-surface refresh:
   - [0.8.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-operator-dry-run.md)
+- [x] live admin-auth blocker rerun completed after the delivery fix:
+  - [0.8.0-live-admin-auth-fix.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-live-admin-auth-fix.md)
 - [x] both reports point to exact live surfaces and release truth used during the run
 - [ ] no ambiguous blocker remains from the latest dry runs
 
-Current blocker:
+Resolved since the latest dry run:
 
 - [#65 Configure live admin auth and delivery for the operator dashboard](https://github.com/Beam-directory/beam-protocol/issues/65)
 
@@ -99,9 +103,10 @@ Do not tag if any of the following is true:
 
 ## Current Release Decision
 
-`NO-GO`
+`HOLD`
 
 Reason:
 
 - buyer readiness is now good enough
-- operator readiness is still blocked by live admin auth configuration and delivery
+- the live admin-auth blocker is resolved
+- one final integrated buyer/operator rerun still needs to be recorded on the chosen cut candidate


### PR DESCRIPTION
## Summary
- support `SMTP_PASSWORD` as an alias for `SMTP_PASS` in the Directory mailer
- document the mail-env compatibility and add a focused SMTP config test
- record the live `#65` admin-auth fix and update the 0.8.0 RC checklist

## Verification
- npm test --workspace=packages/directory
- cd docs && npm run build
- live `api.beam.directory/admin/auth/config` -> `configured: true`, `emailDelivery: true`
- live magic-link request, verify, and session introspection for the real admin email

Closes #65