### PR TITLE
Force docs deploy actions onto Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,12 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+env:
+  # actions/upload-pages-artifact@v4 still shells through upload-artifact v4.
+  # Force GitHub-hosted JS actions onto Node 24 now so the docs path stays quiet
+  # ahead of the Node 20 runner deprecation.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: read
   pages: write

--- a/reports/0.8.1-release-hygiene-plan.md
+++ b/reports/0.8.1-release-hygiene-plan.md
@@ -104,3 +104,9 @@ For `#71`, the tagged release path should stay deterministic:
 - the directory deploy job writes `packages/directory/release.json` from the tag version, tagged SHA, and deploy timestamp,
 - the Fly deploy builds that exact metadata into the API image,
 - the workflow verifies that `https://api.beam.directory/health`, `/stats`, and `/release` all report the same live release truth before the GitHub release job finishes.
+
+For `#72`, the docs deploy path should keep the current GitHub Pages action set, but opt GitHub-hosted JavaScript actions into Node 24 explicitly:
+
+- `actions/upload-pages-artifact@v4` currently pulls `actions/upload-artifact@v4` under the hood,
+- GitHub's own warning recommends `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` as the forward-safe workaround,
+- the custom-domain verification step must stay in place so the workaround does not quietly regress `docs.beam.directory`.


### PR DESCRIPTION
## Summary
- opt the docs deploy workflow into Node 24 for GitHub-hosted JavaScript actions
- keep the existing Pages/custom-domain flow intact
- document the workaround in the 0.8.1 release hygiene plan

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "yaml-ok"'
- git diff --check