### PR TITLE
Add partner-stage analytics to funnel review

### DIFF
--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -334,6 +334,8 @@ Request events use the same path, but require a compatible `workflowType`. Demo 
 `GET /admin/funnel` returns:
 
 - milestone progression across landing, guided evaluation, hosted beta, request, and demo proof
+- partner motion metrics across hosted beta request, qualified, scheduled, pilot-complete, and next-step readiness
+- stage aging, overdue follow-up counts, and a current stall list for weekly operator review
 - entry pages
 - CTA click summaries
 - request workflow breakdown

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -784,6 +784,56 @@ export interface FunnelRecentEvent {
   createdAt: string
 }
 
+export interface PartnerMotionStage {
+  stage: BetaRequestStatus
+  count: number
+  averageAgeHours: number | null
+  oldestAgeHours: number | null
+  stale: number
+  followUpDue: number
+  unowned: number
+  proofLinked: number
+}
+
+export interface PartnerMotionStall {
+  id: number
+  company: string | null
+  email: string
+  workflowType: string | null
+  stage: BetaRequestStatus
+  owner: string | null
+  stageAgeHours: number
+  stageAgeLabel: string
+  followUpDue: boolean
+  stale: boolean
+  attentionFlags: BetaRequestAttention[]
+  followUpReason: string | null
+  staleReason: string | null
+  nextAction: string | null
+  lastContactAt: string | null
+  nextMeetingAt: string | null
+  reminderAt: string | null
+  proofIntentNonce: string | null
+}
+
+export interface PartnerMotionWeeklyPoint {
+  weekStart: string
+  requests: number
+  qualified: number
+  scheduled: number
+  pilotComplete: number
+  nextStepReady: number
+}
+
+export interface PartnerMotionWorkflow {
+  workflowType: string
+  requests: number
+  qualified: number
+  scheduled: number
+  pilotComplete: number
+  overdue: number
+}
+
 export interface FunnelAnalyticsResponse {
   days: number
   generatedAt: string
@@ -817,6 +867,26 @@ export interface FunnelAnalyticsResponse {
   }>
   timeline: FunnelTimelinePoint[]
   recentEvents: FunnelRecentEvent[]
+  partnerMotion: {
+    summary: {
+      requests: number
+      qualified: number
+      scheduled: number
+      pilotComplete: number
+      nextStepReady: number
+      overdueFollowUps: number
+      stalledRequests: number
+      unowned: number
+      qualificationRate: number | null
+      schedulingRate: number | null
+      pilotCompleteRate: number | null
+      nextStepRate: number | null
+    }
+    byStage: PartnerMotionStage[]
+    stalled: PartnerMotionStall[]
+    weekly: PartnerMotionWeeklyPoint[]
+    workflows: PartnerMotionWorkflow[]
+  }
 }
 
 export interface IntentFeedMessage {

--- a/packages/dashboard/src/pages/FunnelPage.tsx
+++ b/packages/dashboard/src/pages/FunnelPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { ApiError, directoryApi, type FunnelAnalyticsResponse } from '../lib/api'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
-import { formatDateTime, formatNumber, formatPercent } from '../lib/utils'
+import { formatDateTime, formatNumber, formatPercent, formatRelativeTime } from '../lib/utils'
 
 const WINDOW_OPTIONS = [7, 14, 30, 90]
 
@@ -32,7 +33,7 @@ export default function FunnelPage() {
     <div className="space-y-6">
       <PageHeader
         title="Funnel"
-        description="First-party buyer funnel analytics for the public landing, hosted-beta intake, and demo milestones."
+        description="First-party buyer funnel analytics plus operator-side design-partner motion, stalls, and overdue follow-up."
         actions={(
           <select className="input-field w-auto min-w-28" value={days} onChange={(event) => setDays(Number(event.target.value))}>
             {WINDOW_OPTIONS.map((option) => (
@@ -74,6 +75,183 @@ export default function FunnelPage() {
         <MetricCard label="Landing → guided eval" value={formatPercent(data?.summary.landingToGuidedRate ?? null, 0)} hint="Unique-session conversion from landing view to guided evaluation." />
         <MetricCard label="Landing → request" value={formatPercent(data?.summary.landingToRequestRate ?? null, 0)} hint="Unique-session conversion from landing view to hosted-beta request." />
         <MetricCard label="Request → demo proof" value={formatPercent(data?.summary.requestToDemoRate ?? null, 0)} hint="How many request sessions also reached a demo milestone in the same window." />
+      </section>
+
+      <section className="space-y-4">
+        <div className="panel">
+          <div className="panel-title">Design partner motion</div>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            This is the operator-side weekly read: how many hosted beta requests qualify, get scheduled, complete a pilot, and still have a named next step.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-8">
+          <MetricCard label="Requests" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.requests ?? 0)} />
+          <MetricCard label="Qualified" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.qualified ?? 0)} tone={(data?.partnerMotion.summary.qualified ?? 0) > 0 ? 'success' : 'default'} />
+          <MetricCard label="Scheduled" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.scheduled ?? 0)} tone={(data?.partnerMotion.summary.scheduled ?? 0) > 0 ? 'success' : 'default'} />
+          <MetricCard label="Pilot complete" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.pilotComplete ?? 0)} tone={(data?.partnerMotion.summary.pilotComplete ?? 0) > 0 ? 'success' : 'default'} />
+          <MetricCard label="Next step ready" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.nextStepReady ?? 0)} tone={(data?.partnerMotion.summary.nextStepReady ?? 0) > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Overdue follow-up" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.overdueFollowUps ?? 0)} tone={(data?.partnerMotion.summary.overdueFollowUps ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Stalled" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.stalledRequests ?? 0)} tone={(data?.partnerMotion.summary.stalledRequests ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Unowned" value={loading ? '—' : formatNumber(data?.partnerMotion.summary.unowned ?? 0)} tone={(data?.partnerMotion.summary.unowned ?? 0) > 0 ? 'critical' : 'default'} />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-4">
+          <MetricCard label="Qualify rate" value={formatPercent(data?.partnerMotion.summary.qualificationRate ?? null, 0)} hint="Requests in the current window that moved beyond the raw intake stage." />
+          <MetricCard label="Schedule rate" value={formatPercent(data?.partnerMotion.summary.schedulingRate ?? null, 0)} hint="Requests with a scheduled working session or a later stage." />
+          <MetricCard label="Pilot-complete rate" value={formatPercent(data?.partnerMotion.summary.pilotCompleteRate ?? null, 0)} hint="Requests that closed or already have a linked proof trace." />
+          <MetricCard label="Next-step rate" value={formatPercent(data?.partnerMotion.summary.nextStepRate ?? null, 0)} hint="Requests with a concrete next action, meeting, or reminder." />
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1.05fr,0.95fr]">
+        <div className="panel overflow-hidden p-0">
+          <div className="border-b border-slate-200 px-5 py-4 dark:border-slate-800">
+            <div className="panel-title">Stage aging</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Where requests accumulate time, overdue follow-up, or unowned work.</p>
+          </div>
+          {loading ? (
+            <div className="p-5">
+              <EmptyPanel label="Loading design-partner stage metrics…" />
+            </div>
+          ) : !data || data.partnerMotion.byStage.length === 0 ? (
+            <div className="p-5">
+              <EmptyPanel label="No hosted beta requests were created in the selected window." />
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm">
+                <thead className="bg-slate-50 dark:bg-slate-950">
+                  <tr>
+                    <th className="table-head">Stage</th>
+                    <th className="table-head">Count</th>
+                    <th className="table-head">Avg age</th>
+                    <th className="table-head">Oldest</th>
+                    <th className="table-head">Overdue</th>
+                    <th className="table-head">Stale</th>
+                    <th className="table-head">Unowned</th>
+                    <th className="table-head">Proof linked</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.partnerMotion.byStage.map((entry) => (
+                    <tr key={entry.stage} className="border-t border-slate-200 dark:border-slate-800">
+                      <td className="table-cell">{formatPartnerStage(entry.stage)}</td>
+                      <td className="table-cell">{formatNumber(entry.count)}</td>
+                      <td className="table-cell">{entry.averageAgeHours == null ? '—' : `${entry.averageAgeHours}h`}</td>
+                      <td className="table-cell">{entry.oldestAgeHours == null ? '—' : `${entry.oldestAgeHours}h`}</td>
+                      <td className="table-cell">{formatNumber(entry.followUpDue)}</td>
+                      <td className="table-cell">{formatNumber(entry.stale)}</td>
+                      <td className="table-cell">{formatNumber(entry.unowned)}</td>
+                      <td className="table-cell">{formatNumber(entry.proofLinked)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Current stalls</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading stalled requests…" />
+            ) : !data || data.partnerMotion.stalled.length === 0 ? (
+              <EmptyPanel label="No stalled or overdue requests were detected in the selected window." />
+            ) : (
+              data.partnerMotion.stalled.map((entry) => (
+                <div key={entry.id} className="rounded-xl border border-slate-200 px-4 py-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{entry.company ?? entry.email}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{entry.email}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <StatusPill label={entry.stage} tone={entry.followUpDue || entry.stale ? 'warning' : 'default'} />
+                      {entry.attentionFlags.map((flag) => (
+                        <StatusPill key={`${entry.id}-${flag}`} label={formatAttention(flag)} tone={flag === 'unowned' ? 'critical' : 'warning'} />
+                      ))}
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
+                    <span>Owner: {entry.owner ?? 'unassigned'}</span>
+                    <span>Stage age: {entry.stageAgeLabel}</span>
+                    <span>Last contact: {entry.lastContactAt ? formatRelativeTime(entry.lastContactAt) : 'not recorded'}</span>
+                    <span>Next meeting: {entry.nextMeetingAt ? formatRelativeTime(entry.nextMeetingAt) : 'not scheduled'}</span>
+                  </div>
+                  <div className="mt-3 rounded-xl bg-slate-50 px-3 py-3 text-sm text-slate-600 dark:bg-slate-950 dark:text-slate-300">
+                    {entry.followUpReason ?? entry.staleReason ?? entry.nextAction ?? 'No next action is recorded yet.'}
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-3">
+                    <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/beta-requests?id=${entry.id}`}>
+                      Open request
+                    </Link>
+                    {entry.proofIntentNonce ? (
+                      <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/intents/${encodeURIComponent(entry.proofIntentNonce)}`}>
+                        Open proof trace
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[1fr,1fr]">
+        <div className="panel">
+          <div className="panel-title">Weekly partner motion</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading weekly partner motion…" />
+            ) : !data || data.partnerMotion.weekly.length === 0 ? (
+              <EmptyPanel label="No hosted beta requests were created in the selected window." />
+            ) : (
+              data.partnerMotion.weekly.map((entry) => (
+                <div key={entry.weekStart} className="rounded-xl border border-slate-200 px-4 py-4 text-sm dark:border-slate-800">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">Week of {entry.weekStart}</div>
+                    <div className="text-slate-500 dark:text-slate-400">{formatNumber(entry.requests)} requests</div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
+                    <span>Qualified: {formatNumber(entry.qualified)}</span>
+                    <span>Scheduled: {formatNumber(entry.scheduled)}</span>
+                    <span>Pilot complete: {formatNumber(entry.pilotComplete)}</span>
+                    <span>Next step ready: {formatNumber(entry.nextStepReady)}</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="panel-title">Workflow stall breakdown</div>
+          <div className="mt-4 space-y-3">
+            {loading ? (
+              <EmptyPanel label="Loading workflow breakdown…" />
+            ) : !data || data.partnerMotion.workflows.length === 0 ? (
+              <EmptyPanel label="No hosted beta workflow data was recorded." />
+            ) : (
+              data.partnerMotion.workflows.map((entry) => (
+                <div key={entry.workflowType} className="rounded-xl border border-slate-200 px-4 py-4 text-sm dark:border-slate-800">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">{entry.workflowType}</div>
+                    <StatusPill label={`${entry.overdue} overdue`} tone={entry.overdue > 0 ? 'warning' : 'default'} />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 sm:grid-cols-2">
+                    <span>Requests: {formatNumber(entry.requests)}</span>
+                    <span>Qualified: {formatNumber(entry.qualified)}</span>
+                    <span>Scheduled: {formatNumber(entry.scheduled)}</span>
+                    <span>Pilot complete: {formatNumber(entry.pilotComplete)}</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
@@ -249,4 +427,25 @@ export default function FunnelPage() {
       </section>
     </div>
   )
+}
+
+function formatPartnerStage(stage: string): string {
+  return stage
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatAttention(flag: string): string {
+  switch (flag) {
+    case 'follow_up_due':
+      return 'follow-up due'
+    case 'unowned':
+      return 'unowned'
+    case 'stale':
+      return 'stale'
+    default:
+      return flag
+  }
 }

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -183,6 +183,200 @@ test('first-party funnel analytics ingest and summary stay available through the
   }
 })
 
+test('partner-stage analytics and overdue follow-up reporting stay available through the funnel API', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const app = createApp(db)
+
+    const createdIds: number[] = []
+    for (const input of [
+      {
+        email: 'new@example.com',
+        company: 'Fresh Intake',
+        workflowSummary: 'New design-partner request.',
+      },
+      {
+        email: 'reviewing@example.com',
+        company: 'Qualified Buyer',
+        workflowSummary: 'Operator is qualifying the workflow.',
+      },
+      {
+        email: 'scheduled@example.com',
+        company: 'Scheduled Pilot',
+        workflowSummary: 'The pilot review is already booked.',
+      },
+      {
+        email: 'closed@example.com',
+        company: 'Completed Pilot',
+        workflowSummary: 'The pilot finished and needs a clear rollout step.',
+      },
+    ]) {
+      const response = await app.request(new Request('http://localhost/waitlist', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          Origin: 'https://beam.directory',
+        },
+        body: JSON.stringify({
+          ...input,
+          source: 'hosted-beta-page',
+          workflowType: 'hosted-beta-partner-handoff',
+          agentCount: 4,
+        }),
+      }))
+      assert.equal(response.status, 201)
+      const body = await response.json() as { request: { id: number } }
+      createdIds.push(body.request.id)
+    }
+
+    const [newId, reviewingId, scheduledId, closedId] = createdIds
+
+    const reviewingResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${reviewingId}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'reviewing',
+        owner: 'ops@example.com',
+        nextAction: 'Qualify the workflow and confirm the pilot scope.',
+      }),
+    }))
+    assert.equal(reviewingResponse.status, 200)
+
+    const scheduledResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${scheduledId}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'scheduled',
+        owner: 'ops@example.com',
+        nextAction: 'Run the pilot review and confirm the next deployment step.',
+        nextMeetingAt: '2026-04-03T09:00:00.000Z',
+        reminderAt: '2026-03-30T09:00:00.000Z',
+      }),
+    }))
+    assert.equal(scheduledResponse.status, 200)
+
+    const closedResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${closedId}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'closed',
+        owner: 'ops@example.com',
+        nextAction: 'Move the completed pilot into a scoped rollout plan.',
+      }),
+    }))
+    assert.equal(closedResponse.status, 200)
+
+    db.prepare(`
+      UPDATE waitlist
+      SET stage_entered_at = ?, updated_at = ?
+      WHERE id = ?
+    `).run('2026-03-26T09:00:00.000Z', '2026-03-26T09:00:00.000Z', newId)
+
+    const analyticsResponse = await app.request(new Request('http://localhost/admin/funnel?days=30', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(analyticsResponse.status, 200)
+
+    const analytics = await analyticsResponse.json() as {
+      partnerMotion: {
+        summary: {
+          requests: number
+          qualified: number
+          scheduled: number
+          pilotComplete: number
+          nextStepReady: number
+          overdueFollowUps: number
+          stalledRequests: number
+          unowned: number
+        }
+        byStage: Array<{
+          stage: string
+          count: number
+          stale: number
+          followUpDue: number
+          unowned: number
+        }>
+        stalled: Array<{
+          id: number
+          stage: string
+          attentionFlags: string[]
+          followUpReason: string | null
+          staleReason: string | null
+        }>
+        weekly: Array<{
+          weekStart: string
+          requests: number
+          qualified: number
+          scheduled: number
+          pilotComplete: number
+          nextStepReady: number
+        }>
+        workflows: Array<{
+          workflowType: string
+          requests: number
+          qualified: number
+          scheduled: number
+          pilotComplete: number
+          overdue: number
+        }>
+      }
+    }
+
+    assert.equal(analytics.partnerMotion.summary.requests, 4)
+    assert.equal(analytics.partnerMotion.summary.qualified, 3)
+    assert.equal(analytics.partnerMotion.summary.scheduled, 2)
+    assert.equal(analytics.partnerMotion.summary.pilotComplete, 1)
+    assert.equal(analytics.partnerMotion.summary.nextStepReady, 3)
+    assert.equal(analytics.partnerMotion.summary.overdueFollowUps, 1)
+    assert.equal(analytics.partnerMotion.summary.stalledRequests, 2)
+    assert.equal(analytics.partnerMotion.summary.unowned, 1)
+
+    const newStage = analytics.partnerMotion.byStage.find((entry) => entry.stage === 'new')
+    assert.equal(newStage?.count, 1)
+    assert.equal(newStage?.stale, 1)
+    assert.equal(newStage?.unowned, 1)
+
+    const scheduledStage = analytics.partnerMotion.byStage.find((entry) => entry.stage === 'scheduled')
+    assert.equal(scheduledStage?.count, 1)
+    assert.equal(scheduledStage?.followUpDue, 1)
+
+    assert.equal(analytics.partnerMotion.stalled.length, 2)
+    assert.equal(analytics.partnerMotion.stalled[0]?.id, scheduledId)
+    assert.ok(analytics.partnerMotion.stalled[0]?.attentionFlags.includes('follow_up_due'))
+    assert.match(analytics.partnerMotion.stalled[0]?.followUpReason ?? '', /reminder/i)
+    assert.equal(analytics.partnerMotion.stalled[1]?.id, newId)
+    assert.ok(analytics.partnerMotion.stalled[1]?.attentionFlags.includes('stale'))
+    assert.match(analytics.partnerMotion.stalled[1]?.staleReason ?? '', /24\+ hours/i)
+
+    assert.ok(analytics.partnerMotion.weekly.length >= 1)
+    assert.equal(analytics.partnerMotion.weekly[0]?.requests, 4)
+    assert.equal(analytics.partnerMotion.weekly[0]?.qualified, 3)
+    assert.equal(analytics.partnerMotion.weekly[0]?.scheduled, 2)
+    assert.equal(analytics.partnerMotion.weekly[0]?.pilotComplete, 1)
+    assert.equal(analytics.partnerMotion.weekly[0]?.nextStepReady, 3)
+
+    assert.equal(analytics.partnerMotion.workflows[0]?.workflowType, 'hosted-beta-partner-handoff')
+    assert.equal(analytics.partnerMotion.workflows[0]?.requests, 4)
+    assert.equal(analytics.partnerMotion.workflows[0]?.qualified, 3)
+    assert.equal(analytics.partnerMotion.workflows[0]?.scheduled, 2)
+    assert.equal(analytics.partnerMotion.workflows[0]?.pilotComplete, 1)
+    assert.equal(analytics.partnerMotion.workflows[0]?.overdue, 1)
+  } finally {
+    db.close()
+  }
+})
+
 test('waitlist signups are idempotent by email and preserve the original created timestamp', async () => {
   const db = createDatabase(':memory:')
 

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -1379,6 +1379,33 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
   return row ?? null
 }
 
+function listPartnerAnalyticsRows(db: Database, sinceIso: string): WaitlistRow[] {
+  return db.prepare(`
+    SELECT
+      id,
+      email,
+      source,
+      company,
+      agent_count,
+      workflow_type,
+      workflow_summary,
+      proof_intent_nonce,
+      status,
+      owner,
+      operator_notes,
+      next_action,
+      last_contact_at,
+      next_meeting_at,
+      reminder_at,
+      stage_entered_at,
+      created_at,
+      updated_at
+    FROM waitlist
+    WHERE created_at >= ?
+    ORDER BY created_at DESC, id DESC
+  `).all(sinceIso) as WaitlistRow[]
+}
+
 function compareStageOrder(left: BetaRequestStatus, right: BetaRequestStatus): number {
   return BETA_REQUEST_STATUSES.indexOf(left) - BETA_REQUEST_STATUSES.indexOf(right)
 }
@@ -1859,6 +1886,190 @@ function summarizeFunnel(rows: Array<{
     workflows: requestsByWorkflow,
     timeline,
     recentEvents: rows.slice(0, 40).map((row) => serializeFunnelEvent(row)),
+  }
+}
+
+function toWeekStart(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    return isoTimestamp.slice(0, 10)
+  }
+
+  const day = (date.getUTCDay() + 6) % 7
+  date.setUTCDate(date.getUTCDate() - day)
+  date.setUTCHours(0, 0, 0, 0)
+  return date.toISOString().slice(0, 10)
+}
+
+function summarizePartnerMotion(rows: WaitlistRow[]) {
+  const byStage = new Map(BETA_REQUEST_STATUSES.map((stage) => [stage, {
+    stage,
+    count: 0,
+    averageAgeHours: null as number | null,
+    oldestAgeHours: null as number | null,
+    stale: 0,
+    followUpDue: 0,
+    unowned: 0,
+    proofLinked: 0,
+  }]))
+  const weekly = new Map<string, {
+    weekStart: string
+    requests: number
+    qualified: number
+    scheduled: number
+    pilotComplete: number
+    nextStepReady: number
+  }>()
+  const workflows = new Map<string, {
+    workflowType: string
+    requests: number
+    qualified: number
+    scheduled: number
+    pilotComplete: number
+    overdue: number
+  }>()
+
+  let qualified = 0
+  let scheduled = 0
+  let pilotComplete = 0
+  let nextStepReady = 0
+  let overdueFollowUps = 0
+  let stalledRequests = 0
+  let unowned = 0
+
+  const stalled = rows
+    .map((row) => {
+      const attention = getBetaRequestAttention(row)
+      const stage = attention.stage
+      const isQualified = stage !== 'new'
+      const isScheduled = ['scheduled', 'active', 'closed'].includes(stage) || Boolean(row.next_meeting_at)
+      const isPilotComplete = Boolean(row.proof_intent_nonce) || stage === 'closed'
+      const hasNextStep = Boolean(row.next_action || row.next_meeting_at || row.reminder_at)
+      const isStalled = attention.stale || attention.followUpDue
+      const workflowType = row.workflow_type ?? 'unknown'
+      const stageBucket = byStage.get(stage)
+
+      if (isQualified) {
+        qualified += 1
+      }
+      if (isScheduled) {
+        scheduled += 1
+      }
+      if (isPilotComplete) {
+        pilotComplete += 1
+      }
+      if (hasNextStep) {
+        nextStepReady += 1
+      }
+      if (attention.followUpDue) {
+        overdueFollowUps += 1
+      }
+      if (attention.attentionFlags.includes('unowned')) {
+        unowned += 1
+      }
+      if (isStalled) {
+        stalledRequests += 1
+      }
+
+      if (stageBucket) {
+        stageBucket.count += 1
+        stageBucket.averageAgeHours = (stageBucket.averageAgeHours ?? 0) + attention.stageAgeHours
+        stageBucket.oldestAgeHours = Math.max(stageBucket.oldestAgeHours ?? 0, attention.stageAgeHours)
+        stageBucket.stale += Number(attention.stale)
+        stageBucket.followUpDue += Number(attention.followUpDue)
+        stageBucket.unowned += Number(attention.attentionFlags.includes('unowned'))
+        stageBucket.proofLinked += Number(Boolean(row.proof_intent_nonce))
+      }
+
+      const weekStart = toWeekStart(row.created_at)
+      const weeklyEntry = weekly.get(weekStart) ?? {
+        weekStart,
+        requests: 0,
+        qualified: 0,
+        scheduled: 0,
+        pilotComplete: 0,
+        nextStepReady: 0,
+      }
+      weeklyEntry.requests += 1
+      weeklyEntry.qualified += Number(isQualified)
+      weeklyEntry.scheduled += Number(isScheduled)
+      weeklyEntry.pilotComplete += Number(isPilotComplete)
+      weeklyEntry.nextStepReady += Number(hasNextStep)
+      weekly.set(weekStart, weeklyEntry)
+
+      const workflowEntry = workflows.get(workflowType) ?? {
+        workflowType,
+        requests: 0,
+        qualified: 0,
+        scheduled: 0,
+        pilotComplete: 0,
+        overdue: 0,
+      }
+      workflowEntry.requests += 1
+      workflowEntry.qualified += Number(isQualified)
+      workflowEntry.scheduled += Number(isScheduled)
+      workflowEntry.pilotComplete += Number(isPilotComplete)
+      workflowEntry.overdue += Number(attention.followUpDue)
+      workflows.set(workflowType, workflowEntry)
+
+      return {
+        id: row.id,
+        company: row.company,
+        email: row.email,
+        workflowType: row.workflow_type,
+        stage,
+        owner: row.owner,
+        stageAgeHours: Number(attention.stageAgeHours.toFixed(1)),
+        stageAgeLabel: attention.stageAgeLabel,
+        followUpDue: attention.followUpDue,
+        stale: attention.stale,
+        attentionFlags: attention.attentionFlags,
+        followUpReason: attention.followUpReason,
+        staleReason: attention.staleReason,
+        nextAction: row.next_action ?? getBetaRequestNextStep(stage),
+        lastContactAt: row.last_contact_at,
+        nextMeetingAt: row.next_meeting_at,
+        reminderAt: row.reminder_at,
+        proofIntentNonce: row.proof_intent_nonce,
+      }
+    })
+    .filter((row) => row.stale || row.followUpDue)
+    .sort((left, right) => {
+      const rightScore = Number(right.followUpDue) * 10000 + Number(right.stale) * 1000 + right.stageAgeHours
+      const leftScore = Number(left.followUpDue) * 10000 + Number(left.stale) * 1000 + left.stageAgeHours
+      return rightScore - leftScore
+    })
+    .slice(0, 12)
+
+  return {
+    summary: {
+      requests: rows.length,
+      qualified,
+      scheduled,
+      pilotComplete,
+      nextStepReady,
+      overdueFollowUps,
+      stalledRequests,
+      unowned,
+      qualificationRate: ratio(qualified, rows.length),
+      schedulingRate: ratio(scheduled, rows.length),
+      pilotCompleteRate: ratio(pilotComplete, rows.length),
+      nextStepRate: ratio(nextStepReady, rows.length),
+    },
+    byStage: Array.from(byStage.values())
+      .map((entry) => ({
+        ...entry,
+        averageAgeHours: entry.count > 0 && entry.averageAgeHours != null
+          ? Number((entry.averageAgeHours / entry.count).toFixed(1))
+          : null,
+        oldestAgeHours: entry.oldestAgeHours == null ? null : Number(entry.oldestAgeHours.toFixed(1)),
+      }))
+      .filter((entry) => entry.count > 0)
+      .sort((left, right) => compareStageOrder(left.stage, right.stage)),
+    stalled,
+    weekly: Array.from(weekly.values()).sort((left, right) => left.weekStart.localeCompare(right.weekStart)),
+    workflows: Array.from(workflows.values())
+      .sort((left, right) => right.requests - left.requests || right.overdue - left.overdue),
   }
 }
 
@@ -2831,17 +3042,20 @@ export function createApp(db: Database): Hono {
     const days = Math.max(1, Math.min(180, Number.parseInt(c.req.query('days') ?? '30', 10) || 30))
 
     try {
+      const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
       const rows = listFunnelEvents(db, {
-        since: new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString(),
+        since,
         limit: 10000,
       })
       const summary = summarizeFunnel(rows)
+      const partnerRows = listPartnerAnalyticsRows(db, since)
 
       c.header('Cache-Control', 'no-store')
       return c.json({
         days,
         generatedAt: new Date().toISOString(),
         ...summary,
+        partnerMotion: summarizePartnerMotion(partnerRows),
       })
     } catch (err) {
       console.error('Funnel summary error:', err)


### PR DESCRIPTION
Closes #78

## Summary
- extend the funnel API with partner-motion analytics, stage aging, stalled request reporting, and weekly workflow rollups
- surface the new design-partner metrics in the dashboard funnel page so operators can run a weekly review beyond raw CTA clicks
- cover the analytics path with API tests and document the expanded admin funnel payload

## Verification
- npm test --workspace=packages/directory
- npm run build --workspace=packages/dashboard
- npm run build
- cd docs && npm run build
- npm test