### PR TITLE
Add reproducible live admin auth path

### DIFF
--- a/.github/workflows/operator-candidate.yml
+++ b/.github/workflows/operator-candidate.yml
@@ -26,6 +26,16 @@ on:
         required: true
         default: https://beam-message-bus.fly.dev
         type: string
+      admin_emails:
+        description: Optional comma-separated admin inbox list to stage on the live candidate API
+        required: false
+        default: ''
+        type: string
+      dashboard_url:
+        description: Dashboard URL embedded into admin magic links
+        required: true
+        default: https://dashboard-phi-five-73.vercel.app
+        type: string
 
 permissions:
   contents: read
@@ -86,6 +96,16 @@ jobs:
             BEAM_DEPLOYED_AT \
             --app beam-protocol \
             --stage || true
+
+      - name: Stage candidate admin inbox config
+        if: ${{ inputs.admin_emails != '' }}
+        run: |
+          test -n "$FLY_API_TOKEN" || { echo "Missing FLY_API_TOKEN repo secret" >&2; exit 1; }
+          /home/runner/.fly/bin/flyctl secrets set \
+            BEAM_ADMIN_EMAILS='${{ inputs.admin_emails }}' \
+            BEAM_DASHBOARD_URL='${{ inputs.dashboard_url }}' \
+            --app beam-protocol \
+            --stage
 
       - name: Deploy candidate API to Fly.io
         working-directory: packages/directory
@@ -173,6 +193,10 @@ jobs:
             echo "- deployed at: \`${{ steps.candidate.outputs.deployed_at }}\`"
             echo "- api url: \`${{ inputs.api_url }}\`"
             echo "- dashboard target: \`${{ inputs.dashboard_target }}\`"
+            echo "- dashboard callback url: \`${{ inputs.dashboard_url }}\`"
+            if [ -n "${{ inputs.admin_emails }}" ]; then
+              echo "- staged admin inboxes: \`${{ inputs.admin_emails }}\`"
+            fi
             if [ "${{ steps.dashboard_config.outputs.ready }}" = "true" ]; then
               echo "- dashboard url: ${{ steps.dashboard.outputs.url }}"
             else

--- a/docs/guide/operator-observability.md
+++ b/docs/guide/operator-observability.md
@@ -72,6 +72,42 @@ POST /admin/auth/logout
 
 The browser stores only the short-lived session token. The old static pasted admin key flow is no longer used.
 
+## Reproducible Live Admin Path
+
+For release-control dry runs, use one shared inbox instead of a personal mailbox.
+
+Current recommended path:
+
+```bash
+BEAM_ADMIN_EMAILS=jarvis@coppen.de
+```
+
+If you need to keep an existing personal operator inbox live during the transition, include both:
+
+```bash
+BEAM_ADMIN_EMAILS=jarvis@coppen.de,tobias.kub@appfor.de
+```
+
+On a machine that already has COPPEN Microsoft Graph credentials, you can request, read, and verify the live admin magic link end to end:
+
+```bash
+source /Users/tobik/.openclaw/workspace/secrets/all-keys.env
+npm run release:admin-auth -- \
+  --api-url https://api.beam.directory \
+  --email jarvis@coppen.de \
+  --mailbox jarvis@coppen.de
+```
+
+The helper script:
+
+- requests `POST /admin/auth/magic-link`
+- polls `jarvis@coppen.de` through Microsoft Graph for the latest `Beam admin sign-in link`
+- extracts the callback token
+- verifies it through `POST /admin/auth/verify`
+- confirms the live session with `GET /admin/auth/session`
+
+That gives the operator dry run a repo-owned, repeatable path instead of relying on one personal inbox.
+
 ## Incident Workflow
 
 ### 1. Start From Alerts

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dogfood:partner-handoff": "node scripts/dogfood/partner-handoff.mjs",
     "dogfood:hosted-demo": "node scripts/demo/dogfood-hosted-demo.mjs",
     "quickstart:smoke": "node scripts/quickstart/smoke.mjs",
+    "release:admin-auth": "node scripts/release/live-admin-auth-smoke.mjs",
     "release:smoke": "node scripts/release/release-smoke.mjs",
     "test": "npm run test --workspaces --if-present",
     "test:e2e": "node scripts/e2e/run.mjs",

--- a/scripts/release/live-admin-auth-smoke.mjs
+++ b/scripts/release/live-admin-auth-smoke.mjs
@@ -1,0 +1,249 @@
+function readFlag(name, fallback = null) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  return process.argv[index + 1] ?? fallback
+}
+
+function requiredFlag(name) {
+  const value = readFlag(name)
+  if (!value || value.startsWith('--')) {
+    throw new Error(`Missing required flag: ${name}`)
+  }
+  return value.trim()
+}
+
+import { existsSync, readFileSync } from 'node:fs'
+
+function loadEnvFile(path) {
+  if (!path) {
+    return
+  }
+
+  if (!existsSync(path)) {
+    throw new Error(`Env file not found: ${path}`)
+  }
+
+  const text = readFileSync(path, 'utf8')
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) {
+      continue
+    }
+
+    const key = line.slice(0, separatorIndex).trim()
+    let value = line.slice(separatorIndex + 1).trim()
+    value = value.replace(/^['"]|['"]$/g, '')
+
+    if (!(key in process.env)) {
+      process.env[key] = value
+    }
+  }
+}
+
+function resolveGraphCredential(name, aliases = []) {
+  for (const key of [name, ...aliases]) {
+    const value = process.env[key]?.trim()
+    if (value) {
+      return value
+    }
+  }
+  throw new Error(`Missing required Graph credential: ${name}`)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchJson(url, init = {}) {
+  const response = await fetch(url, init)
+  const text = await response.text()
+  if (!response.ok) {
+    throw new Error(`Request failed for ${url}: ${response.status}${text ? ` ${text}` : ''}`)
+  }
+  return {
+    json: text ? JSON.parse(text) : null,
+    headers: response.headers,
+  }
+}
+
+async function acquireGraphToken() {
+  const tenantId = resolveGraphCredential('MSGRAPH_TENANT_ID', ['GRAPH_TENANT_ID'])
+  const clientId = resolveGraphCredential('MSGRAPH_CLIENT_ID', ['GRAPH_CLIENT_ID'])
+  const clientSecret = resolveGraphCredential('MSGRAPH_CLIENT_SECRET', ['GRAPH_CLIENT_SECRET'])
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: 'https://graph.microsoft.com/.default',
+    grant_type: 'client_credentials',
+  })
+
+  const { json } = await fetchJson(`https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  })
+
+  if (!json?.access_token) {
+    throw new Error('Graph token response did not include access_token')
+  }
+
+  return json.access_token
+}
+
+async function fetchMailboxMessages({ token, mailbox, top = 10 }) {
+  const url = new URL(`https://graph.microsoft.com/v1.0/users/${encodeURIComponent(mailbox)}/messages`)
+  url.searchParams.set('$top', String(top))
+  url.searchParams.set('$orderby', 'receivedDateTime DESC')
+  url.searchParams.set('$select', 'subject,receivedDateTime,body')
+
+  const { json } = await fetchJson(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Prefer: 'outlook.body-content-type="html"',
+    },
+  })
+
+  return Array.isArray(json?.value) ? json.value : []
+}
+
+function extractMagicLink(body) {
+  if (!body) {
+    return null
+  }
+
+  const match = body.match(/https:\/\/[^"'\\s<]+\/auth\/callback\?token=[A-Za-z0-9]+/i)
+  return match ? match[0] : null
+}
+
+async function waitForMagicLink({ mailbox, subject, issuedAfter, attempts, delayMs }) {
+  const token = await acquireGraphToken()
+  const issuedAfterTs = Date.parse(issuedAfter)
+  if (Number.isNaN(issuedAfterTs)) {
+    throw new Error(`Invalid issuedAfter timestamp: ${issuedAfter}`)
+  }
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const messages = await fetchMailboxMessages({ token, mailbox, top: 10 })
+
+    const match = messages.find((message) => {
+      const receivedAt = Date.parse(message.receivedDateTime ?? '')
+      if (!Number.isFinite(receivedAt) || receivedAt < issuedAfterTs) {
+        return false
+      }
+
+      if ((message.subject ?? '').trim() !== subject) {
+        return false
+      }
+
+      return Boolean(extractMagicLink(message.body?.content))
+    })
+
+    if (match) {
+      const url = extractMagicLink(match.body?.content)
+      if (!url) {
+        throw new Error('Matching email found, but no magic link URL could be extracted')
+      }
+
+      return {
+        receivedDateTime: match.receivedDateTime,
+        subject: match.subject,
+        url,
+      }
+    }
+
+    if (attempt < attempts) {
+      await sleep(delayMs)
+    }
+  }
+
+  throw new Error(`No admin magic link email found in ${mailbox} after ${attempts} attempts`)
+}
+
+function readTokenFromMagicLink(url) {
+  const parsed = new URL(url)
+  const token = parsed.searchParams.get('token')
+  if (!token) {
+    throw new Error('Magic link URL did not include a token')
+  }
+  return token
+}
+
+async function main() {
+  await loadEnvFile(readFlag('--env-file'))
+
+  const apiUrl = requiredFlag('--api-url').replace(/\/+$/, '')
+  const email = requiredFlag('--email').toLowerCase()
+  const mailbox = (readFlag('--mailbox', email) ?? email).toLowerCase()
+  const subject = readFlag('--subject', 'Beam admin sign-in link')
+  const attempts = Number.parseInt(readFlag('--attempts', '12'), 10)
+  const delayMs = Number.parseInt(readFlag('--delay-ms', '5000'), 10)
+  const issuedAfter = new Date().toISOString()
+
+  const { json: challenge } = await fetchJson(`${apiUrl}/admin/auth/magic-link`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  })
+
+  if (!challenge?.ok) {
+    throw new Error(`Magic link request did not return ok=true: ${JSON.stringify(challenge)}`)
+  }
+
+  const message = await waitForMagicLink({
+    mailbox,
+    subject,
+    issuedAfter,
+    attempts,
+    delayMs,
+  })
+
+  const magicToken = readTokenFromMagicLink(message.url)
+  const { json: verify, headers } = await fetchJson(`${apiUrl}/admin/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: magicToken }),
+  })
+
+  const setCookie = headers.get('set-cookie')
+  const sessionCookie = setCookie ? setCookie.split(';', 1)[0] : null
+  const { json: session } = await fetchJson(`${apiUrl}/admin/auth/session`, {
+    headers: sessionCookie ? { Cookie: sessionCookie } : undefined,
+  })
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        apiUrl,
+        email,
+        mailbox,
+        challenge: {
+          email: challenge.email,
+          role: challenge.role,
+          expiresAt: challenge.expiresAt,
+        },
+        magicLink: message,
+        verify: {
+          email: verify.email,
+          role: verify.role,
+          expiresAt: verify.expiresAt,
+        },
+        session,
+        sessionCookie,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a repo-owned helper that requests a live admin magic link, reads it from Microsoft Graph, verifies it, and checks the resulting session
- extend the operator-candidate workflow so release-control runs can stage a shared admin inbox and dashboard callback URL on the live candidate API
- document the reproducible `jarvis@coppen.de` path in the operator observability guide

## Verification
- `node --check scripts/release/live-admin-auth-smoke.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/operator-candidate.yml"); puts "yaml-ok"'`
- `cd docs && npm run build`
- Microsoft Graph mailbox probe for `jarvis@coppen.de`

## Notes
- this PR sets up the reproducible path, but the live proof still needs one workflow dispatch with `admin_emails=jarvis@coppen.de,tobias.kub@appfor.de`
- `dashboard.beam.directory` DNS is still external drift, so the safe callback default remains the working Vercel production URL until DNS is fixed

Refs #94
