### PR TITLE
Add 0.9.0 dry-run evidence and cut control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.9.0 (draft)
+
+### Design-Partner Motion
+- extend hosted-beta requests with stage age, reminders, next meeting, and follow-up due signals
+- add partner-stage analytics so operators can see where requests stall during weekly funnel review
+- add shareable pilot proof summaries tied to real trace evidence inside the beta-request workflow
+
+### Public Funnel
+- keep the landing page, guided evaluation path, hosted beta intake, and onboarding pack on one proof-first design-partner story
+- make the buyer path easier to understand in plain language before any deeper technical evaluation
+
+### Release Control
+- add repo-visible `0.9.0` buyer and operator dry runs before the final cut
+- add an explicit `0.9.0` cut checklist and release-notes draft before release week
+- track current operator blockers as explicit GitHub issues instead of chat-only notes
+
 ## v0.8.1 (2026-03-31)
 
 ### Release Hygiene

--- a/reports/0.9.0-buyer-dry-run.md
+++ b/reports/0.9.0-buyer-dry-run.md
@@ -1,0 +1,111 @@
+# Beam 0.9.0 Buyer Dry Run
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-9-0-dry-runs`
+- live surfaces used:
+  - `https://beam.directory/`
+  - `https://beam.directory/guided-evaluation.html`
+  - `https://beam.directory/hosted-beta.html`
+  - `https://docs.beam.directory/guide/design-partner-onboarding`
+  - `https://api.beam.directory/analytics/events`
+  - `https://api.beam.directory/waitlist`
+  - `https://api.beam.directory/health`
+  - `https://api.beam.directory/stats`
+  - `https://api.beam.directory/release`
+- live API release truth during the run:
+  - version: `0.8.1`
+  - git SHA: `51fbbb9058236c495f8712521b5ec2ccf343abcf`
+  - deployed at: `2026-03-31T10:39:14.000Z`
+
+## Run
+
+### 1. Landing page comprehension
+
+The live landing page still opens on the plain-language buyer framing:
+
+- page title: `Beam | Safe AI Work Between Companies`
+- meta description still frames Beam around cross-company AI work with an auditable trail
+
+This keeps the first impression anchored in business workflow clarity, not protocol jargon.
+
+### 2. Guided evaluation path
+
+The next public step is still narrow and consistent:
+
+- page title: `Guided Beam Evaluation — Beam Protocol`
+- the first-party analytics event posted successfully to the live API with the public Beam origin:
+
+```json
+{
+  "ok": true,
+  "event": {
+    "id": 4,
+    "sessionId": "buyer-090-1774959748",
+    "origin": "https://beam.directory",
+    "pageKey": "guided_evaluation",
+    "eventCategory": "cta_click",
+    "ctaKey": "guided_eval_request_beta",
+    "targetPage": "hosted_beta",
+    "createdAt": "2026-03-31T12:22:28.350Z"
+  }
+}
+```
+
+That confirms the live funnel still records a real buyer signal instead of relying on local mocks.
+
+### 3. Hosted beta intake
+
+The hosted-beta page remains the buyer conversion step:
+
+- page title: `Request a Guided Beam Pilot — Beam Protocol`
+
+The first submission with a string `agentCount` was rejected with the expected API guardrail:
+
+```json
+{
+  "error": "agentCount must be a non-negative integer",
+  "errorCode": "INVALID_AGENT_COUNT"
+}
+```
+
+The corrected submission with a numeric `agentCount` was accepted on the live API:
+
+```json
+{
+  "ok": true,
+  "status": "registered",
+  "id": 4,
+  "email": "beam-090-1774959760@northwind.example",
+  "company": "Northwind Example",
+  "agentCount": 24,
+  "workflowType": "hosted-beta-partner-handoff",
+  "requestStatus": "new",
+  "nextStep": "Beam will review the workflow, assign an owner, and follow up with the next concrete step."
+}
+```
+
+Important detail:
+
+- the live intake still produces the canonical hosted-beta request object
+- the request is visible as a real operator-owned artifact, not just a marketing form success state
+
+### 4. Docs alignment
+
+The onboarding pack stays on the same path:
+
+- page title: `Design-Partner Onboarding Pack | Beam Protocol`
+
+The live docs still reinforce one guided pilot, one workflow summary, and one operator follow-up path.
+
+## Result
+
+`PASS`
+
+The buyer-like path is strong enough on the current live surfaces for another external-style design-partner conversation.
+
+Important caveat:
+
+- the public surfaces used in this pass are ahead of the live operator API release truth
+- that mismatch is tracked separately as an operator-side blocker in [#93](https://github.com/Beam-directory/beam-protocol/issues/93), not a buyer-path blocker

--- a/reports/0.9.0-operator-dry-run.md
+++ b/reports/0.9.0-operator-dry-run.md
@@ -1,0 +1,105 @@
+# Beam 0.9.0 Operator Dry Run
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-9-0-dry-runs`
+- live surfaces used:
+  - `https://dashboard-phi-five-73.vercel.app`
+  - `https://api.beam.directory/admin/auth/config`
+  - `https://api.beam.directory/admin/auth/magic-link`
+  - `https://api.beam.directory/admin/funnel?days=30`
+  - `https://api.beam.directory/health`
+  - `https://api.beam.directory/stats`
+  - `https://api.beam.directory/release`
+- live API release truth during the run:
+  - version: `0.8.1`
+  - git SHA: `51fbbb9058236c495f8712521b5ec2ccf343abcf`
+  - deployed at: `2026-03-31T10:39:14.000Z`
+
+## Run
+
+### 1. Dashboard production preflight
+
+The real production dashboard URL is live and serves a valid bundle:
+
+- page title: `Beam Dashboard`
+- current JS bundle: `/assets/index-CTL2kq1I.js`
+
+### 2. Admin-auth preflight
+
+`GET /admin/auth/config` on the live API returns:
+
+```json
+{
+  "configured": true,
+  "emailDelivery": true,
+  "localDevMagicLinks": false,
+  "sessionTtlSeconds": 604800
+}
+```
+
+This proves the live operator path is not blocked by missing configuration.
+
+### 3. Magic-link challenge
+
+The live API accepted a real admin magic-link request for the authorized operator mailbox:
+
+```json
+{
+  "ok": true,
+  "email": "tobias.kub@appfor.de",
+  "role": "admin",
+  "expiresAt": "2026-03-31T12:35:04.873Z",
+  "dev": false
+}
+```
+
+That confirms delivery is wired on the production path.
+
+### 4. Reproducibility check
+
+The operator dry run could not complete session creation through a repo-owned access path.
+
+Observed evidence:
+
+- `POST /admin/auth/magic-link` for `tobias@coppen.de` returned `UNAUTHORIZED`
+- `POST /admin/auth/magic-link` for `jarvis@coppen.de` returned `UNAUTHORIZED`
+- the only authorized admin mailbox exposed by the live flow during this pass is still a personal mailbox outside the repo-owned automation path
+
+### 5. Protected operator surface
+
+Without a valid session, the protected operator funnel stays correctly gated:
+
+```http
+HTTP/2 401
+```
+
+with body:
+
+```json
+{
+  "error": "Unauthorized",
+  "errorCode": "UNAUTHORIZED"
+}
+```
+
+This is expected behavior, but it means the current operator dry run cannot verify the live queue, partner-stage analytics, or proof-summary surfaces end to end.
+
+### 6. Candidate mismatch
+
+The operator pass is also running against the previous tagged API release:
+
+- `GET /release` returned `0.8.1` / `51fbbb9`
+- current `main` already contains `0.9.0` operator work such as partner-stage analytics and pilot proof summaries
+
+That means the live operator stack used in this pass is not the same operator candidate that would actually ship as `0.9.0`.
+
+## Result
+
+`NO-GO`
+
+The buyer path is currently ahead of the operator release-control path. The final `0.9.0` cut should stay blocked until these issues are resolved:
+
+- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
+- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox

--- a/reports/0.9.0-rc1-checklist.md
+++ b/reports/0.9.0-rc1-checklist.md
@@ -1,0 +1,55 @@
+# Beam 0.9.0 RC1 Checklist
+
+## Context
+
+This checklist is the explicit cut-control path for `0.9.0`.
+
+Current release decision:
+
+- `NO-GO`
+
+Current blocker set:
+
+- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
+- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox
+
+## Evidence Already In Repo
+
+- [x] one buyer-style dry run exists on the `0.9.0` candidate path:
+  - [0.9.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-buyer-dry-run.md)
+- [x] one operator-style dry run exists on the current live operator path:
+  - [0.9.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-dry-run.md)
+- [x] the blocker set from the latest dry runs is tracked as GitHub issues, not chat-only notes:
+  - [#93](https://github.com/Beam-directory/beam-protocol/issues/93)
+  - [#94](https://github.com/Beam-directory/beam-protocol/issues/94)
+- [x] a repo-visible release-notes draft exists before the final cut:
+  - [0.9.0-release-notes-draft.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-release-notes-draft.md)
+
+## Must Be True Before Tagging
+
+- [ ] one explicit live or staging operator surface is deployed from the current `0.9.0` candidate SHA
+- [ ] `GET /release` on that operator surface matches the candidate version and SHA
+- [ ] a reproducible admin-auth path exists for release dry runs without relying on one personal mailbox
+- [ ] the operator dry run is rerun against that candidate surface and ends in a real admin session
+- [ ] the rerun reaches the hosted-beta queue, funnel review, and proof-summary surfaces
+- [ ] `npm run release:smoke` passes against the final live `0.9.0` surfaces after the tag
+- [ ] the changelog and release-notes draft match what is actually live
+
+## Final Week Sequence
+
+1. Resolve [#93](https://github.com/Beam-directory/beam-protocol/issues/93).
+2. Resolve [#94](https://github.com/Beam-directory/beam-protocol/issues/94).
+3. Rerun the operator dry run on the deployed candidate surface.
+4. Rerun the buyer dry run only if the public funnel changed materially since the current pass.
+5. Update this checklist and the release-notes draft with the final live evidence.
+6. Run the release smoke path on the final tag.
+7. Tag `v0.9.0` only if the operator rerun is boring.
+
+## Release Decision
+
+As of `2026-03-31`, `0.9.0` should not be cut.
+
+Reason:
+
+- the buyer path is strong enough
+- the operator path is still not verifiable on the actual `0.9.0` candidate

--- a/reports/0.9.0-release-notes-draft.md
+++ b/reports/0.9.0-release-notes-draft.md
@@ -1,0 +1,49 @@
+# Beam 0.9.0 Release Notes Draft
+
+Status:
+
+- draft only
+- do not publish until [#93](https://github.com/Beam-directory/beam-protocol/issues/93) and [#94](https://github.com/Beam-directory/beam-protocol/issues/94) are resolved
+
+## Summary
+
+Beam `0.9.0` turns the hosted-beta story into a more operational design-partner motion.
+
+This release is aimed at one outcome:
+
+- a real buyer can understand the product quickly
+- a real operator can triage, prove, and follow up on one narrow partner workflow
+
+## Highlights
+
+### Design-Partner Motion
+
+- extend hosted-beta requests with stage age, reminder timing, next meeting, and follow-up due signals
+- add partner-stage analytics so operators can see where requests stall in weekly funnel review
+- add shareable pilot proof summaries tied to real trace evidence inside the beta-request workflow
+
+### Public Funnel
+
+- keep the landing page, guided evaluation, hosted beta page, and onboarding pack on one proof-first design-partner story
+- make the buyer path clearer around one guided pilot instead of a generic technical evaluation
+
+### Release Control
+
+- add repo-visible buyer and operator dry runs before the final cut
+- keep one explicit `0.9.0` cut checklist and draft release notes in the repo before release week
+- turn observed operator blockers into tracked GitHub issues instead of relying on chat notes
+
+## Compatibility Note
+
+No protocol-family change is planned in this release train. Beam `0.9.0` remains on `beam/1`.
+
+## Evidence
+
+- [0.9.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-buyer-dry-run.md)
+- [0.9.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-dry-run.md)
+- [0.9.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-rc1-checklist.md)
+
+## Open Release Blockers
+
+- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
+- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox


### PR DESCRIPTION
## Summary
- add repo-visible buyer and operator dry-run reports for the current `0.9.0` path
- add the `0.9.0` RC checklist and release-notes draft
- record the current operator NO-GO blockers in the changelog and tracked issues

## Verification
- `git diff --check`
- live buyer-path evidence against `beam.directory`, `docs.beam.directory`, and `api.beam.directory`
- live operator preflight evidence against `dashboard-phi-five-73.vercel.app` and `api.beam.directory`

Closes #79
Closes #80
Refs #93
Refs #94