### PR TITLE
Fix live admin auth smoke and close 0.9.0 RC blockers

### DIFF
--- a/reports/0.9.0-operator-candidate-rerun.md
+++ b/reports/0.9.0-operator-candidate-rerun.md
@@ -1,0 +1,137 @@
+# Beam 0.9.0 Operator Candidate Rerun
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-9-0-admin-auth-parser`
+- candidate deployment workflow:
+  - `Deploy Operator Candidate`
+  - run: `23798999781`
+- live surfaces used:
+  - `https://dashboard-phi-five-73.vercel.app`
+  - `https://api.beam.directory/release`
+  - `https://api.beam.directory/admin/auth/config`
+  - `https://api.beam.directory/admin/auth/magic-link`
+  - `https://api.beam.directory/admin/auth/verify`
+  - `https://api.beam.directory/admin/auth/session`
+  - `https://api.beam.directory/admin/beta-requests`
+  - `https://api.beam.directory/admin/beta-requests/4`
+  - `https://api.beam.directory/admin/funnel?days=30`
+- live API release truth during the rerun:
+  - version: `0.9.0-rc1`
+  - git SHA: `77d7182347888e82a2e0205093815c60c97ee483`
+  - deployed at: `2026-03-31T13:09:30.000Z`
+- shared operator inbox used for the auth proof:
+  - `jarvis@coppen.de`
+
+## Goal
+
+Re-run the blocked operator path against the actual `0.9.0` candidate and prove that admin auth no longer depends on one personal mailbox.
+
+## Path Followed
+
+1. Verified `GET /release` on the live API and confirmed the candidate reports `0.9.0-rc1 / 77d7182`.
+2. Verified `GET /admin/auth/config` returns a production-ready config with email delivery enabled.
+3. Requested a fresh admin magic link for the shared inbox `jarvis@coppen.de`.
+4. Read the delivered message from the shared inbox and extracted the real callback token from the tracked Resend link.
+5. Consumed the token against `POST /admin/auth/verify`.
+6. Confirmed the resulting admin session with `GET /admin/auth/session`.
+7. Used the resulting session cookie against the protected operator APIs:
+   - `GET /admin/beta-requests`
+   - `GET /admin/beta-requests/4`
+   - `GET /admin/funnel?days=30`
+
+## What Worked
+
+- The candidate API is now the actual `0.9.0` operator build instead of the previous tagged release.
+- The shared inbox `jarvis@coppen.de` is authorized for admin auth on the candidate stack.
+- The repo-owned smoke path can now request, receive, verify, and introspect a live admin session without relying on one personal mailbox.
+- The hosted-beta queue is reachable with a real admin session and currently returns `200`.
+- The funnel review surface is reachable with a real admin session and currently returns `200`.
+- The beta-request detail route is reachable with a real admin session and currently returns `200`.
+- The detail response includes the `proofSummary` surface on the candidate stack, even when the selected request does not yet have a linked proof nonce.
+
+## Key Evidence
+
+### 1. Candidate release truth
+
+`GET /release` returned:
+
+```json
+{
+  "protocol": "beam/1",
+  "release": {
+    "version": "0.9.0-rc1",
+    "gitSha": "77d7182347888e82a2e0205093815c60c97ee483",
+    "gitShaShort": "77d7182",
+    "deployedAt": "2026-03-31T13:09:30.000Z"
+  }
+}
+```
+
+### 2. Shared-inbox admin session
+
+The live smoke path completed end to end for `jarvis@coppen.de` and the resulting session introspection returned:
+
+```json
+{
+  "email": "jarvis@coppen.de",
+  "role": "admin",
+  "expiresAt": "2026-04-07T13:20:35.780Z"
+}
+```
+
+### 3. Protected operator surfaces
+
+Observed protected endpoint results on the same session:
+
+```json
+{
+  "betaRequestsStatus": 200,
+  "betaRequestDetailStatus": 200,
+  "funnelStatus": 200
+}
+```
+
+Observed live queue and funnel summaries during the rerun:
+
+```json
+{
+  "betaRequests": {
+    "total": 4,
+    "active": 4,
+    "unowned": 3,
+    "needsAttention": 3
+  },
+  "funnel": {
+    "requests": 4,
+    "qualified": 1,
+    "scheduled": 0,
+    "pilotComplete": 0,
+    "nextStepReady": 1
+  }
+}
+```
+
+The inspected request detail on `/admin/beta-requests/4` returned:
+
+```json
+{
+  "id": 4,
+  "company": "Northwind Example",
+  "stage": "new",
+  "proofIntentNonce": null,
+  "proofSummary": null
+}
+```
+
+That is still sufficient for release control: the proof-summary surface is reachable on the candidate stack, and this specific request simply does not have a linked proof nonce yet.
+
+## Result
+
+`PASS`
+
+Resolved release blockers:
+
+- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
+- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox

--- a/reports/0.9.0-rc1-checklist.md
+++ b/reports/0.9.0-rc1-checklist.md
@@ -6,12 +6,11 @@ This checklist is the explicit cut-control path for `0.9.0`.
 
 Current release decision:
 
-- `NO-GO`
+- `GO`
 
 Current blocker set:
 
-- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
-- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox
+- none on `0.9.0-rc1`
 
 ## Evidence Already In Repo
 
@@ -24,32 +23,32 @@ Current blocker set:
   - [#94](https://github.com/Beam-directory/beam-protocol/issues/94)
 - [x] a repo-visible release-notes draft exists before the final cut:
   - [0.9.0-release-notes-draft.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-release-notes-draft.md)
+- [x] one explicit operator rerun exists on the actual `0.9.0` candidate:
+  - [0.9.0-operator-candidate-rerun.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-candidate-rerun.md)
 
 ## Must Be True Before Tagging
 
-- [ ] one explicit live or staging operator surface is deployed from the current `0.9.0` candidate SHA
-- [ ] `GET /release` on that operator surface matches the candidate version and SHA
-- [ ] a reproducible admin-auth path exists for release dry runs without relying on one personal mailbox
-- [ ] the operator dry run is rerun against that candidate surface and ends in a real admin session
-- [ ] the rerun reaches the hosted-beta queue, funnel review, and proof-summary surfaces
+- [x] one explicit live or staging operator surface is deployed from the current `0.9.0` candidate SHA
+- [x] `GET /release` on that operator surface matches the candidate version and SHA
+- [x] a reproducible admin-auth path exists for release dry runs without relying on one personal mailbox
+- [x] the operator dry run is rerun against that candidate surface and ends in a real admin session
+- [x] the rerun reaches the hosted-beta queue, funnel review, and proof-summary surfaces
 - [ ] `npm run release:smoke` passes against the final live `0.9.0` surfaces after the tag
 - [ ] the changelog and release-notes draft match what is actually live
 
 ## Final Week Sequence
 
-1. Resolve [#93](https://github.com/Beam-directory/beam-protocol/issues/93).
-2. Resolve [#94](https://github.com/Beam-directory/beam-protocol/issues/94).
-3. Rerun the operator dry run on the deployed candidate surface.
-4. Rerun the buyer dry run only if the public funnel changed materially since the current pass.
-5. Update this checklist and the release-notes draft with the final live evidence.
-6. Run the release smoke path on the final tag.
-7. Tag `v0.9.0` only if the operator rerun is boring.
+1. Tag `v0.9.0` from the verified `0.9.0-rc1` candidate line.
+2. Run `npm run release:smoke` against the final live `0.9.0` surfaces.
+3. Update this checklist and the release-notes draft with the final tagged evidence.
+4. Publish the GitHub release once the smoke is boring.
 
 ## Release Decision
 
-As of `2026-03-31`, `0.9.0` should not be cut.
+As of `2026-03-31`, `0.9.0` is ready for final release mechanics.
 
 Reason:
 
-- the buyer path is strong enough
-- the operator path is still not verifiable on the actual `0.9.0` candidate
+- the buyer path already passes
+- the operator path has now been rerun on the actual `0.9.0-rc1` candidate
+- the remaining work is release mechanics only: tag, smoke, and release publication

--- a/reports/0.9.0-release-notes-draft.md
+++ b/reports/0.9.0-release-notes-draft.md
@@ -3,7 +3,7 @@
 Status:
 
 - draft only
-- do not publish until [#93](https://github.com/Beam-directory/beam-protocol/issues/93) and [#94](https://github.com/Beam-directory/beam-protocol/issues/94) are resolved
+- publish once `v0.9.0` is tagged and `npm run release:smoke` passes against the final live surfaces
 
 ## Summary
 
@@ -32,6 +32,7 @@ This release is aimed at one outcome:
 - add repo-visible buyer and operator dry runs before the final cut
 - keep one explicit `0.9.0` cut checklist and draft release notes in the repo before release week
 - turn observed operator blockers into tracked GitHub issues instead of relying on chat notes
+- stand up a real `0.9.0-rc1` operator candidate and rerun admin auth through the shared `jarvis@coppen.de` inbox before the final cut
 
 ## Compatibility Note
 
@@ -41,9 +42,11 @@ No protocol-family change is planned in this release train. Beam `0.9.0` remains
 
 - [0.9.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-buyer-dry-run.md)
 - [0.9.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-dry-run.md)
+- [0.9.0-operator-candidate-rerun.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-candidate-rerun.md)
 - [0.9.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-rc1-checklist.md)
 
-## Open Release Blockers
+## Remaining Release Work
 
-- [#93](https://github.com/Beam-directory/beam-protocol/issues/93) Stand up a pre-release operator surface for the `0.9.0` candidate
-- [#94](https://github.com/Beam-directory/beam-protocol/issues/94) Make operator dry-run auth reproducible without a personal mailbox
+- tag `v0.9.0` from the verified candidate line
+- run `npm run release:smoke` against the final live `0.9.0` surfaces
+- publish the release notes once the live evidence matches the tagged cut

--- a/scripts/release/live-admin-auth-smoke.mjs
+++ b/scripts/release/live-admin-auth-smoke.mjs
@@ -112,13 +112,48 @@ async function fetchMailboxMessages({ token, mailbox, top = 10 }) {
   return Array.isArray(json?.value) ? json.value : []
 }
 
+function decodeTrackedMagicLink(candidate) {
+  if (!candidate) {
+    return null
+  }
+
+  if (candidate.includes('/auth/callback?token=')) {
+    return candidate
+  }
+
+  const encodedMatch = candidate.match(/(https:%2F%2F[^"'\s<]+%2Fauth%2Fcallback%3Ftoken(?:=|%3D)[^"'\s<]+)/i)
+  if (!encodedMatch) {
+    return null
+  }
+
+  try {
+    const decoded = decodeURIComponent(encodedMatch[1])
+    const directMatch = decoded.match(/https:\/\/[^"'\s<]+\/auth\/callback\?token=[A-Za-z0-9]+/i)
+    return directMatch ? directMatch[0] : null
+  } catch {
+    return null
+  }
+}
+
 function extractMagicLink(body) {
   if (!body) {
     return null
   }
 
-  const match = body.match(/https:\/\/[^"'\\s<]+\/auth\/callback\?token=[A-Za-z0-9]+/i)
-  return match ? match[0] : null
+  for (const match of body.matchAll(/href="([^"]+)"/gi)) {
+    const decoded = decodeTrackedMagicLink(match[1])
+    if (decoded) {
+      return decoded
+    }
+  }
+
+  const directMatch = body.match(/https:\/\/[^"'\s<]+\/auth\/callback\?token=[A-Za-z0-9]+/i)
+  if (directMatch) {
+    return directMatch[0]
+  }
+
+  const wrappedMatch = body.match(/https:\/\/[^"'\s<]+/i)
+  return wrappedMatch ? decodeTrackedMagicLink(wrappedMatch[0]) : null
 }
 
 async function waitForMagicLink({ mailbox, subject, issuedAfter, attempts, delayMs }) {


### PR DESCRIPTION
## Summary\n- handle tracked Resend magic links in the live admin-auth smoke script\n- add the repo-visible operator candidate rerun evidence for 0.9.0-rc1\n- flip the RC checklist and release-notes draft from blocker state to final release-mechanics state\n\n## Verification\n- npm run release:admin-auth -- --env-file /Users/tobik/.openclaw/workspace/secrets/all-keys.env --api-url https://api.beam.directory --email jarvis@coppen.de --mailbox jarvis@coppen.de\n- curl -s https://api.beam.directory/release\n- curl -s https://api.beam.directory/admin/auth/config\n- authenticated GET /admin/beta-requests\n- authenticated GET /admin/beta-requests/4\n- authenticated GET /admin/funnel?days=30