### PR TITLE
Prepare 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.8.1 (2026-03-31)
+
+### Release Hygiene
+- automate GitHub release creation from tagged builds using repo-owned release notes
+- automate the public-site deployment path from the repo workflow and keep the live deploy path inside GitHub
+- automate API release-truth injection so tagged version, SHA, and deploy timestamp are written into the directory image and verified live after deploy
+- isolate the remaining GitHub Pages Node 20 deprecation noise behind the explicit Node 24 opt-in workaround for JavaScript actions
+- add one repo-visible release smoke path for API, public site, docs, and npm, plus a checked-in baseline evidence report
+
+### Compatibility Note
+- No protocol-family change in this release train. Beam `0.8.1` remains on `beam/1`.
+
 ## v0.8.0 (2026-03-31)
 
 ### Buyer Path

--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ See the full policy in [`docs/guide/compatibility.md`](./docs/guide/compatibilit
 ## Release Readiness
 
 The 0.6.0 dogfood workflow and findings live in [`reports/0.6.0-release-readiness.md`](./reports/0.6.0-release-readiness.md).
-The current release-control evidence lives in [`reports/0.8.0-buyer-final-pass.md`](./reports/0.8.0-buyer-final-pass.md), [`reports/0.8.0-operator-final-pass.md`](./reports/0.8.0-operator-final-pass.md), [`reports/0.8.0-rc1-checklist.md`](./reports/0.8.0-rc1-checklist.md), and [`reports/0.8.0-release-smoke.md`](./reports/0.8.0-release-smoke.md).
+The current release-control evidence lives in [`reports/0.8.0-buyer-final-pass.md`](./reports/0.8.0-buyer-final-pass.md), [`reports/0.8.0-operator-final-pass.md`](./reports/0.8.0-operator-final-pass.md), [`reports/0.8.0-rc1-checklist.md`](./reports/0.8.0-rc1-checklist.md), [`reports/0.8.0-release-smoke.md`](./reports/0.8.0-release-smoke.md), and [`reports/0.8.1-release-notes-draft.md`](./reports/0.8.1-release-notes-draft.md).
 
 For post-release verification, run:
 
 ```bash
-npm run release:smoke -- --version 0.8.0 --git-sha <tagged-sha> --output reports/0.8.0-release-smoke.md
+npm run release:smoke -- --version <release-version> --git-sha <tagged-sha> --output reports/<release-version>-release-smoke.md
 ```
 
 ## Repository Layout

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-03-30T19:00:00.000Z",
   "release": {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-03-30T19:00:00.000Z"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol-docs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "devDependencies": {
         "vitepress": "1.6.4"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "0.8.0"
+  "version": "0.8.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.8.0",
+        "beam-protocol-sdk": "^0.8.1",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.8.0"
+        "beam-protocol-sdk": "^0.8.1"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.8.0",
+    "beam-protocol-sdk": "^0.8.1",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.8.0"
+    "beam-protocol-sdk": "^0.8.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",

--- a/reports/0.8.1-release-notes-draft.md
+++ b/reports/0.8.1-release-notes-draft.md
@@ -1,0 +1,41 @@
+# Beam 0.8.1 Release Notes
+
+Beam `0.8.1` is a release-hygiene patch release.
+
+It does not widen the Beam product surface or change the protocol family.
+It makes the release path itself boring, repeatable, and repo-owned.
+
+## What Changed
+
+### Release Automation
+
+- tag builds now publish the GitHub release from the repo using a checked-in notes file
+- the public-site production deploy path is now driven from the repo workflow instead of a separate manual path
+
+### Live Release Truth
+
+- tag builds now write version, git SHA, and deploy timestamp into the directory release metadata
+- the Fly deploy step verifies that `/health`, `/stats`, and `/release` all agree on the live release truth before the GitHub release job completes
+
+### Docs Deploy Hygiene
+
+- the docs workflow now opts GitHub-hosted JavaScript actions into Node 24 explicitly
+- the custom-domain deploy path for `docs.beam.directory` stays intact while the remaining upstream Pages annotation is isolated and documented
+
+### Release Verification
+
+- Beam now includes a single release smoke path at `npm run release:smoke`
+- the smoke verifies:
+  - live API release truth
+  - public-site proof pages
+  - docs freshness
+  - published npm package versions
+
+## Evidence
+
+- [0.8.0-release-smoke.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.0-release-smoke.md)
+- [0.8.1-release-hygiene-plan.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.8.1-release-hygiene-plan.md)
+
+## Compatibility Note
+
+No protocol-family change in this release train. Beam `0.8.1` remains on `beam/1`.


### PR DESCRIPTION
## Summary
- bump the repo and published package versions to 0.8.1
- add the checked-in 0.8.1 release notes draft used by the tag workflow
- keep README and API docs aligned with the new release-smoke path

## Verification
- npm run build
- npm test
- cd docs && npm run build
- npm pack --dry-run --workspace=packages/sdk-typescript
- npm pack --dry-run --workspace=packages/cli