### PR TITLE
Add 0.8.1 release recovery workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,18 @@ jobs:
       - name: Install Flyctl
         run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/home/runner/.fly sh
 
+      - name: Clear stale Fly release env overrides
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          test -n "$FLY_API_TOKEN" || { echo "Missing FLY_API_TOKEN repo secret" >&2; exit 1; }
+          /home/runner/.fly/bin/flyctl secrets unset \
+            BEAM_RELEASE_VERSION \
+            BEAM_RELEASE_SHA \
+            BEAM_DEPLOYED_AT \
+            --app beam-protocol \
+            --stage || true
+
       - name: Deploy directory API to Fly.io
         working-directory: packages/directory
         env:

--- a/.github/workflows/recover-release.yml
+++ b/.github/workflows/recover-release.yml
@@ -1,0 +1,109 @@
+name: Recover Tagged Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing git tag to recover and verify
+        required: true
+        type: string
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tagged ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Prepare tagged release metadata
+        env:
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          VERSION="${TAG_NAME#v}"
+          GIT_SHA="$(git rev-parse "${TAG_NAME}^{commit}")"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+
+          if [ "$VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Tag version $VERSION does not match package.json version $PACKAGE_VERSION" >&2
+            exit 1
+          fi
+
+          DEPLOYED_AT="$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+
+          node scripts/release/write-directory-release-metadata.mjs \
+            --version "$VERSION" \
+            --git-sha "$GIT_SHA" \
+            --deployed-at "$DEPLOYED_AT"
+
+          echo "BEAM_RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "BEAM_RELEASE_SHA=$GIT_SHA" >> "$GITHUB_ENV"
+          echo "BEAM_DEPLOYED_AT=$DEPLOYED_AT" >> "$GITHUB_ENV"
+
+      - name: Install Flyctl
+        run: curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/home/runner/.fly sh
+
+      - name: Clear stale Fly release env overrides
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          test -n "$FLY_API_TOKEN" || { echo "Missing FLY_API_TOKEN repo secret" >&2; exit 1; }
+          /home/runner/.fly/bin/flyctl secrets unset \
+            BEAM_RELEASE_VERSION \
+            BEAM_RELEASE_SHA \
+            BEAM_DEPLOYED_AT \
+            --app beam-protocol \
+            --stage || true
+
+      - name: Deploy directory API to Fly.io
+        working-directory: packages/directory
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          test -n "$FLY_API_TOKEN" || { echo "Missing FLY_API_TOKEN repo secret" >&2; exit 1; }
+          /home/runner/.fly/bin/flyctl deploy \
+            --config fly.toml \
+            --app beam-protocol \
+            --remote-only \
+            --yes
+
+      - name: Verify live API release truth
+        run: |
+          node scripts/release/verify-api-release-truth.mjs \
+            --base-url "https://api.beam.directory" \
+            --version "$BEAM_RELEASE_VERSION" \
+            --git-sha "$BEAM_RELEASE_SHA" \
+            --deployed-at "$BEAM_DEPLOYED_AT"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.tag }}
+        run: |
+          NOTES_FILE="reports/${TAG_NAME#v}-release-notes-draft.md"
+
+          if [ ! -f "$NOTES_FILE" ]; then
+            echo "Expected release notes file not found: $NOTES_FILE" >&2
+            exit 1
+          fi
+
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release edit "$TAG_NAME" \
+              --title "$TAG_NAME" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          else
+            gh release create "$TAG_NAME" \
+              --verify-tag \
+              --title "$TAG_NAME" \
+              --notes-file "$NOTES_FILE" \
+              --latest
+          fi


### PR DESCRIPTION
## Summary
- add a workflow_dispatch path to recover an already-tagged release
- clear stale Fly release env overrides before tag deploys
- reuse the existing release verification and GitHub release steps for recovery

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/recover-release.yml"); puts "yaml ok"'
