### PR TITLE
Add partner activity timeline and tighter follow-up loop

### DIFF
--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -588,6 +588,29 @@ export interface BetaRequest {
   updatedAt: string
 }
 
+export type BetaRequestActivityKind =
+  | 'request_created'
+  | 'stage_changed'
+  | 'request_updated'
+  | 'contact_logged'
+  | 'meeting_scheduled'
+  | 'reminder'
+  | 'notification'
+
+export type BetaRequestActivityTone = 'default' | 'success' | 'warning'
+
+export interface BetaRequestActivityEntry {
+  key: string
+  kind: BetaRequestActivityKind
+  timestamp: string
+  title: string
+  detail: string
+  actor: string | null
+  tone: BetaRequestActivityTone
+  href: string | null
+  upcoming: boolean
+}
+
 export type WaitlistEntry = BetaRequest
 
 export interface WaitlistListResponse {
@@ -616,6 +639,7 @@ export interface BetaRequestListResponse {
 
 export interface BetaRequestDetailResponse {
   request: BetaRequest
+  activity: BetaRequestActivityEntry[]
 }
 
 export interface BetaRequestUpdateInput {

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -1,4 +1,4 @@
-import { Clock3, Download, RefreshCw, Search, TriangleAlert } from 'lucide-react'
+import { ArrowUpRight, CalendarClock, CheckCircle2, Clock3, Download, RefreshCw, Search, TriangleAlert, UserRoundPlus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
@@ -6,6 +6,7 @@ import { useAdminAuth } from '../lib/admin-auth'
 import {
   ApiError,
   directoryApi,
+  type BetaRequestActivityEntry,
   type BetaRequest,
   type BetaRequestAttention,
   type BetaRequestStatus,
@@ -48,6 +49,7 @@ export default function BetaRequestsPage() {
   const { session } = useAdminAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const [requests, setRequests] = useState<BetaRequest[]>([])
+  const [selectedDetail, setSelectedDetail] = useState<{ request: BetaRequest; activity: BetaRequestActivityEntry[] } | null>(null)
   const [total, setTotal] = useState(0)
   const [summary, setSummary] = useState<{
     total: number
@@ -59,6 +61,7 @@ export default function BetaRequestsPage() {
     byStatus: Record<BetaRequestStatus, number>
   } | null>(null)
   const [loading, setLoading] = useState(true)
+  const [detailLoading, setDetailLoading] = useState(false)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
@@ -75,6 +78,8 @@ export default function BetaRequestsPage() {
     () => requests.find((entry) => entry.id === selectedId) ?? requests[0] ?? null,
     [requests, selectedId],
   )
+  const detailRequest = selectedDetail?.request ?? selectedRequest
+  const activity = selectedDetail?.activity ?? []
 
   const [draftStatus, setDraftStatus] = useState<BetaRequestStatus>('new')
   const [draftOwner, setDraftOwner] = useState('')
@@ -107,7 +112,7 @@ export default function BetaRequestsPage() {
   }, [searchParams, selectedId, selectedRequest, setSearchParams])
 
   useEffect(() => {
-    if (!selectedRequest) {
+    if (!detailRequest) {
       setDraftStatus('new')
       setDraftOwner('')
       setDraftNextAction('')
@@ -118,14 +123,27 @@ export default function BetaRequestsPage() {
       return
     }
 
-    setDraftStatus(selectedRequest.stage)
-    setDraftOwner(selectedRequest.owner ?? '')
-    setDraftNextAction(selectedRequest.nextAction ?? '')
-    setDraftLastContactAt(toDateTimeLocalValue(selectedRequest.lastContactAt))
-    setDraftNextMeetingAt(toDateTimeLocalValue(selectedRequest.nextMeetingAt))
-    setDraftReminderAt(toDateTimeLocalValue(selectedRequest.reminderAt))
-    setDraftNotes(selectedRequest.operatorNotes ?? '')
-  }, [selectedRequest])
+    setDraftStatus(detailRequest.stage)
+    setDraftOwner(detailRequest.owner ?? '')
+    setDraftNextAction(detailRequest.nextAction ?? '')
+    setDraftLastContactAt(toDateTimeLocalValue(detailRequest.lastContactAt))
+    setDraftNextMeetingAt(toDateTimeLocalValue(detailRequest.nextMeetingAt))
+    setDraftReminderAt(toDateTimeLocalValue(detailRequest.reminderAt))
+    setDraftNotes(detailRequest.operatorNotes ?? '')
+  }, [detailRequest])
+
+  async function loadRequestDetail(id: number) {
+    try {
+      setDetailLoading(true)
+      const response = await directoryApi.getBetaRequest(id)
+      setSelectedDetail(response)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load request detail')
+    } finally {
+      setDetailLoading(false)
+    }
+  }
 
   async function load() {
     try {
@@ -153,15 +171,25 @@ export default function BetaRequestsPage() {
     void load()
   }, [attention, ownerFilter, query, sort, status])
 
+  useEffect(() => {
+    if (!selectedRequest) {
+      setSelectedDetail(null)
+      setDetailLoading(false)
+      return
+    }
+
+    void loadRequestDetail(selectedRequest.id)
+  }, [selectedRequest?.id])
+
   async function saveRequest() {
-    if (!selectedRequest || !canEdit) {
+    if (!detailRequest || !canEdit) {
       return
     }
 
     try {
       setSaving(true)
       setNotice(null)
-      const response = await directoryApi.updateBetaRequest(selectedRequest.id, {
+      const response = await directoryApi.updateBetaRequest(detailRequest.id, {
         status: draftStatus,
         owner: draftOwner || null,
         nextAction: draftNextAction || null,
@@ -174,7 +202,7 @@ export default function BetaRequestsPage() {
         entry.id === response.request.id ? response.request : entry
       )))
       setNotice('Operator updates saved.')
-      await load()
+      await Promise.all([load(), loadRequestDetail(response.request.id)])
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to save beta request')
     } finally {
@@ -364,46 +392,46 @@ export default function BetaRequestsPage() {
         <div className="space-y-4">
           <div className="panel space-y-4">
             <div className="panel-title">Request detail</div>
-            {!selectedRequest ? (
+            {!detailRequest ? (
               <EmptyPanel label="Select a hosted beta request to inspect its workflow summary and operator state." />
             ) : (
               <>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <InfoRow label="Company" value={selectedRequest.company ?? '—'} />
-                  <InfoRow label="Email" value={selectedRequest.email} />
-                  <InfoRow label="Stage" value={selectedRequest.stage} />
-                  <InfoRow label="Signal" value={selectedRequest.notificationStatus ?? 'no operator signal'} />
-                  <InfoRow label="Created" value={formatDateTime(selectedRequest.createdAt)} />
-                  <InfoRow label="Updated" value={formatDateTime(selectedRequest.updatedAt)} />
-                  <InfoRow label="Stage entered" value={formatDateTime(selectedRequest.stageEnteredAt)} />
-                  <InfoRow label="Stage age" value={selectedRequest.stageAgeLabel} />
-                  <InfoRow label="Last contact" value={formatDateTime(selectedRequest.lastContactAt)} />
-                  <InfoRow label="Next meeting" value={formatDateTime(selectedRequest.nextMeetingAt)} />
-                  <InfoRow label="Reminder" value={formatDateTime(selectedRequest.reminderAt)} />
-                  <InfoRow label="Owner" value={selectedRequest.owner ?? 'unassigned'} />
+                  <InfoRow label="Company" value={detailRequest.company ?? '—'} />
+                  <InfoRow label="Email" value={detailRequest.email} />
+                  <InfoRow label="Stage" value={detailRequest.stage} />
+                  <InfoRow label="Signal" value={detailRequest.notificationStatus ?? 'no operator signal'} />
+                  <InfoRow label="Created" value={formatDateTime(detailRequest.createdAt)} />
+                  <InfoRow label="Updated" value={formatDateTime(detailRequest.updatedAt)} />
+                  <InfoRow label="Stage entered" value={formatDateTime(detailRequest.stageEnteredAt)} />
+                  <InfoRow label="Stage age" value={detailRequest.stageAgeLabel} />
+                  <InfoRow label="Last contact" value={formatDateTime(detailRequest.lastContactAt)} />
+                  <InfoRow label="Next meeting" value={formatDateTime(detailRequest.nextMeetingAt)} />
+                  <InfoRow label="Reminder" value={formatDateTime(detailRequest.reminderAt)} />
+                  <InfoRow label="Owner" value={detailRequest.owner ?? 'unassigned'} />
                 </div>
 
                 <div className="rounded-xl bg-slate-50 p-4 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
-                  {selectedRequest.workflowSummary || 'No workflow summary was provided in the intake.'}
+                  {detailRequest.workflowSummary || 'No workflow summary was provided in the intake.'}
                 </div>
 
                 <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
                   <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Next action</div>
                   <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
-                    {selectedRequest.nextAction ?? 'No next action is recorded yet.'}
+                    {detailRequest.nextAction ?? 'No next action is recorded yet.'}
                   </div>
-                  {selectedRequest.notificationId ? (
+                  {detailRequest.notificationId ? (
                     <div className="mt-3">
-                      <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/inbox">
+                      <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/inbox?id=${detailRequest.notificationId}`}>
                         Open operator inbox signal
                       </Link>
                     </div>
                   ) : null}
                 </div>
 
-                {selectedRequest.staleReason || selectedRequest.followUpReason ? (
+                {detailRequest.staleReason || detailRequest.followUpReason ? (
                   <div className="space-y-3">
-                    {[selectedRequest.followUpReason, selectedRequest.staleReason].filter(Boolean).map((message) => (
+                    {[detailRequest.followUpReason, detailRequest.staleReason].filter(Boolean).map((message) => (
                       <div key={message} className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
                         {message}
                       </div>
@@ -415,8 +443,57 @@ export default function BetaRequestsPage() {
           </div>
 
           <div className="panel space-y-4">
+            <div className="panel-title">Activity timeline</div>
+            {!detailRequest ? (
+              <EmptyPanel label="Select a request to inspect the partner activity timeline and the next planned follow-up." />
+            ) : detailLoading ? (
+              <div className="text-sm text-slate-500 dark:text-slate-400">Loading recent partner activity…</div>
+            ) : activity.length === 0 ? (
+              <EmptyPanel label="No partner activity has been recorded for this request yet." />
+            ) : (
+              <>
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Recent operator movement plus the next scheduled touchpoints for this design-partner thread.
+                </p>
+                <div className="space-y-3">
+                  {activity.map((entry) => (
+                    <div key={entry.key} className={`rounded-xl border px-4 py-4 ${activityToneClasses(entry.tone)}`}>
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="text-sm font-medium">{entry.title}</div>
+                        <div className="text-xs opacity-80">{formatDateTime(entry.timestamp)}</div>
+                      </div>
+                      <div className="mt-2 text-sm opacity-90">{entry.detail}</div>
+                      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs opacity-80">
+                        <span>{formatActivityKind(entry.kind)}</span>
+                        <span>{entry.actor ? `Actor: ${entry.actor}` : 'Actor: system'}</span>
+                        {entry.upcoming ? <span>Upcoming</span> : null}
+                        {entry.href ? (
+                          <Link className="inline-flex items-center gap-1 text-orange-700 hover:text-orange-800 dark:text-orange-300 dark:hover:text-orange-200" to={entry.href}>
+                            <span>Open linked surface</span>
+                            <ArrowUpRight size={14} />
+                          </Link>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  {detailRequest.notificationId ? (
+                    <Link className="btn-secondary" to={`/inbox?id=${detailRequest.notificationId}`}>
+                      <span>Open operator signal</span>
+                    </Link>
+                  ) : null}
+                  <Link className="btn-secondary" to="/inbox?source=beta_request">
+                    <span>Open beta inbox</span>
+                  </Link>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="panel space-y-4">
             <div className="panel-title">Operator assignment</div>
-            {!selectedRequest ? (
+            {!detailRequest ? (
               <EmptyPanel label="Select a request to assign an owner, move the stage, and capture follow-up." />
             ) : (
               <>
@@ -494,6 +571,17 @@ export default function BetaRequestsPage() {
                 </div>
 
                 <div className="flex flex-wrap gap-3">
+                  {session?.email ? (
+                    <button
+                      className="btn-secondary"
+                      disabled={!canEdit || saving}
+                      onClick={() => setDraftOwner(session.email)}
+                      type="button"
+                    >
+                      <UserRoundPlus size={16} />
+                      <span>Assign to me</span>
+                    </button>
+                  ) : null}
                   <button
                     className="btn-secondary"
                     disabled={!canEdit || saving}
@@ -520,6 +608,36 @@ export default function BetaRequestsPage() {
                   >
                     <Clock3 size={16} />
                     <span>Set reminder +1 day</span>
+                  </button>
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving}
+                    onClick={() => {
+                      setDraftStatus('scheduled')
+                      setDraftNextMeetingAt(futureDateTimeLocalValue({ days: 3 }))
+                      if (!draftReminderAt) {
+                        setDraftReminderAt(futureDateTimeLocalValue({ days: 1 }))
+                      }
+                    }}
+                    type="button"
+                  >
+                    <CalendarClock size={16} />
+                    <span>Queue walkthrough</span>
+                  </button>
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving}
+                    onClick={() => {
+                      setDraftStatus('active')
+                      setDraftLastContactAt(toDateTimeLocalValue(new Date().toISOString()))
+                      if (!draftReminderAt) {
+                        setDraftReminderAt(futureDateTimeLocalValue({ days: 2 }))
+                      }
+                    }}
+                    type="button"
+                  >
+                    <CheckCircle2 size={16} />
+                    <span>Mark follow-up active</span>
                   </button>
                 </div>
 
@@ -575,14 +693,14 @@ export default function BetaRequestsPage() {
               >
                 Open onboarding pack
               </a>
-              {selectedRequest ? (
+              {detailRequest ? (
                 <a
                   className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
-                  href={`${ONBOARDING_PACK_URL}${templateAnchorForStage(selectedRequest.stage)}`}
+                  href={`${ONBOARDING_PACK_URL}${templateAnchorForStage(detailRequest.stage)}`}
                   rel="noreferrer"
                   target="_blank"
                 >
-                  Open template for {selectedRequest.stage}
+                  Open template for {detailRequest.stage}
                 </a>
               ) : null}
             </div>
@@ -615,6 +733,38 @@ function formatAttentionFlag(flag: BetaRequestAttention): string {
     case 'stale':
     default:
       return 'stale'
+  }
+}
+
+function formatActivityKind(kind: BetaRequestActivityEntry['kind']): string {
+  switch (kind) {
+    case 'request_created':
+      return 'Intake'
+    case 'stage_changed':
+      return 'Stage'
+    case 'contact_logged':
+      return 'Contact'
+    case 'meeting_scheduled':
+      return 'Meeting'
+    case 'reminder':
+      return 'Reminder'
+    case 'notification':
+      return 'Signal'
+    case 'request_updated':
+    default:
+      return 'Update'
+  }
+}
+
+function activityToneClasses(tone: BetaRequestActivityEntry['tone']): string {
+  switch (tone) {
+    case 'success':
+      return 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200'
+    case 'warning':
+      return 'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200'
+    case 'default':
+    default:
+      return 'border-slate-200 bg-white text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100'
   }
 }
 

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -442,7 +442,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
 
     const contactTimestamp = '2026-03-30T20:15:00.000Z'
     const meetingTimestamp = '2026-04-02T14:00:00.000Z'
-    const reminderTimestamp = '2020-01-01T09:00:00.000Z'
+    const reminderTimestamp = '2026-03-30T21:00:00.000Z'
     const contactResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
       method: 'PATCH',
       headers: {
@@ -479,6 +479,35 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(contacted.request.reminderAt, reminderTimestamp)
     assert.equal(contacted.request.notificationStatus, 'acted')
     assert.deepEqual(contacted.request.attentionFlags, ['follow_up_due'])
+
+    const detailResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(detailResponse.status, 200)
+
+    const detail = await detailResponse.json() as {
+      request: {
+        id: number
+        stage: string
+        notificationStatus: string | null
+      }
+      activity: Array<{
+        title: string
+        kind: string
+        href: string | null
+      }>
+    }
+    assert.equal(detail.request.id, created.request.id)
+    assert.equal(detail.request.stage, 'scheduled')
+    assert.equal(detail.request.notificationStatus, 'acted')
+    assert.ok(detail.activity.length >= 6)
+    assert.ok(detail.activity.some((entry) => entry.title === 'Hosted beta request captured'))
+    assert.ok(detail.activity.some((entry) => entry.title === 'Stage moved to Scheduled'))
+    assert.ok(detail.activity.some((entry) => entry.title === 'Last contact recorded'))
+    assert.ok(detail.activity.some((entry) => entry.title === 'Next meeting is scheduled'))
+    assert.ok(detail.activity.some((entry) => entry.title === 'Follow-up reminder is due'))
+    assert.ok(detail.activity.some((entry) => entry.title === 'Operator signal marked acted'))
+    assert.ok(detail.activity.some((entry) => entry.href === `/inbox?id=${created.request.notificationId}`))
 
     const dueResponse = await app.request(new Request('http://localhost/admin/beta-requests?attention=follow_up_due&status=scheduled', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -58,7 +58,7 @@ import {
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import { getReleaseInfo } from './release.js'
-import type { AgentRow, IntentFrame, OperatorNotificationRow } from './types.js'
+import type { AgentRow, AuditLogRow, IntentFrame, OperatorNotificationRow } from './types.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
@@ -78,6 +78,15 @@ type BetaRequestAttention = 'unowned' | 'stale' | 'follow_up_due'
 type BetaRequestSort = 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
 type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 type OperatorNotificationSource = 'beta_request' | 'critical_alert'
+type BetaRequestActivityKind =
+  | 'request_created'
+  | 'stage_changed'
+  | 'request_updated'
+  | 'contact_logged'
+  | 'meeting_scheduled'
+  | 'reminder'
+  | 'notification'
+type BetaRequestActivityTone = 'default' | 'success' | 'warning'
 type FunnelEventCategory = 'page_view' | 'cta_click' | 'request' | 'demo_milestone'
 type FunnelPageKey =
   | 'landing'
@@ -151,6 +160,18 @@ type WaitlistRow = {
   stage_entered_at: string | null
   created_at: string
   updated_at: string
+}
+
+type BetaRequestActivityEntry = {
+  key: string
+  kind: BetaRequestActivityKind
+  timestamp: string
+  title: string
+  detail: string
+  actor: string | null
+  tone: BetaRequestActivityTone
+  href: string | null
+  upcoming: boolean
 }
 
 const BETA_REQUEST_STATUSES: BetaRequestStatus[] = ['new', 'reviewing', 'contacted', 'scheduled', 'active', 'closed']
@@ -543,6 +564,309 @@ function serializeBetaRequest(
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   }
+}
+
+function parseAuditDetails(details: string | null | undefined): Record<string, unknown> | null {
+  if (!details) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(details)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    return null
+  }
+
+  return null
+}
+
+function formatBetaRequestStatusLabel(value: string | null | undefined): string {
+  if (!value) {
+    return 'Unknown'
+  }
+
+  return value.charAt(0).toUpperCase() + value.slice(1)
+}
+
+function describeBetaRequestAuditEntry(log: AuditLogRow): BetaRequestActivityEntry {
+  const details = parseAuditDetails(log.details)
+  const detailParts: string[] = []
+  const nextStatus = typeof details?.status === 'string' ? details.status : null
+  const owner = typeof details?.owner === 'string' ? details.owner : null
+
+  if (owner) {
+    detailParts.push(`Owner: ${owner}.`)
+  }
+
+  if (details?.nextActionChanged === true) {
+    detailParts.push('Next action updated.')
+  }
+
+  if (details?.operatorNotesChanged === true) {
+    detailParts.push('Operator notes updated.')
+  }
+
+  if (details?.lastContactChanged === true) {
+    detailParts.push('Last contact refreshed.')
+  }
+
+  if (details?.nextMeetingChanged === true) {
+    detailParts.push('Next meeting updated.')
+  }
+
+  if (details?.reminderChanged === true) {
+    detailParts.push('Reminder timing updated.')
+  }
+
+  let kind: BetaRequestActivityKind = 'request_updated'
+  let title = 'Operator updated the partner request'
+  let tone: BetaRequestActivityTone = 'default'
+
+  if (nextStatus) {
+    kind = 'stage_changed'
+    title = `Stage moved to ${formatBetaRequestStatusLabel(nextStatus)}`
+    tone = nextStatus === 'active' || nextStatus === 'closed' ? 'success' : 'default'
+  } else if (details?.lastContactChanged === true) {
+    kind = 'contact_logged'
+    title = 'Last contact was recorded'
+    tone = 'success'
+  } else if (details?.nextMeetingChanged === true) {
+    kind = 'meeting_scheduled'
+    title = 'Next meeting plan changed'
+  } else if (details?.reminderChanged === true) {
+    kind = 'reminder'
+    title = 'Follow-up reminder changed'
+    tone = 'warning'
+  }
+
+  return {
+    key: `audit-${log.id}`,
+    kind,
+    timestamp: log.timestamp,
+    title,
+    detail: detailParts.join(' ') || 'Operator metadata changed for this partner request.',
+    actor: log.actor,
+    tone,
+    href: null,
+    upcoming: false,
+  }
+}
+
+function describeNotificationAuditEntry(
+  log: AuditLogRow,
+  notificationId: number | null,
+): BetaRequestActivityEntry | null {
+  const details = parseAuditDetails(log.details)
+  if (details?.sourceType !== 'beta_request') {
+    return null
+  }
+
+  const detailParts: string[] = []
+  const status = typeof details?.status === 'string' ? details.status : null
+  const owner = typeof details?.owner === 'string' ? details.owner : null
+  const nextAction = typeof details?.nextAction === 'string' ? details.nextAction : null
+
+  if (owner) {
+    detailParts.push(`Owner: ${owner}.`)
+  }
+
+  if (nextAction) {
+    detailParts.push(`Next: ${nextAction}`)
+  }
+
+  let title = 'Operator signal updated'
+  let tone: BetaRequestActivityTone = 'default'
+
+  if (status === 'new') {
+    title = 'Operator signal reset to new'
+    tone = 'warning'
+  } else if (status === 'acknowledged') {
+    title = 'Operator signal acknowledged'
+  } else if (status === 'acted') {
+    title = 'Operator signal marked acted'
+    tone = 'success'
+  }
+
+  return {
+    key: `notification-audit-${log.id}`,
+    kind: 'notification',
+    timestamp: log.timestamp,
+    title,
+    detail: detailParts.join(' ') || 'Operator signal state changed for this partner request.',
+    actor: log.actor,
+    tone,
+    href: notificationId ? `/inbox?id=${notificationId}` : '/inbox',
+    upcoming: false,
+  }
+}
+
+function buildBetaRequestActivityTimeline(
+  db: Database,
+  row: WaitlistRow,
+  notification?: OperatorNotificationRow | null,
+): BetaRequestActivityEntry[] {
+  const activities: BetaRequestActivityEntry[] = []
+  const stage = normalizeBetaRequestStatus(row.status) ?? 'new'
+  const requestHref = `/beta-requests?id=${row.id}`
+  const notificationHref = notification?.id ? `/inbox?id=${notification.id}` : '/inbox'
+  const workflowLabel = row.workflow_type
+    ? row.workflow_type.replace(/^hosted-beta-/, '').replaceAll('-', ' ')
+    : 'workflow review'
+
+  activities.push({
+    key: `request-${row.id}-created`,
+    kind: 'request_created',
+    timestamp: row.created_at,
+    title: 'Hosted beta request captured',
+    detail: `${row.company ?? row.email} entered Beam through ${row.source ?? 'the public intake'} for ${workflowLabel}.`,
+    actor: row.email,
+    tone: 'default',
+    href: requestHref,
+    upcoming: false,
+  })
+
+  if (row.stage_entered_at) {
+    activities.push({
+      key: `request-${row.id}-stage-${row.stage_entered_at}`,
+      kind: 'stage_changed',
+      timestamp: row.stage_entered_at,
+      title: `Current stage is ${formatBetaRequestStatusLabel(stage)}`,
+      detail: row.next_action ?? getBetaRequestNextStep(stage),
+      actor: row.owner,
+      tone: stage === 'active' || stage === 'closed' ? 'success' : 'default',
+      href: requestHref,
+      upcoming: false,
+    })
+  }
+
+  if (row.last_contact_at) {
+    activities.push({
+      key: `request-${row.id}-contact-${row.last_contact_at}`,
+      kind: 'contact_logged',
+      timestamp: row.last_contact_at,
+      title: 'Last contact recorded',
+      detail: row.owner
+        ? `Beam has a recorded touchpoint from ${row.owner}.`
+        : 'Beam has a recorded touchpoint for this partner request.',
+      actor: row.owner,
+      tone: 'success',
+      href: requestHref,
+      upcoming: false,
+    })
+  }
+
+  if (row.next_meeting_at) {
+    const meetingTime = new Date(row.next_meeting_at).getTime()
+    const meetingUpcoming = !Number.isNaN(meetingTime) && meetingTime > Date.now()
+    activities.push({
+      key: `request-${row.id}-meeting-${row.next_meeting_at}`,
+      kind: 'meeting_scheduled',
+      timestamp: row.next_meeting_at,
+      title: meetingUpcoming ? 'Next meeting is scheduled' : 'Meeting time is in the past',
+      detail: row.next_action ?? 'A follow-up meeting is attached to this partner request.',
+      actor: row.owner,
+      tone: meetingUpcoming ? 'default' : 'warning',
+      href: requestHref,
+      upcoming: meetingUpcoming,
+    })
+  }
+
+  if (row.reminder_at) {
+    const reminderTime = new Date(row.reminder_at).getTime()
+    const reminderDue = !Number.isNaN(reminderTime) && reminderTime <= Date.now()
+    const attention = getBetaRequestAttention(row)
+    activities.push({
+      key: `request-${row.id}-reminder-${row.reminder_at}`,
+      kind: 'reminder',
+      timestamp: row.reminder_at,
+      title: reminderDue ? 'Follow-up reminder is due' : 'Follow-up reminder is scheduled',
+      detail: attention.followUpDue
+        ? (attention.followUpReason ?? 'A follow-up touchpoint is due.')
+        : 'Beam has a scheduled reminder for the next partner touchpoint.',
+      actor: row.owner,
+      tone: reminderDue ? 'warning' : 'default',
+      href: requestHref,
+      upcoming: !reminderDue,
+    })
+  }
+
+  if (notification) {
+    activities.push({
+      key: `notification-${notification.id}-created`,
+      kind: 'notification',
+      timestamp: notification.created_at,
+      title: 'Operator signal opened',
+      detail: notification.message,
+      actor: notification.actor,
+      tone: 'default',
+      href: notificationHref,
+      upcoming: false,
+    })
+
+    if (notification.acknowledged_at) {
+      activities.push({
+        key: `notification-${notification.id}-acknowledged`,
+        kind: 'notification',
+        timestamp: notification.acknowledged_at,
+        title: 'Operator signal acknowledged',
+        detail: notification.next_action ?? 'Someone took ownership of the next response.',
+        actor: notification.actor,
+        tone: 'default',
+        href: notificationHref,
+        upcoming: false,
+      })
+    }
+
+    if (notification.acted_at) {
+      activities.push({
+        key: `notification-${notification.id}-acted`,
+        kind: 'notification',
+        timestamp: notification.acted_at,
+        title: 'Operator signal marked acted',
+        detail: notification.next_action ?? 'A concrete next step was recorded on the operator signal.',
+        actor: notification.actor,
+        tone: 'success',
+        href: notificationHref,
+        upcoming: false,
+      })
+    }
+  }
+
+  for (const audit of listAuditLog(db, {
+    action: 'admin.beta_request.updated',
+    target: String(row.id),
+    limit: 40,
+  })) {
+    activities.push(describeBetaRequestAuditEntry(audit))
+  }
+
+  for (const audit of listAuditLog(db, {
+    action: 'admin.operator_notification.updated',
+    limit: 80,
+  })) {
+    const details = parseAuditDetails(audit.details)
+    if (details?.sourceKey !== betaRequestNotificationSourceKey(row.id)) {
+      continue
+    }
+
+    const entry = describeNotificationAuditEntry(audit, notification?.id ?? null)
+    if (entry) {
+      activities.push(entry)
+    }
+  }
+
+  return activities.sort((left, right) => {
+    const leftTime = new Date(left.timestamp).getTime()
+    const rightTime = new Date(right.timestamp).getTime()
+    if (leftTime !== rightTime) {
+      return rightTime - leftTime
+    }
+
+    return left.key.localeCompare(right.key)
+  })
 }
 
 function getBetaRequestNextStep(status: string): string {
@@ -1951,7 +2275,10 @@ export function createApp(db: Database): Hono {
       }
       const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(row.id))
       c.header('Cache-Control', 'no-store')
-      return c.json({ request: serializeBetaRequest(row, notification) })
+      return c.json({
+        request: serializeBetaRequest(row, notification),
+        activity: buildBetaRequestActivityTimeline(db, row, notification),
+      })
     } catch (err) {
       console.error('Admin beta request detail error:', err)
       return c.json({ error: 'Failed to load beta request', errorCode: 'DB_ERROR' }, 500)


### PR DESCRIPTION
## Summary\n- add a partner activity timeline to hosted beta request detail by stitching request state, operator signal state, and audit events\n- tighten the operator follow-up loop with assign-to-me and stage-based shortcut actions in the beta request queue\n- close the already-completed milestone issues #74 and #75 so the 0.9.0 backlog reflects reality\n\nCloses #76\n\n## Verification\n- npm test --workspace=packages/directory\n- npm run build --workspace=packages/dashboard\n- npm run build\n- npm test