### PR TITLE
Plan 0.8.1 release hygiene and 0.9.0 design-partner launch

### DIFF
--- a/reports/0.8.1-release-hygiene-plan.md
+++ b/reports/0.8.1-release-hygiene-plan.md
@@ -1,0 +1,97 @@
+# Beam 0.8.1 Release Hygiene Plan
+
+## Goal
+
+Beam `0.8.1` is not a product milestone. It is a release-operations cleanup pass.
+
+The purpose is simple:
+
+**remove the manual release glue that still existed during the `0.8.0` cut so the next release is boring**
+
+At the end of `0.8.1`, the team should not need ad hoc manual steps to:
+
+1. create the GitHub release,
+2. push the public site live,
+3. inject release-truth metadata into production,
+4. explain whether the release is actually complete.
+
+## Why This Exists
+
+`0.8.0` shipped successfully, but the cut still exposed a few process-level gaps:
+
+- the GitHub Release entry did not appear automatically on tag push,
+- `beam.directory` still depended on a separate production deploy path outside the repo workflows,
+- release-truth metadata for the live API still needed a manual production push,
+- the docs deployment still emits a known GitHub Pages Node 20 deprecation warning.
+
+None of these blocked `0.8.0`, but all of them are the wrong kind of work to repeat during `0.9.0`.
+
+## Scope
+
+`0.8.1` should only include release and deployment hygiene:
+
+- GitHub release creation on tag,
+- public-site deployment automation,
+- release-truth automation,
+- docs workflow hygiene,
+- one explicit release-verification path.
+
+## Non-Goals
+
+`0.8.1` is not for:
+
+- new protocol features,
+- new dashboard surfaces,
+- new landing-page messaging work,
+- new hosted-beta pipeline behavior,
+- widening the product scope.
+
+## Success Criteria
+
+`0.8.1` is done when all of the following are true:
+
+- pushing a release tag creates a published GitHub release without a manual follow-up step,
+- `beam.directory` deploys from the repo-controlled workflow instead of a separate manual path,
+- production release-truth values are derived from the tagged commit through automation,
+- the docs deploy path no longer relies on the known Node 20 deprecation-prone step, or the remaining warning is explicitly isolated with a planned upstream-safe workaround,
+- one repo-visible verification script or checklist can prove:
+  - live API version and SHA,
+  - public-site version evidence,
+  - docs deployment freshness,
+  - npm package versions.
+
+## Workstreams
+
+### 1. Release Automation
+
+Make tag push mean "real release" instead of "release plus manual cleanup".
+
+### 2. Public Deploy Automation
+
+Bring `beam.directory` onto the same repeatable repo-driven deployment path as the rest of the release.
+
+### 3. Release Truth
+
+Make production version/SHA/deployed-at values deterministic and automation-owned.
+
+### 4. Docs Workflow Hygiene
+
+Remove or isolate the remaining GitHub Pages warning path so it does not linger as recurring release noise.
+
+### 5. Verification
+
+Ship one short, explicit release-smoke path that can be run after every tagged cut.
+
+## Planned Backlog
+
+1. [#69](https://github.com/Beam-directory/beam-protocol/issues/69) Automate GitHub release creation on tag push.
+2. [#70](https://github.com/Beam-directory/beam-protocol/issues/70) Automate production deployment for `beam.directory` from the repo workflow.
+3. [#71](https://github.com/Beam-directory/beam-protocol/issues/71) Automate live release-truth injection from the tagged commit.
+4. [#72](https://github.com/Beam-directory/beam-protocol/issues/72) Remove or isolate the remaining docs deploy Node 20 warning.
+5. [#73](https://github.com/Beam-directory/beam-protocol/issues/73) Add a release smoke path for API, public site, docs, and npm.
+
+## Release Decision
+
+Only cut `0.8.1` if these changes stay small and operational.
+
+If a task starts turning into product work, it belongs in `0.9.0`.

--- a/reports/0.9.0-design-partner-launch-plan.md
+++ b/reports/0.9.0-design-partner-launch-plan.md
@@ -1,0 +1,212 @@
+# Beam 0.9.0 Design Partner Launch Plan
+
+## Goal
+
+Beam `0.9.0` should move from "shipped design-partner-ready release" to "operational design-partner launch motion".
+
+The milestone goal is:
+
+**turn Beam into a product that can attract, qualify, run, and follow through on real design-partner pilots for verified B2B handoffs**
+
+At the end of `0.9.0`, Beam should feel less like a polished evaluation and more like a repeatable design-partner machine.
+
+## Target Outcome
+
+By `0.9.0`, the team should be able to do this cleanly:
+
+1. a buyer lands on `beam.directory` and understands the use case immediately,
+2. the buyer requests a guided pilot with enough qualification data to act on,
+3. an operator owns the request, schedules next action, and keeps the thread warm,
+4. the pilot produces shareable proof that can be sent back to the buyer,
+5. the team can see where the funnel converts or stalls without relying on memory.
+
+## North Star
+
+Beam `0.9.0` succeeds if one external-style design-partner workflow can move through the full path:
+
+`landing page -> hosted beta request -> operator qualification -> scheduled walkthrough -> live pilot proof -> follow-up decision`
+
+without improvising the process in chat.
+
+## Non-Goals
+
+`0.9.0` is not for:
+
+- widening Beam into a generic multi-agent platform,
+- introducing major new protocol primitives,
+- adding broad new SDK/framework integrations as headline work,
+- building self-serve enterprise packaging or billing,
+- multiplying demos instead of strengthening one design-partner motion.
+
+## Current Position After 0.8.0
+
+Beam already has the right foundation:
+
+- a clear buyer-language landing page,
+- a guided evaluation path,
+- a hosted-beta intake,
+- an operator inbox and beta-request pipeline,
+- live proof, observability, and release-truth surfaces,
+- a clean `0.8.0` release with published packages and evidence reports.
+
+What is still missing is not core protocol credibility. It is execution maturity:
+
+- the design-partner funnel is visible but not yet strong enough for steady follow-through,
+- operator follow-up still needs a more explicit contact rhythm,
+- the product has proof, but not yet a richer proof pack for outbound or recap use,
+- the team has analytics, but not yet enough partner-stage insight to manage a live motion.
+
+## Success Criteria
+
+`0.9.0` is done when all of the following are true:
+
+- `beam.directory` has a stronger proof-first story for design partners:
+  - what Beam solves,
+  - what a guided pilot looks like,
+  - what proof the buyer receives,
+  - what the next commercial step is.
+- hosted-beta requests support an execution rhythm:
+  - stage aging,
+  - reminders,
+  - last contact,
+  - next meeting / next action,
+  - explicit owner accountability.
+- the operator dashboard supports design-partner follow-through:
+  - queue by urgency,
+  - overdue follow-ups,
+  - recent activity timeline,
+  - linked evidence from live pilot runs.
+- Beam can produce a shareable pilot proof package:
+  - short summary,
+  - trace / reliability proof,
+  - screenshots or proof links,
+  - recommended next step.
+- the funnel is measurable beyond raw CTA clicks:
+  - request -> qualified,
+  - qualified -> scheduled,
+  - scheduled -> pilot completed,
+  - pilot completed -> next-step decision.
+- at least two external-style dry runs are documented on the `0.9.0` candidate:
+  - one buyer / design-partner pass,
+  - one operator / follow-up pass.
+
+## Product Thesis For 0.9.0
+
+The key product bet for `0.9.0` is this:
+
+**Beam grows by making the design-partner motion tighter, not by making the protocol broader.**
+
+That means the milestone should optimize for:
+
+- conversion clarity over more capability,
+- follow-through over novelty,
+- proof packages over more internal complexity,
+- operator rhythm over more raw surface area.
+
+## Workstreams
+
+### 1. Design-Partner Conversion Surface
+
+Goal: make the public story strong enough to convert real design-partner conversations.
+
+Scope:
+
+- sharpen the "why Beam" story with more concrete proof,
+- add a richer proof section or pilot recap surface,
+- strengthen FAQ / pilot framing / next-step language,
+- make the design-partner CTA path feel intentional instead of exploratory.
+
+### 2. Partner Pipeline And Follow-Up Rhythm
+
+Goal: turn the beta-request pipeline into a real partner-tracking workflow.
+
+Scope:
+
+- stage aging and overdue follow-up visibility,
+- reminder and follow-up templates,
+- last-contact and next-meeting semantics,
+- clearer operator ownership for every partner thread.
+
+### 3. Operator Timeline And Evidence
+
+Goal: make pilot support and recap work faster and less manual.
+
+Scope:
+
+- partner activity timeline,
+- linked trace / alert / dead-letter evidence,
+- better shortcut flow from partner record to live operational proof,
+- explicit recap state after pilot completion.
+
+### 4. Shareable Proof Package
+
+Goal: make Beam easy to recap after a pilot.
+
+Scope:
+
+- a concise partner-proof artifact,
+- a repeatable summary generated from live evidence,
+- short references to reliability, identity, and operator visibility,
+- a clean "what happens next" section for the buyer.
+
+### 5. Funnel And Stage Analytics
+
+Goal: measure the design-partner motion, not just page activity.
+
+Scope:
+
+- pipeline stage counts,
+- stage conversion,
+- stage aging,
+- partner request source,
+- operator follow-up lag.
+
+### 6. Dry Runs And Cut Control
+
+Goal: keep the next release disciplined.
+
+Scope:
+
+- one buyer-like dry run,
+- one operator-like dry run,
+- one repo-visible cut checklist and release-notes draft before the final week.
+
+## Planned Backlog
+
+1. [#74](https://github.com/Beam-directory/beam-protocol/issues/74) Strengthen the landing and guided-evaluation proof package for design-partner conversion.
+2. [#75](https://github.com/Beam-directory/beam-protocol/issues/75) Add stage aging, reminders, and next-meeting state to the beta-request pipeline.
+3. [#76](https://github.com/Beam-directory/beam-protocol/issues/76) Add a partner activity timeline and tighter operator follow-up loop.
+4. [#77](https://github.com/Beam-directory/beam-protocol/issues/77) Generate a shareable pilot proof summary from live evidence.
+5. [#78](https://github.com/Beam-directory/beam-protocol/issues/78) Add partner-stage analytics and overdue follow-up reporting.
+6. [#79](https://github.com/Beam-directory/beam-protocol/issues/79) Run buyer and operator design-partner dry runs on the `0.9.0` candidate.
+7. [#80](https://github.com/Beam-directory/beam-protocol/issues/80) Prepare the `0.9.0` cut checklist and release notes before the final cut.
+
+## Sequence
+
+### Phase 1: Tighten The Conversion Story
+
+- strengthen proof and CTA surfaces,
+- make the design-partner motion easier to understand,
+- keep the public story narrow and concrete.
+
+### Phase 2: Tighten The Partner Pipeline
+
+- make ownership and follow-up visible,
+- eliminate stale partner requests,
+- make reminders and stage aging operationally obvious.
+
+### Phase 3: Tighten The Operator Loop
+
+- connect partner records with live evidence,
+- reduce context-switching during support and recap,
+- make pilot follow-up procedural.
+
+### Phase 4: Measure And Dry Run
+
+- turn on stage-level reporting,
+- run two fresh design-partner passes,
+- cut only from explicit evidence.
+
+## Release Decision
+
+`0.9.0` should ship only when Beam can support a real design-partner motion end to end, not merely demonstrate one.


### PR DESCRIPTION
## Summary
- add a small 0.8.1 release-hygiene plan to remove manual release/deploy glue after v0.8.0
- add the 0.9.0 design-partner launch plan focused on conversion, follow-through, and proof
- close the old 0.8.0 milestone and seed the next issue backlog on GitHub

## Notes
- no product code changes in this PR
- the GitHub backlog now spans issues #69-#80 across the two new milestones