### PR TITLE
Add hosted beta pilot proof summaries

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -247,11 +247,17 @@ List filtering currently supports:
   "owner": "operator@beam.directory",
   "operatorNotes": "Intro email sent, follow-up call pending.",
   "nextAction": "Prepare a 30 minute buyer walkthrough.",
-  "lastContactAt": "2026-03-31T09:30:00.000Z"
+  "lastContactAt": "2026-03-31T09:30:00.000Z",
+  "proofIntentNonce": "pilot-proof-123456"
 }
 ```
 
-The response request record carries the same pipeline fields plus notification state, so operators can tell whether a request is still `new`, already `acknowledged`, or fully `acted` on.
+The response request record carries the same pipeline fields plus notification state and an optional `proofIntentNonce`, so operators can tell whether a request is still `new`, already `acknowledged`, or fully `acted` on.
+
+`GET /admin/beta-requests/:id` also returns:
+
+- `activity`: the operator and follow-up timeline
+- `proofSummary`: a buyer-friendly artifact generated from the linked `proofIntentNonce`, including identity proof, delivery proof, operator visibility, and a recommended next step
 
 Hosted beta export includes:
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -566,6 +566,7 @@ export interface BetaRequest {
   agentCount: number | null
   workflowType: string | null
   workflowSummary: string | null
+  proofIntentNonce: string | null
   requestStatus: BetaRequestStatus
   stage: BetaRequestStatus
   owner: string | null
@@ -611,6 +612,49 @@ export interface BetaRequestActivityEntry {
   upcoming: boolean
 }
 
+export interface BetaRequestProofSummaryParty {
+  beamId: string
+  displayName: string
+  verificationTier: string
+  trustScore: number | null
+  verified: boolean
+}
+
+export interface BetaRequestProofSummary {
+  generatedAt: string
+  proofIntentNonce: string
+  headline: string
+  summary: string
+  recommendation: string
+  markdown: string
+  identity: {
+    sender: BetaRequestProofSummaryParty
+    recipient: BetaRequestProofSummaryParty
+  }
+  delivery: {
+    intentType: string
+    status: IntentLifecycleStatus
+    requestedAt: string
+    completedAt: string | null
+    latencyMs: number | null
+    traceStageCount: number
+    stages: string[]
+    routeLabel: string | null
+    shieldDecision: string | null
+  }
+  operatorVisibility: {
+    signalStatus: OperatorNotificationStatus | 'missing'
+    signalOwner: string | null
+    nextAction: string | null
+    activityCount: number
+    liveAgents: number
+    activeAlerts: number
+    traceHref: string
+    signalHref: string | null
+    requestHref: string
+  }
+}
+
 export type WaitlistEntry = BetaRequest
 
 export interface WaitlistListResponse {
@@ -640,6 +684,7 @@ export interface BetaRequestListResponse {
 export interface BetaRequestDetailResponse {
   request: BetaRequest
   activity: BetaRequestActivityEntry[]
+  proofSummary: BetaRequestProofSummary | null
 }
 
 export interface BetaRequestUpdateInput {
@@ -650,6 +695,7 @@ export interface BetaRequestUpdateInput {
   lastContactAt?: string | null
   nextMeetingAt?: string | null
   reminderAt?: string | null
+  proofIntentNonce?: string | null
 }
 
 export interface BetaRequestUpdateResponse {

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, CalendarClock, CheckCircle2, Clock3, Download, RefreshCw, Search, TriangleAlert, UserRoundPlus } from 'lucide-react'
+import { ArrowUpRight, CalendarClock, CheckCircle2, Clock3, Copy, Download, RefreshCw, Search, TriangleAlert, UserRoundPlus } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
@@ -7,6 +7,8 @@ import {
   ApiError,
   directoryApi,
   type BetaRequestActivityEntry,
+  type BetaRequestDetailResponse,
+  type BetaRequestProofSummary,
   type BetaRequest,
   type BetaRequestAttention,
   type BetaRequestStatus,
@@ -49,7 +51,7 @@ export default function BetaRequestsPage() {
   const { session } = useAdminAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const [requests, setRequests] = useState<BetaRequest[]>([])
-  const [selectedDetail, setSelectedDetail] = useState<{ request: BetaRequest; activity: BetaRequestActivityEntry[] } | null>(null)
+  const [selectedDetail, setSelectedDetail] = useState<BetaRequestDetailResponse | null>(null)
   const [total, setTotal] = useState(0)
   const [summary, setSummary] = useState<{
     total: number
@@ -65,6 +67,7 @@ export default function BetaRequestsPage() {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  const [copyNotice, setCopyNotice] = useState<string | null>(null)
 
   const query = searchParams.get('q') ?? ''
   const status = (searchParams.get('status') ?? '') as '' | BetaRequestStatus
@@ -80,6 +83,7 @@ export default function BetaRequestsPage() {
   )
   const detailRequest = selectedDetail?.request ?? selectedRequest
   const activity = selectedDetail?.activity ?? []
+  const proofSummary = selectedDetail?.proofSummary ?? null
 
   const [draftStatus, setDraftStatus] = useState<BetaRequestStatus>('new')
   const [draftOwner, setDraftOwner] = useState('')
@@ -87,6 +91,7 @@ export default function BetaRequestsPage() {
   const [draftLastContactAt, setDraftLastContactAt] = useState('')
   const [draftNextMeetingAt, setDraftNextMeetingAt] = useState('')
   const [draftReminderAt, setDraftReminderAt] = useState('')
+  const [draftProofIntentNonce, setDraftProofIntentNonce] = useState('')
   const [draftNotes, setDraftNotes] = useState('')
 
   function updateSearchParam(key: string, value: string) {
@@ -119,6 +124,7 @@ export default function BetaRequestsPage() {
       setDraftLastContactAt('')
       setDraftNextMeetingAt('')
       setDraftReminderAt('')
+      setDraftProofIntentNonce('')
       setDraftNotes('')
       return
     }
@@ -129,12 +135,14 @@ export default function BetaRequestsPage() {
     setDraftLastContactAt(toDateTimeLocalValue(detailRequest.lastContactAt))
     setDraftNextMeetingAt(toDateTimeLocalValue(detailRequest.nextMeetingAt))
     setDraftReminderAt(toDateTimeLocalValue(detailRequest.reminderAt))
+    setDraftProofIntentNonce(detailRequest.proofIntentNonce ?? '')
     setDraftNotes(detailRequest.operatorNotes ?? '')
   }, [detailRequest])
 
   async function loadRequestDetail(id: number) {
     try {
       setDetailLoading(true)
+      setCopyNotice(null)
       const response = await directoryApi.getBetaRequest(id)
       setSelectedDetail(response)
       setError(null)
@@ -189,6 +197,7 @@ export default function BetaRequestsPage() {
     try {
       setSaving(true)
       setNotice(null)
+      setCopyNotice(null)
       const response = await directoryApi.updateBetaRequest(detailRequest.id, {
         status: draftStatus,
         owner: draftOwner || null,
@@ -196,6 +205,7 @@ export default function BetaRequestsPage() {
         lastContactAt: draftLastContactAt || null,
         nextMeetingAt: draftNextMeetingAt || null,
         reminderAt: draftReminderAt || null,
+        proofIntentNonce: draftProofIntentNonce || null,
         operatorNotes: draftNotes || null,
       })
       setRequests((current) => current.map((entry) => (
@@ -225,6 +235,16 @@ export default function BetaRequestsPage() {
       setNotice(`Exported hosted beta requests as ${format.toUpperCase()}.`)
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to export beta requests')
+    }
+  }
+
+  async function copyProofMarkdown(summary: BetaRequestProofSummary) {
+    try {
+      await navigator.clipboard.writeText(summary.markdown)
+      setCopyNotice('Pilot proof summary copied.')
+      setError(null)
+    } catch {
+      setError('Failed to copy the pilot proof summary.')
     }
   }
 
@@ -312,6 +332,12 @@ export default function BetaRequestsPage() {
       {notice ? (
         <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
           {notice}
+        </div>
+      ) : null}
+
+      {copyNotice ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+          {copyNotice}
         </div>
       ) : null}
 
@@ -443,6 +469,63 @@ export default function BetaRequestsPage() {
           </div>
 
           <div className="panel space-y-4">
+            <div className="panel-title">Pilot proof summary</div>
+            {!detailRequest ? (
+              <EmptyPanel label="Select a request to generate a buyer-friendly proof summary from a live pilot trace." />
+            ) : !proofSummary ? (
+              <EmptyPanel label={detailRequest.proofIntentNonce
+                ? 'Beam could not generate a proof summary for the linked nonce yet.'
+                : 'Link a pilot trace nonce to this request to generate a shareable proof summary.'}
+              />
+            ) : (
+              <>
+                <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200">
+                  <div className="font-medium">{proofSummary.headline}</div>
+                  <div className="mt-2">{proofSummary.summary}</div>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <InfoRow label="Proof nonce" value={proofSummary.proofIntentNonce} />
+                  <InfoRow label="Intent" value={proofSummary.delivery.intentType} />
+                  <InfoRow label="Delivery status" value={proofSummary.delivery.status} />
+                  <InfoRow label="Latency" value={proofSummary.delivery.latencyMs == null ? 'n/a' : `${proofSummary.delivery.latencyMs}ms`} />
+                  <InfoRow label="Sender" value={proofSummary.identity.sender.displayName} />
+                  <InfoRow label="Recipient" value={proofSummary.identity.recipient.displayName} />
+                  <InfoRow label="Sender trust" value={formatTrustScore(proofSummary.identity.sender.trustScore)} />
+                  <InfoRow label="Recipient trust" value={formatTrustScore(proofSummary.identity.recipient.trustScore)} />
+                  <InfoRow label="Signal status" value={proofSummary.operatorVisibility.signalStatus} />
+                  <InfoRow label="Live agents (24h)" value={String(proofSummary.operatorVisibility.liveAgents)} />
+                </div>
+
+                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Recommended next step</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{proofSummary.recommendation}</div>
+                </div>
+
+                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Shareable markdown</div>
+                  <pre className="mt-3 overflow-x-auto whitespace-pre-wrap text-xs leading-6 text-slate-600 dark:text-slate-300">{proofSummary.markdown}</pre>
+                </div>
+
+                <div className="flex flex-wrap gap-3">
+                  <button className="btn-secondary" onClick={() => void copyProofMarkdown(proofSummary)} type="button">
+                    <Copy size={16} />
+                    <span>Copy summary</span>
+                  </button>
+                  <Link className="btn-secondary" to={proofSummary.operatorVisibility.traceHref}>
+                    <span>Open trace</span>
+                  </Link>
+                  {proofSummary.operatorVisibility.signalHref ? (
+                    <Link className="btn-secondary" to={proofSummary.operatorVisibility.signalHref}>
+                      <span>Open signal</span>
+                    </Link>
+                  ) : null}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="panel space-y-4">
             <div className="panel-title">Activity timeline</div>
             {!detailRequest ? (
               <EmptyPanel label="Select a request to inspect the partner activity timeline and the next planned follow-up." />
@@ -569,6 +652,20 @@ export default function BetaRequestsPage() {
                     />
                   </label>
                 </div>
+
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium">Proof trace nonce</span>
+                  <input
+                    className="input-field"
+                    disabled={!canEdit || saving}
+                    placeholder="beam-proof-123456"
+                    value={draftProofIntentNonce}
+                    onChange={(event) => setDraftProofIntentNonce(event.target.value)}
+                  />
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    Link the exact pilot trace that should back the buyer-facing proof summary.
+                  </span>
+                </label>
 
                 <div className="flex flex-wrap gap-3">
                   {session?.email ? (
@@ -722,6 +819,14 @@ function formatWorkflowType(value: string | null): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ')
+}
+
+function formatTrustScore(value: number | null): string {
+  if (value == null) {
+    return 'n/a'
+  }
+
+  return `${Math.round(value * 100)}%`
 }
 
 function formatAttentionFlag(flag: BetaRequestAttention): string {

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -161,6 +161,7 @@ function initSchema(db: DB): void {
       agent_count INTEGER,
       workflow_type TEXT,
       workflow_summary TEXT,
+      proof_intent_nonce TEXT,
       status TEXT NOT NULL DEFAULT 'new',
       owner TEXT,
       operator_notes TEXT,
@@ -524,6 +525,7 @@ function initSchema(db: DB): void {
   ensureColumn(db, 'agents', 'personal', 'INTEGER NOT NULL DEFAULT 0')
   ensureColumn(db, 'waitlist', 'workflow_type', 'TEXT')
   ensureColumn(db, 'waitlist', 'workflow_summary', 'TEXT')
+  ensureColumn(db, 'waitlist', 'proof_intent_nonce', 'TEXT')
   ensureColumn(db, 'waitlist', 'status', "TEXT NOT NULL DEFAULT 'new'")
   ensureColumn(db, 'waitlist', 'owner', 'TEXT')
   ensureColumn(db, 'waitlist', 'operator_notes', 'TEXT')
@@ -538,6 +540,7 @@ function initSchema(db: DB): void {
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_last_contact ON waitlist(last_contact_at, updated_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_next_meeting ON waitlist(next_meeting_at, updated_at DESC)')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_reminder ON waitlist(reminder_at, updated_at DESC)')
+  db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_proof_intent_nonce ON waitlist(proof_intent_nonce)')
   db.prepare(`
     UPDATE waitlist
     SET status = COALESCE(NULLIF(status, ''), 'new'),

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
-import { assignDirectoryRole, createDatabase, upsertOperatorNotification } from './db.js'
+import { appendIntentTraceEvent, assignDirectoryRole, createDatabase, finalizeIntentLog, logIntentStart, registerAgent, setIntentLifecycleStatus, upsertOperatorNotification } from './db.js'
 import { getLocalDirectoryUrl } from './federation.js'
 
 function createAdminHeaders(
@@ -440,6 +440,101 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(updated.request.notificationStatus, 'acknowledged')
     assert.deepEqual(updated.request.attentionFlags, [])
 
+    const proofNonce = 'pilot-proof-demo-0001'
+    registerAgent(db, {
+      beamId: 'procurement@acme.beam.directory',
+      displayName: 'Acme Procurement',
+      capabilities: ['procurement'],
+      publicKey: 'MCowBQYDK2VwAyEAEHzHjWwTn/RZiC407+hCtk8nde/GEVUn85iOaZBH2Bw=',
+      verificationTier: 'business',
+      email: 'procurement@acme.example',
+      emailVerified: true,
+    })
+    registerAgent(db, {
+      beamId: 'finance@northwind.beam.directory',
+      displayName: 'Northwind Finance',
+      capabilities: ['finance'],
+      publicKey: 'MCowBQYDK2VwAyEAr+N7jwgoTnwP/02HeC88JezBI3D/FbtcWbhOOyUpM8Y=',
+      verificationTier: 'verified',
+      email: 'finance@northwind.example',
+      emailVerified: true,
+    })
+    logIntentStart(db, {
+      v: '1',
+      nonce: proofNonce,
+      from: 'procurement@acme.beam.directory',
+      to: 'finance@northwind.beam.directory',
+      intent: 'conversation.message',
+      payload: { message: 'Can you approve the async quote?' },
+      timestamp: '2026-03-30T20:15:30.000Z',
+    })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'received',
+      timestamp: '2026-03-30T20:15:30.000Z',
+      details: { channel: 'websocket' },
+    })
+    setIntentLifecycleStatus(db, { nonce: proofNonce, status: 'validated' })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'validated',
+      timestamp: '2026-03-30T20:15:31.000Z',
+      details: { signatureVerified: true },
+    })
+    setIntentLifecycleStatus(db, { nonce: proofNonce, status: 'queued' })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'queued',
+      timestamp: '2026-03-30T20:15:32.000Z',
+      details: { queue: 'default' },
+    })
+    setIntentLifecycleStatus(db, { nonce: proofNonce, status: 'dispatched' })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'dispatched',
+      timestamp: '2026-03-30T20:15:33.000Z',
+      details: { transport: 'direct-http' },
+    })
+    setIntentLifecycleStatus(db, { nonce: proofNonce, status: 'delivered' })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'delivered',
+      timestamp: '2026-03-30T20:15:34.000Z',
+      details: { route: 'direct-http' },
+    })
+    finalizeIntentLog(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      status: 'acked',
+      latencyMs: 220,
+      resultJson: JSON.stringify({ success: true }),
+    })
+    appendIntentTraceEvent(db, {
+      nonce: proofNonce,
+      fromBeamId: 'procurement@acme.beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      intentType: 'conversation.message',
+      stage: 'acked',
+      timestamp: '2026-03-30T20:15:35.000Z',
+      details: { route: 'direct-http' },
+    })
+
     const contactTimestamp = '2026-03-30T20:15:00.000Z'
     const meetingTimestamp = '2026-04-02T14:00:00.000Z'
     const reminderTimestamp = '2026-03-30T21:00:00.000Z'
@@ -455,6 +550,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         lastContactAt: contactTimestamp,
         nextMeetingAt: meetingTimestamp,
         reminderAt: reminderTimestamp,
+        proofIntentNonce: proofNonce,
       }),
     }))
     assert.equal(contactResponse.status, 200)
@@ -467,6 +563,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         lastContactAt: string | null
         nextMeetingAt: string | null
         reminderAt: string | null
+        proofIntentNonce: string | null
         notificationStatus: string
         attentionFlags: string[]
       }
@@ -477,6 +574,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(contacted.request.lastContactAt, contactTimestamp)
     assert.equal(contacted.request.nextMeetingAt, meetingTimestamp)
     assert.equal(contacted.request.reminderAt, reminderTimestamp)
+    assert.equal(contacted.request.proofIntentNonce, proofNonce)
     assert.equal(contacted.request.notificationStatus, 'acted')
     assert.deepEqual(contacted.request.attentionFlags, ['follow_up_due'])
 
@@ -489,6 +587,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
       request: {
         id: number
         stage: string
+        proofIntentNonce: string | null
         notificationStatus: string | null
       }
       activity: Array<{
@@ -496,9 +595,36 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         kind: string
         href: string | null
       }>
+      proofSummary: {
+        headline: string
+        recommendation: string
+        markdown: string
+        identity: {
+          sender: {
+            beamId: string
+            verificationTier: string
+          }
+          recipient: {
+            beamId: string
+            verificationTier: string
+          }
+        }
+        delivery: {
+          status: string
+          latencyMs: number | null
+          stages: string[]
+          routeLabel: string | null
+        }
+        operatorVisibility: {
+          signalStatus: string
+          traceHref: string
+          signalHref: string | null
+        }
+      } | null
     }
     assert.equal(detail.request.id, created.request.id)
     assert.equal(detail.request.stage, 'scheduled')
+    assert.equal(detail.request.proofIntentNonce, proofNonce)
     assert.equal(detail.request.notificationStatus, 'acted')
     assert.ok(detail.activity.length >= 6)
     assert.ok(detail.activity.some((entry) => entry.title === 'Hosted beta request captured'))
@@ -508,6 +634,21 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.ok(detail.activity.some((entry) => entry.title === 'Follow-up reminder is due'))
     assert.ok(detail.activity.some((entry) => entry.title === 'Operator signal marked acted'))
     assert.ok(detail.activity.some((entry) => entry.href === `/inbox?id=${created.request.notificationId}`))
+    assert.ok(detail.proofSummary)
+    assert.match(detail.proofSummary?.headline ?? '', /pilot handoff .* acknowledged/i)
+    assert.equal(detail.proofSummary?.identity.sender.beamId, 'procurement@acme.beam.directory')
+    assert.equal(detail.proofSummary?.identity.sender.verificationTier, 'business')
+    assert.equal(detail.proofSummary?.identity.recipient.beamId, 'finance@northwind.beam.directory')
+    assert.equal(detail.proofSummary?.identity.recipient.verificationTier, 'verified')
+    assert.equal(detail.proofSummary?.delivery.status, 'acked')
+    assert.equal(detail.proofSummary?.delivery.latencyMs, 220)
+    assert.deepEqual(detail.proofSummary?.delivery.stages, ['received', 'validated', 'queued', 'dispatched', 'delivered', 'acked'])
+    assert.equal(detail.proofSummary?.delivery.routeLabel, 'direct-http')
+    assert.equal(detail.proofSummary?.operatorVisibility.signalStatus, 'acted')
+    assert.equal(detail.proofSummary?.operatorVisibility.traceHref, `/intents/${proofNonce}`)
+    assert.equal(detail.proofSummary?.operatorVisibility.signalHref, `/inbox?id=${created.request.notificationId}`)
+    assert.match(detail.proofSummary?.recommendation ?? '', /pilot review/i)
+    assert.match(detail.proofSummary?.markdown ?? '', /Beam pilot proof summary/)
 
     const dueResponse = await app.request(new Request('http://localhost/admin/beta-requests?attention=follow_up_due&status=scheduled', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),

--- a/packages/directory/src/routes/observability.ts
+++ b/packages/directory/src/routes/observability.ts
@@ -438,7 +438,7 @@ function searchAuditRows(
   return { entries, total: totalRow?.count ?? entries.length }
 }
 
-function buildOverviewPayload(db: Database, windowHours: number) {
+export function buildOverviewPayload(db: Database, windowHours: number) {
   const since = nowMinusHours(windowHours)
   const rows = db.prepare(`
     SELECT *

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -18,7 +18,7 @@ import { didRouter } from './routes/did.js'
 import { federationRouter } from './routes/federation.js'
 import { agentKeysRouter, revokedKeysRouter } from './routes/keys.js'
 import { orgsRouter } from './routes/orgs.js'
-import { buildAlertsWithNotificationState, observabilityRouter } from './routes/observability.js'
+import { buildAlerts, buildAlertsWithNotificationState, buildOverviewPayload, observabilityRouter } from './routes/observability.js'
 import { reportsRouter } from './routes/reports.js'
 import { shieldRouter } from './routes/shield.js'
 import { verificationRouter } from './routes/verify.js'
@@ -40,15 +40,18 @@ import {
   deleteDirectoryRole,
   getAgent,
   getDIDDocument,
+  getIntentLogByNonce,
   getOperatorNotificationBySourceKey,
   insertFunnelEvent,
   listAgentKeys,
   listAuditLog,
   listFunnelEvents,
+  listIntentTraceEvents,
   listDirectoryRoles,
   listOperatorNotifications,
   listOperatorNotificationsBySourceKeys,
   listRecentIntentLogs,
+  listShieldAuditLog,
   listTrustScores,
   logAuditEvent,
   updateOperatorNotificationStatus,
@@ -58,7 +61,7 @@ import {
 import { getFederationSharedSecret, getLocalDirectoryUrl, isPrivateDirectoryMode } from './federation.js'
 import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import { getReleaseInfo } from './release.js'
-import type { AgentRow, AuditLogRow, IntentFrame, OperatorNotificationRow } from './types.js'
+import type { AgentRow, AuditLogRow, IntentFrame, IntentTraceEventRow, OperatorNotificationRow } from './types.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
@@ -111,6 +114,7 @@ type BetaRequestUpdateInput = {
   lastContactAt?: string | null
   nextMeetingAt?: string | null
   reminderAt?: string | null
+  proofIntentNonce?: string | null
 }
 
 type BetaRequestFilters = {
@@ -150,6 +154,7 @@ type WaitlistRow = {
   agent_count: number | null
   workflow_type: string | null
   workflow_summary: string | null
+  proof_intent_nonce: string | null
   status: string
   owner: string | null
   operator_notes: string | null
@@ -172,6 +177,49 @@ type BetaRequestActivityEntry = {
   tone: BetaRequestActivityTone
   href: string | null
   upcoming: boolean
+}
+
+type BetaRequestProofSummaryParty = {
+  beamId: string
+  displayName: string
+  verificationTier: string
+  trustScore: number | null
+  verified: boolean
+}
+
+type BetaRequestProofSummary = {
+  generatedAt: string
+  proofIntentNonce: string
+  headline: string
+  summary: string
+  recommendation: string
+  markdown: string
+  identity: {
+    sender: BetaRequestProofSummaryParty
+    recipient: BetaRequestProofSummaryParty
+  }
+  delivery: {
+    intentType: string
+    status: string
+    requestedAt: string
+    completedAt: string | null
+    latencyMs: number | null
+    traceStageCount: number
+    stages: string[]
+    routeLabel: string | null
+    shieldDecision: string | null
+  }
+  operatorVisibility: {
+    signalStatus: OperatorNotificationStatus | 'missing'
+    signalOwner: string | null
+    nextAction: string | null
+    activityCount: number
+    liveAgents: number
+    activeAlerts: number
+    traceHref: string
+    signalHref: string | null
+    requestHref: string
+  }
 }
 
 const BETA_REQUEST_STATUSES: BetaRequestStatus[] = ['new', 'reviewing', 'contacted', 'scheduled', 'active', 'closed']
@@ -227,6 +275,15 @@ const BETA_REQUEST_STALE_HOURS: Record<BetaRequestStatus, number | null> = {
 
 function normalizeOptionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function normalizeOptionalNonce(value: unknown): string | null {
+  const normalized = normalizeOptionalString(value)
+  if (!normalized) {
+    return null
+  }
+
+  return /^[A-Za-z0-9:_-]{8,200}$/.test(normalized) ? normalized : null
 }
 
 function normalizeOptionalIsoDateTime(value: unknown): string | null {
@@ -543,6 +600,7 @@ function serializeBetaRequest(
     agentCount: row.agent_count,
     workflowType: row.workflow_type,
     workflowSummary: row.workflow_summary,
+    proofIntentNonce: row.proof_intent_nonce,
     requestStatus: attention.stage,
     stage: attention.stage,
     owner: row.owner,
@@ -566,13 +624,13 @@ function serializeBetaRequest(
   }
 }
 
-function parseAuditDetails(details: string | null | undefined): Record<string, unknown> | null {
-  if (!details) {
+function parseJsonRecord(value: string | null | undefined): Record<string, unknown> | null {
+  if (!value) {
     return null
   }
 
   try {
-    const parsed = JSON.parse(details)
+    const parsed = JSON.parse(value)
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>
     }
@@ -581,6 +639,10 @@ function parseAuditDetails(details: string | null | undefined): Record<string, u
   }
 
   return null
+}
+
+function parseAuditDetails(details: string | null | undefined): Record<string, unknown> | null {
+  return parseJsonRecord(details)
 }
 
 function formatBetaRequestStatusLabel(value: string | null | undefined): string {
@@ -619,6 +681,10 @@ function describeBetaRequestAuditEntry(log: AuditLogRow): BetaRequestActivityEnt
 
   if (details?.reminderChanged === true) {
     detailParts.push('Reminder timing updated.')
+  }
+
+  if (details?.proofIntentChanged === true) {
+    detailParts.push('Pilot proof trace updated.')
   }
 
   let kind: BetaRequestActivityKind = 'request_updated'
@@ -869,6 +935,209 @@ function buildBetaRequestActivityTimeline(
   })
 }
 
+function formatIntentLifecycleLabel(status: string): string {
+  return status
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatBuyerDeliveryOutcome(status: string): string {
+  switch (status) {
+    case 'acked':
+      return 'acknowledged'
+    case 'dead_letter':
+      return 'dead-lettered'
+    default:
+      return formatIntentLifecycleLabel(status).toLowerCase()
+  }
+}
+
+function formatProofParty(agent: AgentRow | null, fallbackBeamId: string): BetaRequestProofSummaryParty {
+  return {
+    beamId: fallbackBeamId,
+    displayName: agent?.display_name ?? fallbackBeamId,
+    verificationTier: agent?.verification_tier ?? 'unknown',
+    trustScore: typeof agent?.trust_score === 'number' ? Number(agent.trust_score.toFixed(2)) : null,
+    verified: agent ? agent.verified === 1 || agent.verification_tier !== 'basic' : false,
+  }
+}
+
+function formatProofPartyLabel(party: BetaRequestProofSummaryParty): string {
+  return party.displayName === party.beamId
+    ? party.beamId
+    : `${party.displayName} (${party.beamId})`
+}
+
+function formatTrustScoreLabel(value: number | null): string {
+  if (value == null) {
+    return 'n/a'
+  }
+
+  return `${Math.round(value * 100)}%`
+}
+
+function findTraceRouteLabel(trace: IntentTraceEventRow[]): string | null {
+  const details = trace
+    .map((entry) => parseJsonRecord(entry.details))
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry))
+    .reverse()
+
+  for (const detail of details) {
+    const route = typeof detail.route === 'string'
+      ? detail.route
+      : typeof detail.transport === 'string'
+        ? detail.transport
+        : typeof detail.deliveryMode === 'string'
+          ? detail.deliveryMode
+          : typeof detail.via === 'string'
+            ? detail.via
+            : typeof detail.channel === 'string'
+              ? detail.channel
+              : null
+    if (route) {
+      return route
+    }
+  }
+
+  return null
+}
+
+function getBetaRequestProofRecommendation(row: WaitlistRow): string {
+  if (row.next_action) {
+    return row.next_action
+  }
+
+  switch (normalizeBetaRequestStatus(row.status) ?? 'new') {
+    case 'reviewing':
+      return 'Confirm the operator owner and move this workflow into a scheduled design-partner review.'
+    case 'contacted':
+      return 'Book the buyer walkthrough and agree on the smallest production workflow to validate next.'
+    case 'scheduled':
+      return 'Use the pilot review to lock the first design-partner scope, success criteria, and next operator check-in.'
+    case 'active':
+      return 'Convert this pilot into a scoped design-partner rollout with named owners and a written success checkpoint.'
+    case 'closed':
+      return 'Reuse this proof summary only as historical evidence; open a fresh request if the workflow changed.'
+    default:
+      return 'Review the workflow, assign an owner, and agree on the first production-grade handoff to validate.'
+  }
+}
+
+function toDashboardUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `https://dashboard.beam.directory${normalizedPath}`
+}
+
+function buildBetaRequestProofMarkdown(summary: BetaRequestProofSummary): string {
+  return [
+    '# Beam pilot proof summary',
+    '',
+    `**Outcome:** ${summary.headline}`,
+    '',
+    summary.summary,
+    '',
+    '## Identity proof',
+    `- Sender: ${formatProofPartyLabel(summary.identity.sender)} · ${summary.identity.sender.verificationTier} · trust ${formatTrustScoreLabel(summary.identity.sender.trustScore)}`,
+    `- Recipient: ${formatProofPartyLabel(summary.identity.recipient)} · ${summary.identity.recipient.verificationTier} · trust ${formatTrustScoreLabel(summary.identity.recipient.trustScore)}`,
+    '',
+    '## Delivery proof',
+    `- Nonce: ${summary.proofIntentNonce}`,
+    `- Intent: ${summary.delivery.intentType}`,
+    `- Final status: ${formatIntentLifecycleLabel(summary.delivery.status)}`,
+    `- Requested at: ${summary.delivery.requestedAt}`,
+    `- Completed at: ${summary.delivery.completedAt ?? 'in flight'}`,
+    `- Latency: ${summary.delivery.latencyMs == null ? 'n/a' : `${summary.delivery.latencyMs}ms`}`,
+    `- Trace stages: ${summary.delivery.stages.join(' -> ')}`,
+    `- Route: ${summary.delivery.routeLabel ?? 'not recorded'}`,
+    `- Shield decision: ${summary.delivery.shieldDecision ?? 'not recorded'}`,
+    '',
+    '## Operator visibility',
+    `- Signal status: ${summary.operatorVisibility.signalStatus}`,
+    `- Signal owner: ${summary.operatorVisibility.signalOwner ?? 'unassigned'}`,
+    `- Next action: ${summary.operatorVisibility.nextAction ?? 'not recorded'}`,
+    `- Activity entries: ${summary.operatorVisibility.activityCount}`,
+    `- Live agents (24h): ${summary.operatorVisibility.liveAgents}`,
+    `- Active alerts (24h): ${summary.operatorVisibility.activeAlerts}`,
+    `- Trace: ${toDashboardUrl(summary.operatorVisibility.traceHref)}`,
+    `- Operator signal: ${summary.operatorVisibility.signalHref ? toDashboardUrl(summary.operatorVisibility.signalHref) : 'not linked yet'}`,
+    `- Request record: ${toDashboardUrl(summary.operatorVisibility.requestHref)}`,
+    '',
+    '## Recommended next step',
+    summary.recommendation,
+  ].join('\n')
+}
+
+function buildBetaRequestProofSummary(
+  db: Database,
+  row: WaitlistRow,
+  notification: OperatorNotificationRow | null | undefined,
+  activity: BetaRequestActivityEntry[],
+): BetaRequestProofSummary | null {
+  if (!row.proof_intent_nonce) {
+    return null
+  }
+
+  const intentLog = getIntentLogByNonce(db, row.proof_intent_nonce)
+  if (!intentLog) {
+    return null
+  }
+
+  const trace = listIntentTraceEvents(db, row.proof_intent_nonce)
+  const sender = formatProofParty(getAgent(db, intentLog.from_beam_id), intentLog.from_beam_id)
+  const recipient = formatProofParty(getAgent(db, intentLog.to_beam_id), intentLog.to_beam_id)
+  const overview = buildOverviewPayload(db, 24)
+  const alerts = buildAlerts(db, 24)
+  const shieldDecision = listShieldAuditLog(db, { nonce: row.proof_intent_nonce, limit: 1 })[0]?.decision ?? null
+  const stages = Array.from(new Set(trace.map((entry) => entry.stage)))
+  const routeLabel = findTraceRouteLabel(trace)
+  const requestHref = `/beta-requests?id=${row.id}`
+  const signalHref = notification?.id ? `/inbox?id=${notification.id}` : null
+  const traceHref = `/intents/${encodeURIComponent(row.proof_intent_nonce)}`
+  const latencyText = intentLog.round_trip_latency_ms == null ? 'without a recorded round-trip latency' : `in ${intentLog.round_trip_latency_ms}ms`
+  const routeText = routeLabel ? ` over ${routeLabel}` : ''
+  const shieldText = shieldDecision ? ` Beam shield recorded a ${shieldDecision} decision for the same nonce.` : ''
+  const headline = `Beam verified a pilot handoff from ${sender.displayName} to ${recipient.displayName} that was ${formatBuyerDeliveryOutcome(intentLog.status)}.`
+  const summary = `${formatProofPartyLabel(sender)} (${sender.verificationTier}, trust ${formatTrustScoreLabel(sender.trustScore)}) sent ${intentLog.intent_type} to ${formatProofPartyLabel(recipient)} (${recipient.verificationTier}, trust ${formatTrustScoreLabel(recipient.trustScore)}). Beam recorded ${Math.max(stages.length, 1)} lifecycle stage${Math.max(stages.length, 1) === 1 ? '' : 's'} and finished ${formatBuyerDeliveryOutcome(intentLog.status)} ${latencyText}${routeText}.${shieldText} Operators can open the exact trace${signalHref ? ' and linked signal' : ''} in the dashboard; ${overview.summary.liveAgents} agent(s) were live in the last 24 hours and ${alerts.length} active alert(s) were visible during the same window.`
+  const result: BetaRequestProofSummary = {
+    generatedAt: new Date().toISOString(),
+    proofIntentNonce: row.proof_intent_nonce,
+    headline,
+    summary,
+    recommendation: getBetaRequestProofRecommendation(row),
+    markdown: '',
+    identity: {
+      sender,
+      recipient,
+    },
+    delivery: {
+      intentType: intentLog.intent_type,
+      status: intentLog.status,
+      requestedAt: intentLog.requested_at,
+      completedAt: intentLog.completed_at,
+      latencyMs: intentLog.round_trip_latency_ms,
+      traceStageCount: Math.max(stages.length, 1),
+      stages: stages.length > 0 ? stages : [intentLog.status],
+      routeLabel,
+      shieldDecision,
+    },
+    operatorVisibility: {
+      signalStatus: notification?.status ?? 'missing',
+      signalOwner: notification?.owner ?? row.owner ?? null,
+      nextAction: notification?.next_action ?? row.next_action ?? null,
+      activityCount: activity.length,
+      liveAgents: overview.summary.liveAgents,
+      activeAlerts: alerts.length,
+      traceHref,
+      signalHref,
+      requestHref,
+    },
+  }
+  result.markdown = buildBetaRequestProofMarkdown(result)
+  return result
+}
+
 function getBetaRequestNextStep(status: string): string {
   switch (status) {
     case 'reviewing':
@@ -1052,6 +1321,7 @@ function listBetaRequestRows(db: Database, filters: {
       agent_count,
       workflow_type,
       workflow_summary,
+      proof_intent_nonce,
       status,
       owner,
       operator_notes,
@@ -1090,6 +1360,7 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
       agent_count,
       workflow_type,
       workflow_summary,
+      proof_intent_nonce,
       status,
       owner,
       operator_notes,
@@ -1208,6 +1479,7 @@ function buildBetaRequestCsv(
     'source',
     'workflow_type',
     'workflow_summary',
+    'proof_intent_nonce',
     'agent_count',
     'status',
     'owner',
@@ -1237,6 +1509,7 @@ function buildBetaRequestCsv(
       row.source,
       row.workflow_type,
       row.workflow_summary,
+      row.proof_intent_nonce,
       row.agent_count,
       row.status,
       row.owner,
@@ -2274,10 +2547,12 @@ export function createApp(db: Database): Hono {
         return c.json({ error: 'Beta request not found', errorCode: 'NOT_FOUND' }, 404)
       }
       const notification = getOperatorNotificationBySourceKey(db, betaRequestNotificationSourceKey(row.id))
+      const activity = buildBetaRequestActivityTimeline(db, row, notification)
       c.header('Cache-Control', 'no-store')
       return c.json({
         request: serializeBetaRequest(row, notification),
-        activity: buildBetaRequestActivityTimeline(db, row, notification),
+        activity,
+        proofSummary: buildBetaRequestProofSummary(db, row, notification, activity),
       })
     } catch (err) {
       console.error('Admin beta request detail error:', err)
@@ -2354,6 +2629,14 @@ export function createApp(db: Database): Hono {
       patch.reminderAt = reminderAt
     }
 
+    if ('proofIntentNonce' in raw) {
+      const proofIntentNonce = normalizeOptionalNonce(raw.proofIntentNonce)
+      if (raw.proofIntentNonce != null && raw.proofIntentNonce !== '' && !proofIntentNonce) {
+        return c.json({ error: 'Invalid proofIntentNonce', errorCode: 'INVALID_PROOF_INTENT_NONCE' }, 400)
+      }
+      patch.proofIntentNonce = proofIntentNonce
+    }
+
     if (
       !('status' in patch)
       && !('owner' in patch)
@@ -2362,6 +2645,7 @@ export function createApp(db: Database): Hono {
       && !('lastContactAt' in patch)
       && !('nextMeetingAt' in patch)
       && !('reminderAt' in patch)
+      && !('proofIntentNonce' in patch)
     ) {
       return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
     }
@@ -2379,10 +2663,15 @@ export function createApp(db: Database): Hono {
       let nextLastContactAt = 'lastContactAt' in patch ? patch.lastContactAt ?? null : existing.last_contact_at
       const nextMeetingAt = 'nextMeetingAt' in patch ? patch.nextMeetingAt ?? null : existing.next_meeting_at
       const nextReminderAt = 'reminderAt' in patch ? patch.reminderAt ?? null : existing.reminder_at
+      const nextProofIntentNonce = 'proofIntentNonce' in patch ? patch.proofIntentNonce ?? null : existing.proof_intent_nonce
       const updatedAt = new Date().toISOString()
       const nextStageEnteredAt = 'status' in patch && patch.status && patch.status !== existing.status
         ? updatedAt
         : (existing.stage_entered_at ?? existing.updated_at ?? existing.created_at)
+
+      if (nextProofIntentNonce && !getIntentLogByNonce(db, nextProofIntentNonce)) {
+        return c.json({ error: 'Linked proof intent was not found', errorCode: 'PROOF_INTENT_NOT_FOUND' }, 404)
+      }
 
       if (!('lastContactAt' in patch) && ['contacted', 'scheduled', 'active'].includes(nextStatus) && !nextLastContactAt) {
         nextLastContactAt = updatedAt
@@ -2390,9 +2679,9 @@ export function createApp(db: Database): Hono {
 
       db.prepare(`
         UPDATE waitlist
-        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, next_meeting_at = ?, reminder_at = ?, stage_entered_at = ?, updated_at = ?
+        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, next_meeting_at = ?, reminder_at = ?, proof_intent_nonce = ?, stage_entered_at = ?, updated_at = ?
         WHERE id = ?
-      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, nextMeetingAt, nextReminderAt, nextStageEnteredAt, updatedAt, id)
+      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, nextMeetingAt, nextReminderAt, nextProofIntentNonce, nextStageEnteredAt, updatedAt, id)
 
       const updated = getBetaRequestById(db, id)
       if (!updated) {
@@ -2416,6 +2705,8 @@ export function createApp(db: Database): Hono {
           lastContactChanged: 'lastContactAt' in patch,
           nextMeetingChanged: 'nextMeetingAt' in patch,
           reminderChanged: 'reminderAt' in patch,
+          proofIntentChanged: 'proofIntentNonce' in patch,
+          proofIntentNonce: nextProofIntentNonce,
         },
       })
 


### PR DESCRIPTION
Closes #77

## Summary
- link hosted beta requests to a proof trace nonce and generate a buyer-facing proof summary from live evidence
- expose the proof summary in the admin beta-request detail response and surface it in the dashboard with copyable markdown
- cover the new flow with public-surface tests and document the admin API additions

## Verification
- npm test --workspace=packages/directory
- npm run build --workspace=packages/dashboard
- npm run build
- cd docs && npm run build
- npm test