### PR TITLE
Strengthen design-partner conversion and follow-up pipeline

### DIFF
--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -6,7 +6,7 @@ export type IntentLifecycleStatus = 'received' | 'validated' | 'queued' | 'dispa
 export type AlertMetricUnit = 'ratio' | 'ms' | 'count'
 export type AlertLinkSurface = 'trace' | 'intents' | 'audit' | 'errors' | 'federation' | 'alerts'
 export type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
-export type BetaRequestAttention = 'unowned' | 'stale'
+export type BetaRequestAttention = 'unowned' | 'stale' | 'follow_up_due'
 export type BetaRequestExportFormat = 'json' | 'csv'
 export type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 export type OperatorNotificationSource = 'beta_request' | 'critical_alert'
@@ -572,8 +572,15 @@ export interface BetaRequest {
   operatorNotes: string | null
   nextAction: string | null
   lastContactAt: string | null
+  nextMeetingAt: string | null
+  reminderAt: string | null
+  stageEnteredAt: string
+  stageAgeHours: number
+  stageAgeLabel: string
   stale: boolean
   staleReason: string | null
+  followUpDue: boolean
+  followUpReason: string | null
   attentionFlags: BetaRequestAttention[]
   notificationId: number | null
   notificationStatus: OperatorNotificationStatus | null
@@ -596,6 +603,7 @@ export interface BetaRequestSummary {
   active: number
   unowned: number
   stale: number
+  followUpDue: number
   needsAttention: number
   byStatus: Record<BetaRequestStatus, number>
 }
@@ -616,6 +624,8 @@ export interface BetaRequestUpdateInput {
   operatorNotes?: string | null
   nextAction?: string | null
   lastContactAt?: string | null
+  nextMeetingAt?: string | null
+  reminderAt?: string | null
 }
 
 export interface BetaRequestUpdateResponse {

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -27,6 +27,7 @@ const ATTENTION_OPTIONS: Array<{ value: '' | BetaRequestAttention; label: string
   { value: '', label: 'All requests' },
   { value: 'unowned', label: 'Unowned' },
   { value: 'stale', label: 'Stale' },
+  { value: 'follow_up_due', label: 'Follow-up due' },
 ]
 
 const SORT_OPTIONS = [
@@ -53,6 +54,7 @@ export default function BetaRequestsPage() {
     active: number
     unowned: number
     stale: number
+    followUpDue: number
     needsAttention: number
     byStatus: Record<BetaRequestStatus, number>
   } | null>(null)
@@ -78,6 +80,8 @@ export default function BetaRequestsPage() {
   const [draftOwner, setDraftOwner] = useState('')
   const [draftNextAction, setDraftNextAction] = useState('')
   const [draftLastContactAt, setDraftLastContactAt] = useState('')
+  const [draftNextMeetingAt, setDraftNextMeetingAt] = useState('')
+  const [draftReminderAt, setDraftReminderAt] = useState('')
   const [draftNotes, setDraftNotes] = useState('')
 
   function updateSearchParam(key: string, value: string) {
@@ -108,6 +112,8 @@ export default function BetaRequestsPage() {
       setDraftOwner('')
       setDraftNextAction('')
       setDraftLastContactAt('')
+      setDraftNextMeetingAt('')
+      setDraftReminderAt('')
       setDraftNotes('')
       return
     }
@@ -116,6 +122,8 @@ export default function BetaRequestsPage() {
     setDraftOwner(selectedRequest.owner ?? '')
     setDraftNextAction(selectedRequest.nextAction ?? '')
     setDraftLastContactAt(toDateTimeLocalValue(selectedRequest.lastContactAt))
+    setDraftNextMeetingAt(toDateTimeLocalValue(selectedRequest.nextMeetingAt))
+    setDraftReminderAt(toDateTimeLocalValue(selectedRequest.reminderAt))
     setDraftNotes(selectedRequest.operatorNotes ?? '')
   }, [selectedRequest])
 
@@ -158,6 +166,8 @@ export default function BetaRequestsPage() {
         owner: draftOwner || null,
         nextAction: draftNextAction || null,
         lastContactAt: draftLastContactAt || null,
+        nextMeetingAt: draftNextMeetingAt || null,
+        reminderAt: draftReminderAt || null,
         operatorNotes: draftNotes || null,
       })
       setRequests((current) => current.map((entry) => (
@@ -194,7 +204,7 @@ export default function BetaRequestsPage() {
     <div className="space-y-6">
       <PageHeader
         title="Hosted Beta Requests"
-        description="Run hosted beta intake as a real operator queue with stage, ownership, next action, and follow-up state."
+        description="Run hosted beta intake as a real operator queue with stage, ownership, next action, meeting state, and follow-up timing."
         actions={(
           <div className="flex flex-wrap gap-2">
             <button className="btn-secondary" onClick={() => void exportRequests('json')} type="button">
@@ -214,11 +224,12 @@ export default function BetaRequestsPage() {
       />
 
       {summary ? (
-        <section className="grid gap-4 md:grid-cols-4 xl:grid-cols-5">
+        <section className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
           <MetricCard label="Total requests" value={String(summary.total)} hint="All hosted beta requests in the current filter." />
-          <MetricCard label="Need attention" value={String(summary.needsAttention)} hint="Requests that are unowned or stale." tone={summary.needsAttention > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Need attention" value={String(summary.needsAttention)} hint="Requests that are unowned, stale, or due for follow-up." tone={summary.needsAttention > 0 ? 'warning' : 'default'} />
           <MetricCard label="Unowned" value={String(summary.unowned)} hint="Requests without an assigned operator." tone={summary.unowned > 0 ? 'critical' : 'default'} />
           <MetricCard label="Stale" value={String(summary.stale)} hint="Requests that have gone too long without contact." tone={summary.stale > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Follow-up due" value={String(summary.followUpDue)} hint="Requests with a due reminder or missing next meeting state." tone={summary.followUpDue > 0 ? 'warning' : 'default'} />
           <MetricCard label="Active" value={String(summary.active)} hint="Everything that is not closed." tone="success" />
         </section>
       ) : null}
@@ -305,7 +316,7 @@ export default function BetaRequestsPage() {
                       <StatusPill label={entry.stage} tone={stageTone(entry.stage)} />
                       {entry.notificationStatus ? <StatusPill label={`signal ${entry.notificationStatus}`} tone={signalTone(entry.notificationStatus)} /> : null}
                       {entry.attentionFlags.map((flag) => (
-                        <StatusPill key={`${entry.id}-${flag}`} label={flag} tone={flag === 'unowned' ? 'critical' : 'warning'} />
+                        <StatusPill key={`${entry.id}-${flag}`} label={formatAttentionFlag(flag)} tone={flag === 'unowned' ? 'critical' : 'warning'} />
                       ))}
                     </div>
 
@@ -322,7 +333,10 @@ export default function BetaRequestsPage() {
                     <div className="grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
                       <span>Owner: {entry.owner ?? 'unassigned'}</span>
                       <span>Updated {formatRelativeTime(entry.updatedAt)}</span>
+                      <span>Stage age: {entry.stageAgeLabel}</span>
                       <span>Last contact: {entry.lastContactAt ? formatRelativeTime(entry.lastContactAt) : 'not recorded'}</span>
+                      <span>Next meeting: {entry.nextMeetingAt ? formatRelativeTime(entry.nextMeetingAt) : 'not scheduled'}</span>
+                      <span>Reminder: {entry.reminderAt ? formatRelativeTime(entry.reminderAt) : 'not set'}</span>
                       <span>Source: {entry.source ?? 'unknown'}</span>
                     </div>
 
@@ -330,10 +344,14 @@ export default function BetaRequestsPage() {
                       {entry.nextAction ?? 'No next action is recorded yet.'}
                     </div>
 
-                    {entry.staleReason ? (
-                      <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
-                        <TriangleAlert size={16} className="mt-0.5 shrink-0" />
-                        <span>{entry.staleReason}</span>
+                    {entry.staleReason || entry.followUpReason ? (
+                      <div className="space-y-2">
+                        {[entry.followUpReason, entry.staleReason].filter(Boolean).map((message) => (
+                          <div key={message} className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                            <TriangleAlert size={16} className="mt-0.5 shrink-0" />
+                            <span>{message}</span>
+                          </div>
+                        ))}
                       </div>
                     ) : null}
                   </button>
@@ -357,7 +375,11 @@ export default function BetaRequestsPage() {
                   <InfoRow label="Signal" value={selectedRequest.notificationStatus ?? 'no operator signal'} />
                   <InfoRow label="Created" value={formatDateTime(selectedRequest.createdAt)} />
                   <InfoRow label="Updated" value={formatDateTime(selectedRequest.updatedAt)} />
+                  <InfoRow label="Stage entered" value={formatDateTime(selectedRequest.stageEnteredAt)} />
+                  <InfoRow label="Stage age" value={selectedRequest.stageAgeLabel} />
                   <InfoRow label="Last contact" value={formatDateTime(selectedRequest.lastContactAt)} />
+                  <InfoRow label="Next meeting" value={formatDateTime(selectedRequest.nextMeetingAt)} />
+                  <InfoRow label="Reminder" value={formatDateTime(selectedRequest.reminderAt)} />
                   <InfoRow label="Owner" value={selectedRequest.owner ?? 'unassigned'} />
                 </div>
 
@@ -379,9 +401,13 @@ export default function BetaRequestsPage() {
                   ) : null}
                 </div>
 
-                {selectedRequest.staleReason ? (
-                  <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
-                    {selectedRequest.staleReason}
+                {selectedRequest.staleReason || selectedRequest.followUpReason ? (
+                  <div className="space-y-3">
+                    {[selectedRequest.followUpReason, selectedRequest.staleReason].filter(Boolean).map((message) => (
+                      <div key={message} className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                        {message}
+                      </div>
+                    ))}
                   </div>
                 ) : null}
               </>
@@ -443,15 +469,59 @@ export default function BetaRequestsPage() {
                   />
                 </label>
 
-                <button
-                  className="btn-secondary"
-                  disabled={!canEdit || saving}
-                  onClick={() => setDraftLastContactAt(toDateTimeLocalValue(new Date().toISOString()))}
-                  type="button"
-                >
-                  <Clock3 size={16} />
-                  <span>Mark contact now</span>
-                </button>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="block space-y-2">
+                    <span className="text-sm font-medium">Next meeting</span>
+                    <input
+                      className="input-field"
+                      disabled={!canEdit || saving}
+                      type="datetime-local"
+                      value={draftNextMeetingAt}
+                      onChange={(event) => setDraftNextMeetingAt(event.target.value)}
+                    />
+                  </label>
+
+                  <label className="block space-y-2">
+                    <span className="text-sm font-medium">Reminder</span>
+                    <input
+                      className="input-field"
+                      disabled={!canEdit || saving}
+                      type="datetime-local"
+                      value={draftReminderAt}
+                      onChange={(event) => setDraftReminderAt(event.target.value)}
+                    />
+                  </label>
+                </div>
+
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving}
+                    onClick={() => setDraftLastContactAt(toDateTimeLocalValue(new Date().toISOString()))}
+                    type="button"
+                  >
+                    <Clock3 size={16} />
+                    <span>Mark contact now</span>
+                  </button>
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving}
+                    onClick={() => setDraftNextMeetingAt(futureDateTimeLocalValue({ days: 3 }))}
+                    type="button"
+                  >
+                    <Clock3 size={16} />
+                    <span>Set meeting +3 days</span>
+                  </button>
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving}
+                    onClick={() => setDraftReminderAt(futureDateTimeLocalValue({ days: 1 }))}
+                    type="button"
+                  >
+                    <Clock3 size={16} />
+                    <span>Set reminder +1 day</span>
+                  </button>
+                </div>
 
                 <label className="block space-y-2">
                   <span className="text-sm font-medium">Operator notes</span>
@@ -536,6 +606,18 @@ function formatWorkflowType(value: string | null): string {
     .join(' ')
 }
 
+function formatAttentionFlag(flag: BetaRequestAttention): string {
+  switch (flag) {
+    case 'follow_up_due':
+      return 'follow-up due'
+    case 'unowned':
+      return 'unowned'
+    case 'stale':
+    default:
+      return 'stale'
+  }
+}
+
 function stageTone(stage: BetaRequestStatus): 'default' | 'success' | 'warning' | 'critical' {
   switch (stage) {
     case 'active':
@@ -581,6 +663,12 @@ function toDateTimeLocalValue(value?: string | null): string {
   const offset = date.getTimezoneOffset()
   const localDate = new Date(date.getTime() - offset * 60_000)
   return localDate.toISOString().slice(0, 16)
+}
+
+function futureDateTimeLocalValue(input: { days?: number; hours?: number }): string {
+  const days = input.days ?? 0
+  const hours = input.hours ?? 0
+  return toDateTimeLocalValue(new Date(Date.now() + (days * 24 + hours) * 60 * 60 * 1000).toISOString())
 }
 
 function templateAnchorForStage(stage: BetaRequestStatus): string {

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -253,10 +253,13 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.ok(waitlistColumns.some((column) => column.name === 'operator_notes'))
     assert.ok(waitlistColumns.some((column) => column.name === 'next_action'))
     assert.ok(waitlistColumns.some((column) => column.name === 'last_contact_at'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'next_meeting_at'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'reminder_at'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'stage_entered_at'))
     assert.ok(waitlistColumns.some((column) => column.name === 'updated_at'))
 
     const waitlistRow = db.prepare(`
-      SELECT email, status, owner, operator_notes, next_action, last_contact_at, updated_at, created_at
+      SELECT email, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, stage_entered_at, updated_at, created_at
       FROM waitlist
       LIMIT 1
     `).get() as {
@@ -266,6 +269,9 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
       operator_notes: string | null
       next_action: string | null
       last_contact_at: string | null
+      next_meeting_at: string | null
+      reminder_at: string | null
+      stage_entered_at: string
       updated_at: string
       created_at: string
     } | undefined
@@ -277,12 +283,17 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.equal(waitlistRow?.operator_notes ?? null, null)
     assert.equal(waitlistRow?.next_action ?? null, null)
     assert.equal(waitlistRow?.last_contact_at ?? null, null)
+    assert.equal(waitlistRow?.next_meeting_at ?? null, null)
+    assert.equal(waitlistRow?.reminder_at ?? null, null)
+    assert.equal(waitlistRow?.stage_entered_at, waitlistRow?.created_at)
     assert.equal(waitlistRow?.updated_at, waitlistRow?.created_at)
 
     const indexes = db.prepare("PRAGMA index_list('waitlist')").all() as Array<{ name: string }>
     assert.ok(indexes.some((index) => index.name === 'idx_waitlist_status'))
     assert.ok(indexes.some((index) => index.name === 'idx_waitlist_owner'))
     assert.ok(indexes.some((index) => index.name === 'idx_waitlist_last_contact'))
+    assert.ok(indexes.some((index) => index.name === 'idx_waitlist_next_meeting'))
+    assert.ok(indexes.some((index) => index.name === 'idx_waitlist_reminder'))
 
     const notificationColumns = db.prepare('PRAGMA table_info(operator_notifications)').all() as Array<{ name: string }>
     assert.ok(notificationColumns.some((column) => column.name === 'source_type'))

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -529,14 +529,20 @@ function initSchema(db: DB): void {
   ensureColumn(db, 'waitlist', 'operator_notes', 'TEXT')
   ensureColumn(db, 'waitlist', 'next_action', 'TEXT')
   ensureColumn(db, 'waitlist', 'last_contact_at', 'TEXT')
+  ensureColumn(db, 'waitlist', 'next_meeting_at', 'TEXT')
+  ensureColumn(db, 'waitlist', 'reminder_at', 'TEXT')
+  ensureColumn(db, 'waitlist', 'stage_entered_at', 'TEXT')
   ensureColumn(db, 'waitlist', 'updated_at', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_status ON waitlist(status, created_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_owner ON waitlist(owner, created_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_last_contact ON waitlist(last_contact_at, updated_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_next_meeting ON waitlist(next_meeting_at, updated_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_reminder ON waitlist(reminder_at, updated_at DESC)')
   db.prepare(`
     UPDATE waitlist
     SET status = COALESCE(NULLIF(status, ''), 'new'),
-        updated_at = COALESCE(NULLIF(updated_at, ''), created_at)
+        updated_at = COALESCE(NULLIF(updated_at, ''), created_at),
+        stage_entered_at = COALESCE(NULLIF(stage_entered_at, ''), NULLIF(updated_at, ''), created_at)
   `).run()
   db.prepare(`
     UPDATE waitlist

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -325,6 +325,8 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         workflowSummary: string
         requestStatus: string
         stage: string
+        nextMeetingAt: string | null
+        reminderAt: string | null
         notificationId: number
         notificationStatus: string
         attentionFlags: string[]
@@ -337,6 +339,8 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.match(created.request.workflowSummary, /Procurement/)
     assert.equal(created.request.requestStatus, 'new')
     assert.equal(created.request.stage, 'new')
+    assert.equal(created.request.nextMeetingAt, null)
+    assert.equal(created.request.reminderAt, null)
     assert.ok(created.request.notificationId > 0)
     assert.equal(created.request.notificationStatus, 'new')
     assert.deepEqual(created.request.attentionFlags, ['unowned'])
@@ -361,6 +365,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         total: number
         unowned: number
         stale: number
+        followUpDue: number
         needsAttention: number
         byStatus: Record<string, number>
       }
@@ -369,6 +374,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(listed.summary.total, 1)
     assert.equal(listed.summary.unowned, 1)
     assert.equal(listed.summary.stale, 0)
+    assert.equal(listed.summary.followUpDue, 0)
     assert.equal(listed.summary.needsAttention, 1)
     assert.equal(listed.summary.byStatus['new'], 1)
     assert.equal(listed.requests[0]?.email, 'buyer@example.com')
@@ -435,6 +441,8 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.deepEqual(updated.request.attentionFlags, [])
 
     const contactTimestamp = '2026-03-30T20:15:00.000Z'
+    const meetingTimestamp = '2026-04-02T14:00:00.000Z'
+    const reminderTimestamp = '2020-01-01T09:00:00.000Z'
     const contactResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
       method: 'PATCH',
       headers: {
@@ -442,9 +450,11 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         'content-type': 'application/json',
       },
       body: JSON.stringify({
-        status: 'contacted',
+        status: 'scheduled',
         nextAction: 'Schedule a 30 minute pilot review with procurement and finance.',
         lastContactAt: contactTimestamp,
+        nextMeetingAt: meetingTimestamp,
+        reminderAt: reminderTimestamp,
       }),
     }))
     assert.equal(contactResponse.status, 200)
@@ -455,14 +465,44 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         requestStatus: string
         nextAction: string
         lastContactAt: string | null
+        nextMeetingAt: string | null
+        reminderAt: string | null
         notificationStatus: string
+        attentionFlags: string[]
       }
     }
     assert.equal(contacted.ok, true)
-    assert.equal(contacted.request.requestStatus, 'contacted')
+    assert.equal(contacted.request.requestStatus, 'scheduled')
     assert.equal(contacted.request.nextAction, 'Schedule a 30 minute pilot review with procurement and finance.')
     assert.equal(contacted.request.lastContactAt, contactTimestamp)
+    assert.equal(contacted.request.nextMeetingAt, meetingTimestamp)
+    assert.equal(contacted.request.reminderAt, reminderTimestamp)
     assert.equal(contacted.request.notificationStatus, 'acted')
+    assert.deepEqual(contacted.request.attentionFlags, ['follow_up_due'])
+
+    const dueResponse = await app.request(new Request('http://localhost/admin/beta-requests?attention=follow_up_due&status=scheduled', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(dueResponse.status, 200)
+
+    const duePayload = await dueResponse.json() as {
+      total: number
+      summary: {
+        followUpDue: number
+      }
+      requests: Array<{
+        id: number
+        followUpDue: boolean
+        followUpReason: string | null
+        stageAgeHours: number
+      }>
+    }
+    assert.equal(duePayload.total, 1)
+    assert.equal(duePayload.summary.followUpDue, 1)
+    assert.equal(duePayload.requests[0]?.id, created.request.id)
+    assert.equal(duePayload.requests[0]?.followUpDue, true)
+    assert.match(duePayload.requests[0]?.followUpReason ?? '', /reminder/i)
+    assert.ok((duePayload.requests[0]?.stageAgeHours ?? 0) >= 0)
 
     const actedInboxResponse = await app.request(new Request('http://localhost/admin/operator-notifications?source=beta_request&status=acted', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
@@ -489,6 +529,9 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.match(csv, /workflow_summary/)
     assert.match(csv, /next_action/)
     assert.match(csv, /last_contact_at/)
+    assert.match(csv, /next_meeting_at/)
+    assert.match(csv, /reminder_at/)
+    assert.match(csv, /follow_up_due/)
     assert.match(csv, /notification_status/)
     assert.match(csv, /attention_flags/)
     assert.match(csv, /Northwind Systems/)

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -74,7 +74,7 @@ type WaitlistSignupInput = {
 }
 
 type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
-type BetaRequestAttention = 'unowned' | 'stale'
+type BetaRequestAttention = 'unowned' | 'stale' | 'follow_up_due'
 type BetaRequestSort = 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
 type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 type OperatorNotificationSource = 'beta_request' | 'critical_alert'
@@ -100,6 +100,8 @@ type BetaRequestUpdateInput = {
   operatorNotes?: string | null
   nextAction?: string | null
   lastContactAt?: string | null
+  nextMeetingAt?: string | null
+  reminderAt?: string | null
 }
 
 type BetaRequestFilters = {
@@ -144,6 +146,9 @@ type WaitlistRow = {
   operator_notes: string | null
   next_action: string | null
   last_contact_at: string | null
+  next_meeting_at: string | null
+  reminder_at: string | null
+  stage_entered_at: string | null
   created_at: string
   updated_at: string
 }
@@ -152,7 +157,7 @@ const BETA_REQUEST_STATUSES: BetaRequestStatus[] = ['new', 'reviewing', 'contact
 const BETA_REQUEST_STATUS_SET = new Set<string>(BETA_REQUEST_STATUSES)
 const BETA_REQUEST_SORTS: BetaRequestSort[] = ['attention', 'updated_desc', 'created_desc', 'stage', 'owner', 'last_contact_desc']
 const BETA_REQUEST_SORT_SET = new Set<string>(BETA_REQUEST_SORTS)
-const BETA_REQUEST_ATTENTION_SET = new Set<BetaRequestAttention>(['unowned', 'stale'])
+const BETA_REQUEST_ATTENTION_SET = new Set<BetaRequestAttention>(['unowned', 'stale', 'follow_up_due'])
 const OPERATOR_NOTIFICATION_STATUSES: OperatorNotificationStatus[] = ['new', 'acknowledged', 'acted']
 const OPERATOR_NOTIFICATION_STATUS_SET = new Set<string>(OPERATOR_NOTIFICATION_STATUSES)
 const OPERATOR_NOTIFICATION_SOURCES: OperatorNotificationSource[] = ['beta_request', 'critical_alert']
@@ -389,12 +394,39 @@ function betaRequestNotificationSourceKey(id: number): string {
 }
 
 function getBetaRequestContactTimestamp(row: WaitlistRow): string {
-  return row.last_contact_at ?? row.updated_at ?? row.created_at
+  return row.last_contact_at ?? row.stage_entered_at ?? row.created_at
+}
+
+function getBetaRequestStageTimestamp(row: WaitlistRow): string {
+  return row.stage_entered_at ?? row.updated_at ?? row.created_at
+}
+
+function formatBetaRequestAgeLabel(hours: number): string {
+  if (hours < 1) {
+    return '<1h'
+  }
+
+  if (hours < 24) {
+    return `${Math.round(hours)}h`
+  }
+
+  const days = hours / 24
+  if (days < 7) {
+    return `${Math.round(days)}d`
+  }
+
+  return `${Math.round(days / 7)}w`
 }
 
 function getBetaRequestAttention(row: WaitlistRow) {
   const stage = normalizeBetaRequestStatus(row.status) ?? 'new'
   const attentionFlags: BetaRequestAttention[] = []
+  const stageTimestamp = getBetaRequestStageTimestamp(row)
+  const stageTime = new Date(stageTimestamp).getTime()
+  const stageAgeHours = Number.isNaN(stageTime)
+    ? 0
+    : Math.max(0, (Date.now() - stageTime) / (1000 * 60 * 60))
+  const stageAgeLabel = formatBetaRequestAgeLabel(stageAgeHours)
 
   if (stage !== 'closed' && !row.owner) {
     attentionFlags.push('unowned')
@@ -403,26 +435,43 @@ function getBetaRequestAttention(row: WaitlistRow) {
   let stale = false
   let staleReason: string | null = null
   const thresholdHours = BETA_REQUEST_STALE_HOURS[stage]
-  const contactTimestamp = getBetaRequestContactTimestamp(row)
+  if (thresholdHours != null && stageAgeHours >= thresholdHours) {
+    stale = true
+    staleReason = `This request has stayed in the ${stage} stage for ${thresholdHours}+ hours.`
+    attentionFlags.push('stale')
+  }
 
-  if (thresholdHours != null) {
-    const contactTime = new Date(contactTimestamp).getTime()
-    if (!Number.isNaN(contactTime)) {
-      const ageHours = (Date.now() - contactTime) / (1000 * 60 * 60)
-      if (ageHours >= thresholdHours) {
-        stale = true
-        staleReason = row.last_contact_at
-          ? `No operator contact has been recorded for ${thresholdHours}+ hours in the ${stage} stage.`
-          : `This request has sat in the ${stage} stage for ${thresholdHours}+ hours without a recorded operator contact.`
-        attentionFlags.push('stale')
+  let followUpDue = false
+  let followUpReason: string | null = null
+
+  if (stage !== 'closed') {
+    if (row.reminder_at) {
+      const reminderTime = new Date(row.reminder_at).getTime()
+      if (!Number.isNaN(reminderTime) && reminderTime <= Date.now()) {
+        followUpDue = true
+        followUpReason = 'A follow-up reminder is due now.'
       }
     }
+
+    if (!followUpDue && stage === 'scheduled' && !row.next_meeting_at) {
+      followUpDue = true
+      followUpReason = 'This request is scheduled, but the next meeting time is still missing.'
+    }
+  }
+
+  if (followUpDue) {
+    attentionFlags.push('follow_up_due')
   }
 
   return {
     stage,
+    stageEnteredAt: stageTimestamp,
+    stageAgeHours,
+    stageAgeLabel,
     stale,
     staleReason,
+    followUpDue,
+    followUpReason,
     attentionFlags,
   }
 }
@@ -479,8 +528,15 @@ function serializeBetaRequest(
     operatorNotes: row.operator_notes,
     nextAction,
     lastContactAt: row.last_contact_at,
+    nextMeetingAt: row.next_meeting_at,
+    reminderAt: row.reminder_at,
+    stageEnteredAt: attention.stageEnteredAt,
+    stageAgeHours: attention.stageAgeHours,
+    stageAgeLabel: attention.stageAgeLabel,
     stale: attention.stale,
     staleReason: attention.staleReason,
+    followUpDue: attention.followUpDue,
+    followUpReason: attention.followUpReason,
     attentionFlags: attention.attentionFlags,
     notificationId: notification?.id ?? null,
     notificationStatus: notification?.status ?? null,
@@ -677,6 +733,9 @@ function listBetaRequestRows(db: Database, filters: {
       operator_notes,
       next_action,
       last_contact_at,
+      next_meeting_at,
+      reminder_at,
+      stage_entered_at,
       created_at,
       updated_at
     FROM waitlist
@@ -712,6 +771,9 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
       operator_notes,
       next_action,
       last_contact_at,
+      next_meeting_at,
+      reminder_at,
+      stage_entered_at,
       created_at,
       updated_at
     FROM waitlist
@@ -756,8 +818,14 @@ function compareBetaRequestRows(left: WaitlistRow, right: WaitlistRow, sort: Bet
       return rightUpdated - leftUpdated
     case 'attention':
     default: {
-      const leftAttentionScore = Number(leftAttention.attentionFlags.includes('unowned')) * 2 + Number(leftAttention.attentionFlags.includes('stale'))
-      const rightAttentionScore = Number(rightAttention.attentionFlags.includes('unowned')) * 2 + Number(rightAttention.attentionFlags.includes('stale'))
+      const leftAttentionScore =
+        Number(leftAttention.attentionFlags.includes('unowned')) * 4
+        + Number(leftAttention.attentionFlags.includes('follow_up_due')) * 2
+        + Number(leftAttention.attentionFlags.includes('stale'))
+      const rightAttentionScore =
+        Number(rightAttention.attentionFlags.includes('unowned')) * 4
+        + Number(rightAttention.attentionFlags.includes('follow_up_due')) * 2
+        + Number(rightAttention.attentionFlags.includes('stale'))
       return rightAttentionScore - leftAttentionScore
         || compareStageOrder(leftStage, rightStage)
         || rightUpdated - leftUpdated
@@ -771,6 +839,7 @@ function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
   let unowned = 0
   let active = 0
   let stale = 0
+  let followUpDue = 0
   let needsAttention = 0
 
   for (const row of rows) {
@@ -781,6 +850,9 @@ function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
     }
     if (attention.attentionFlags.includes('stale')) {
       stale += 1
+    }
+    if (attention.attentionFlags.includes('follow_up_due')) {
+      followUpDue += 1
     }
     if (attention.attentionFlags.length > 0) {
       needsAttention += 1
@@ -795,6 +867,7 @@ function summarizeBetaRequests(rows: WaitlistRow[], total: number) {
     active,
     unowned,
     stale,
+    followUpDue,
     needsAttention,
     byStatus,
   }
@@ -817,6 +890,11 @@ function buildBetaRequestCsv(
     'operator_notes',
     'next_action',
     'last_contact_at',
+    'next_meeting_at',
+    'reminder_at',
+    'stage_entered_at',
+    'stage_age_hours',
+    'follow_up_due',
     'notification_status',
     'stale',
     'attention_flags',
@@ -841,6 +919,11 @@ function buildBetaRequestCsv(
       row.operator_notes,
       row.next_action ?? getBetaRequestNextStep(row.status),
       row.last_contact_at,
+      row.next_meeting_at,
+      row.reminder_at,
+      getBetaRequestStageTimestamp(row),
+      attention.stageAgeHours.toFixed(1),
+      attention.followUpDue ? 'true' : 'false',
       notification?.status ?? null,
       attention.stale ? 'true' : 'false',
       attention.attentionFlags.join('|'),
@@ -913,6 +996,9 @@ function ensureBetaRequestNotification(
       workflowType: row.workflow_type,
       stage: normalizeBetaRequestStatus(row.status) ?? 'new',
       nextAction: row.next_action ?? getBetaRequestNextStep(row.status),
+      nextMeetingAt: row.next_meeting_at,
+      reminderAt: row.reminder_at,
+      stageEnteredAt: getBetaRequestStageTimestamp(row),
     },
   })
 }
@@ -1925,7 +2011,31 @@ export function createApp(db: Database): Hono {
       patch.lastContactAt = lastContactAt
     }
 
-    if (!('status' in patch) && !('owner' in patch) && !('operatorNotes' in patch) && !('nextAction' in patch) && !('lastContactAt' in patch)) {
+    if ('nextMeetingAt' in raw) {
+      const nextMeetingAt = normalizeOptionalIsoDateTime(raw.nextMeetingAt)
+      if (raw.nextMeetingAt != null && raw.nextMeetingAt !== '' && !nextMeetingAt) {
+        return c.json({ error: 'Invalid nextMeetingAt timestamp', errorCode: 'INVALID_NEXT_MEETING' }, 400)
+      }
+      patch.nextMeetingAt = nextMeetingAt
+    }
+
+    if ('reminderAt' in raw) {
+      const reminderAt = normalizeOptionalIsoDateTime(raw.reminderAt)
+      if (raw.reminderAt != null && raw.reminderAt !== '' && !reminderAt) {
+        return c.json({ error: 'Invalid reminderAt timestamp', errorCode: 'INVALID_REMINDER' }, 400)
+      }
+      patch.reminderAt = reminderAt
+    }
+
+    if (
+      !('status' in patch)
+      && !('owner' in patch)
+      && !('operatorNotes' in patch)
+      && !('nextAction' in patch)
+      && !('lastContactAt' in patch)
+      && !('nextMeetingAt' in patch)
+      && !('reminderAt' in patch)
+    ) {
       return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
     }
 
@@ -1940,7 +2050,12 @@ export function createApp(db: Database): Hono {
       const nextOperatorNotes = 'operatorNotes' in patch ? patch.operatorNotes ?? null : existing.operator_notes
       const nextAction = 'nextAction' in patch ? patch.nextAction ?? null : existing.next_action
       let nextLastContactAt = 'lastContactAt' in patch ? patch.lastContactAt ?? null : existing.last_contact_at
+      const nextMeetingAt = 'nextMeetingAt' in patch ? patch.nextMeetingAt ?? null : existing.next_meeting_at
+      const nextReminderAt = 'reminderAt' in patch ? patch.reminderAt ?? null : existing.reminder_at
       const updatedAt = new Date().toISOString()
+      const nextStageEnteredAt = 'status' in patch && patch.status && patch.status !== existing.status
+        ? updatedAt
+        : (existing.stage_entered_at ?? existing.updated_at ?? existing.created_at)
 
       if (!('lastContactAt' in patch) && ['contacted', 'scheduled', 'active'].includes(nextStatus) && !nextLastContactAt) {
         nextLastContactAt = updatedAt
@@ -1948,9 +2063,9 @@ export function createApp(db: Database): Hono {
 
       db.prepare(`
         UPDATE waitlist
-        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, updated_at = ?
+        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, next_meeting_at = ?, reminder_at = ?, stage_entered_at = ?, updated_at = ?
         WHERE id = ?
-      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, updatedAt, id)
+      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, nextMeetingAt, nextReminderAt, nextStageEnteredAt, updatedAt, id)
 
       const updated = getBetaRequestById(db, id)
       if (!updated) {
@@ -1972,6 +2087,8 @@ export function createApp(db: Database): Hono {
           operatorNotesChanged: 'operatorNotes' in patch,
           nextActionChanged: 'nextAction' in patch,
           lastContactChanged: 'lastContactAt' in patch,
+          nextMeetingChanged: 'nextMeetingAt' in patch,
+          reminderChanged: 'reminderAt' in patch,
         },
       })
 
@@ -2451,7 +2568,7 @@ export function createApp(db: Database): Hono {
 
     try {
       const existing = db.prepare(`
-        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, next_action, last_contact_at, created_at, updated_at
+        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, stage_entered_at, created_at, updated_at
         FROM waitlist
         WHERE email = ?
         ORDER BY created_at DESC, id DESC
@@ -2471,9 +2588,19 @@ export function createApp(db: Database): Hono {
 
         db.prepare(`
           UPDATE waitlist
-          SET source = ?, company = ?, agent_count = ?, workflow_type = ?, workflow_summary = ?, status = ?, updated_at = ?
+          SET source = ?, company = ?, agent_count = ?, workflow_type = ?, workflow_summary = ?, status = ?, stage_entered_at = ?, updated_at = ?
           WHERE id = ?
-        `).run(nextSource, nextCompany, nextAgentCount, nextWorkflowType, nextWorkflowSummary, nextStatus, timestamp, existing.id)
+        `).run(
+          nextSource,
+          nextCompany,
+          nextAgentCount,
+          nextWorkflowType,
+          nextWorkflowSummary,
+          nextStatus,
+          nextStatus !== existing.status ? timestamp : (existing.stage_entered_at ?? existing.updated_at ?? existing.created_at),
+          timestamp,
+          existing.id,
+        )
 
         const updated = getBetaRequestById(db, existing.id)
         if (!updated) {
@@ -2510,6 +2637,8 @@ export function createApp(db: Database): Hono {
           operatorNotes: updated.operator_notes,
           nextAction: updated.next_action ?? getBetaRequestNextStep(updated.status),
           lastContactAt: updated.last_contact_at,
+          nextMeetingAt: updated.next_meeting_at,
+          reminderAt: updated.reminder_at,
           createdAt: updated.created_at,
           updatedAt: updated.updated_at,
           request: serializeBetaRequest(updated, notification),
@@ -2530,10 +2659,13 @@ export function createApp(db: Database): Hono {
           operator_notes,
           next_action,
           last_contact_at,
+          next_meeting_at,
+          reminder_at,
+          stage_entered_at,
           created_at,
           updated_at
         )
-        VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, NULL, NULL, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, 'new', NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, ?)
       `).run(
         signup.email,
         signup.source,
@@ -2541,6 +2673,7 @@ export function createApp(db: Database): Hono {
         signup.agentCount,
         signup.workflowType,
         signup.workflowSummary,
+        timestamp,
         timestamp,
         timestamp,
       )
@@ -2591,6 +2724,8 @@ export function createApp(db: Database): Hono {
         operatorNotes: created.operator_notes,
         nextAction: created.next_action ?? getBetaRequestNextStep(created.status),
         lastContactAt: created.last_contact_at,
+        nextMeetingAt: created.next_meeting_at,
+        reminderAt: created.reminder_at,
         createdAt: created.created_at,
         updatedAt: created.updated_at,
         request: serializeBetaRequest(created, notification),

--- a/packages/public-site/guided-evaluation.html
+++ b/packages/public-site/guided-evaluation.html
@@ -726,8 +726,8 @@
           <h1>See the Beam proof before you commit to a pilot.</h1>
           <p>
             This is the shortest public path from curiosity to evidence. In one guided evaluation,
-            you see one company hand work to another, inspect the operator proof, and decide whether
-            one live workflow is worth a hosted pilot.
+            you see one company hand work to another, inspect the operator proof, and leave with a
+            compact proof pack that makes the next decision around one live workflow obvious.
           </p>
 
           <div class="hero-actions">
@@ -745,8 +745,8 @@
               <span>The screenshots and evidence blocks below come from the actual seeded Beam environment.</span>
             </div>
             <div class="hero-point">
-              <strong>One workflow, one owner, one next step</strong>
-              <span>The goal is not a platform tour. The goal is to decide whether one handoff deserves a real pilot.</span>
+              <strong>One workflow, one proof pack, one next step</strong>
+              <span>The goal is not a platform tour. The goal is to decide whether one handoff deserves a real pilot and to leave with something you can share internally.</span>
             </div>
           </div>
         </div>
@@ -771,8 +771,8 @@
                 <span>The same request can be inspected from sender to reply.</span>
               </div>
               <div class="proof-pill">
-                <strong>Shared proof</strong>
-                <span>Both sides can point to the same request, status, and next action.</span>
+                <strong>Shareable proof pack</strong>
+                <span>Both sides can point to the same request, status, owner, and next action after the walkthrough.</span>
               </div>
             </div>
           </div>
@@ -879,9 +879,9 @@
               <div class="evidence-card">
                 <h3>What you get after the evaluation</h3>
                 <ul>
-                  <li>A decision on whether one live workflow deserves a pilot.</li>
-                  <li>A shared description of sender, receiver, owner, and success condition.</li>
-                  <li>A concrete next action instead of an open-ended beta conversation.</li>
+                  <li>A short workflow recap naming sender, receiver, owner, and success condition.</li>
+                  <li>Proof links from the overview and trace surfaces, including async follow-up state.</li>
+                  <li>One honest next decision: proceed, narrow the ask, or stop cleanly.</li>
                 </ul>
               </div>
             </div>
@@ -933,8 +933,9 @@
         <div class="section-kicker">Next step</div>
         <h2>If the proof maps cleanly to your workflow, scope one pilot.</h2>
         <p>
-          The right Beam next step is small: one hosted pilot, one operator owner, one workflow that
-          matters. If the fit is not there yet, stop at the evaluation and keep the scope honest.
+          The right Beam next step is still small: one hosted pilot, one operator owner, one
+          workflow that matters, and one proof package you can reuse in the internal decision.
+          If the fit is not there yet, stop at the evaluation and keep the scope honest.
         </p>
         <div class="closing-actions">
           <a class="btn btn-primary" data-beam-cta="guided_eval_hosted_beta_closing" href="/hosted-beta.html">Request hosted beta</a>

--- a/packages/public-site/hosted-beta.html
+++ b/packages/public-site/hosted-beta.html
@@ -723,13 +723,13 @@
           <h1>Request a guided Beam pilot for one real workflow.</h1>
           <p>
             If your AI needs another company's AI to do something real, Beam can scope a small
-            pilot around that handoff. We start narrow, prove it, set expectations up front, and
-            only expand if it works.
+            pilot around that handoff. We start narrow, prove it, write down the recap, and only
+            expand if the first pilot earns a bigger footprint.
           </p>
           <ul>
             <li>One workflow first, not a platform rollout.</li>
-            <li>Shared proof for both companies and one operator owner.</li>
-            <li>Managed directory, dashboard, and follow-up around the pilot.</li>
+            <li>Shared proof pack for both companies and one operator owner.</li>
+            <li>Managed directory, dashboard, and follow-up until one next decision is clear.</li>
           </ul>
           <div class="hero-metrics">
             <div class="metric">
@@ -746,7 +746,7 @@
             </div>
             <div class="metric">
               <strong>Guided rollout</strong>
-              <span>Beam helps scope the first evaluation, shares the onboarding pack, and sets the next concrete step after it.</span>
+              <span>Beam helps scope the first evaluation, shares the onboarding pack, and leaves the pilot with a recap, proof links, and one next concrete step.</span>
             </div>
           </div>
         </div>
@@ -848,11 +848,12 @@
           <div class="expect-grid">
           <div class="expect-card">
             <div class="section-kicker">01 · what you get</div>
-            <h3>Managed Beam surfaces</h3>
-            <p>Directory, dashboard, intake, and operator guidance stay aligned to the same proof path used on the public site.</p>
+            <h3>Managed Beam surfaces plus a proof pack</h3>
+            <p>Directory, dashboard, intake, and operator guidance stay aligned to the same proof path used on the public site, and the first pilot ends with something your team can reuse.</p>
             <ul>
               <li>Managed directory and dashboard instead of only self-hosting.</li>
               <li>Operator runbook, demo path, and rollout guidance around one workflow.</li>
+              <li>Workflow recap, proof links, and an explicit next-step recommendation.</li>
               <li>Support for traces, alerts, stuck-work queues, rate limits, and recovery.</li>
             </ul>
           </div>
@@ -876,6 +877,7 @@
               <li>Run the hosted demo first if the use case is still fuzzy.</li>
               <li>Use the intake to scope one workflow, not a broad platform conversation.</li>
               <li>Treat pricing and rollout as workflow-scoped, not as an open-ended beta promise.</li>
+              <li>End the first pilot with a go, no-go, or narrower next step instead of a vague follow-up thread.</li>
             </ul>
           </div>
           </div>
@@ -888,6 +890,7 @@
               <ul>
                 <li>One workflow, one owner, one success condition</li>
                 <li>What proof Beam should show during the walkthrough</li>
+                <li>What the buyer should take away after the first pilot</li>
                 <li>What happens after the call if the fit is real</li>
               </ul>
               <div class="submit-row" style="margin-top: 18px;">
@@ -927,6 +930,13 @@
             <p>
               The first step is a short fit conversation. If there is a fit, Beam scopes one
               workflow before anything broader.
+            </p>
+          </div>
+          <div class="faq-card">
+            <h3>What should come out of the first pilot?</h3>
+            <p>
+              A short workflow recap, proof links from the operator surface, and one clear next
+              decision. If Beam cannot produce that, the pilot stayed too fuzzy.
             </p>
           </div>
           <div class="faq-card">
@@ -1024,6 +1034,7 @@
             `<strong>You are already on the hosted beta list.</strong><br />` +
             `Beam refreshed the latest workflow context for <code>${email}</code> and kept the original intake.` +
             `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Expected outcome: workflow recap, proof links, and one next-step decision.</span>` +
             `<br /><span style="color: inherit; opacity: 0.8;">Reference pack: <a href="https://docs.beam.directory/guide/design-partner-onboarding" target="_blank" rel="noreferrer">design-partner onboarding</a></span>` +
             (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Original intake: ${createdAt}</span>` : ''),
           )
@@ -1033,6 +1044,7 @@
             `<strong>Hosted beta request recorded.</strong><br />` +
             `Beam queued <strong>${workflowLabel}</strong> for <strong>${company}</strong>.` +
             `<br /><span style="color: inherit; opacity: 0.8;">Next: ${nextStep}</span>` +
+            `<br /><span style="color: inherit; opacity: 0.8;">Expected outcome: workflow recap, proof links, and one next-step decision.</span>` +
             `<br /><span style="color: inherit; opacity: 0.8;">Reference pack: <a href="https://docs.beam.directory/guide/design-partner-onboarding" target="_blank" rel="noreferrer">design-partner onboarding</a></span>` +
             (createdAt ? `<br /><span style="color: inherit; opacity: 0.8;">Recorded: ${createdAt}</span>` : ''),
           )

--- a/packages/public-site/index.html
+++ b/packages/public-site/index.html
@@ -1660,7 +1660,7 @@
           <p>
             Beam helps two companies move work between their AI systems without losing who asked,
             who answered, what changed, or where it stalled. Start with one guided evaluation,
-            inspect the proof, then decide whether Beam deserves a bigger footprint.
+            inspect the proof, then decide whether one guided pilot deserves a bigger footprint.
           </p>
           <div class="hero-actions">
             <a class="btn btn-primary" data-beam-cta="landing_guided_eval_hero" href="/guided-evaluation.html">See the guided evaluation</a>
@@ -1680,8 +1680,8 @@
               <span>Beam shows retries, stuck work, and recovery context instead of hiding failure in glue code.</span>
             </div>
             <div class="proof-item">
-              <strong>Start with one guided proof path</strong>
-              <span>See the evaluation first, then decide whether one real partner workflow is worth a guided rollout.</span>
+              <strong>Leave with a pilot proof pack</strong>
+              <span>Beam is strongest when the first conversation ends with a recap, proof links, and one next decision.</span>
             </div>
           </div>
         </div>
@@ -1978,11 +1978,57 @@
       </div>
     </section>
 
+    <section id="proof-pack">
+      <div class="container">
+        <div class="section-head reveal">
+          <div class="kicker">What the buyer gets back</div>
+          <h2>A good Beam pilot ends with something you can share internally.</h2>
+          <p>
+            The first Beam pilot should not end as a vague “interesting platform” note. It should
+            end with a compact proof pack your team can use to decide whether to move forward.
+          </p>
+        </div>
+
+        <div class="stack-layout">
+          <div class="stack-column reveal">
+            <div class="stack-kicker">01 · workflow recap</div>
+            <h3>One narrow handoff, written down clearly.</h3>
+            <p>The recap should name the sender, recipient, owner, success condition, and the exact business job Beam covered.</p>
+            <ul>
+              <li>What the first live handoff actually was</li>
+              <li>Who owned the walkthrough and follow-up</li>
+              <li>What “good enough for pilot” meant</li>
+            </ul>
+          </div>
+          <div class="stack-column reveal">
+            <div class="stack-kicker">02 · live proof links</div>
+            <h3>Operator-visible evidence, not just a promise.</h3>
+            <p>The proof pack should include the same overview, trace, and operational state Beam shows during the guided path.</p>
+            <ul>
+              <li>Healthy baseline before the pilot starts</li>
+              <li>One traceable request from send to reply</li>
+              <li>Clear visibility if follow-up becomes async or stalls</li>
+            </ul>
+          </div>
+          <div class="stack-column reveal">
+            <div class="stack-kicker">03 · next commercial step</div>
+            <h3>One honest decision instead of a fuzzy beta thread.</h3>
+            <p>Every Beam pilot should end with a go, no-go, or narrower next step that both the buyer and operator understand.</p>
+            <ul>
+              <li>Proceed to a scoped design-partner pilot</li>
+              <li>Keep Beam in evaluation with one missing proof item</li>
+              <li>Stop cleanly if the workflow is not the right fit</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section id="stack">
       <div class="container">
         <div class="section-head reveal">
           <div class="kicker">What you get if Beam fits</div>
-          <h2>Beam already has the pieces people ask for once the use case is real.</h2>
+          <h2>Beam already has the pieces a design partner needs once the use case is real.</h2>
           <p>
             You do not need to believe in a giant platform story first. Beam already has the
             identity, delivery, and operator pieces behind the first workflow.
@@ -2013,9 +2059,9 @@
             </ul>
           </div>
           <div class="stack-column reveal">
-            <div class="stack-kicker">Operator proof</div>
+            <div class="stack-kicker">Shareable proof</div>
             <h3>The proof path is already operationalized.</h3>
-            <p>Dashboard, docs, public site, and the seeded hosted demo already point at the same story and evidence.</p>
+            <p>Dashboard, docs, public site, and the seeded hosted demo already point at the same story and evidence you can reuse in partner follow-up.</p>
             <ul>
               <li>Hosted quickstart and dogfood scripts</li>
               <li>Operator runbook and readiness reports</li>
@@ -2058,6 +2104,13 @@
             <p>
               A scoped workflow review, managed Beam surfaces, operator-visible proof, and a guided
               next step around one live workflow instead of a generic platform conversation.
+            </p>
+          </div>
+          <div class="faq-card reveal">
+            <h3>What should we have in hand after the first Beam pilot?</h3>
+            <p>
+              A short workflow recap, proof links from the operator surface, and a clear next-step
+              decision. If Beam cannot produce that, the pilot was too vague.
             </p>
           </div>
           <div class="faq-card reveal">


### PR DESCRIPTION
## Summary\n- add next meeting, reminder, stage aging, and follow-up-due state to hosted beta requests\n- surface the new follow-up timing state in the operator queue and request detail view\n- tighten the landing, guided evaluation, and hosted beta copy around a reusable proof pack for design-partner conversion\n\n## Verification\n- npm test --workspace=packages/directory\n- npm run build --workspace=packages/dashboard\n- npm run build\n- cd docs && npm run build\n- npm test\n- node inline-JS syntax check for public-site pages