### PR TITLE
Cut 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.9.0 (draft)
+## v0.9.0 (2026-03-31)
 
 ### Design-Partner Motion
 - extend hosted-beta requests with stage age, reminders, next meeting, and follow-up due signals
@@ -15,6 +15,10 @@
 - add repo-visible `0.9.0` buyer and operator dry runs before the final cut
 - add an explicit `0.9.0` cut checklist and release-notes draft before release week
 - track current operator blockers as explicit GitHub issues instead of chat-only notes
+- rerun the operator path on the real `0.9.0-rc1` candidate with shared-inbox admin auth before release
+
+### Compatibility Note
+- No protocol-family change in this release train. Beam `0.9.0` remains on `beam/1`.
 
 ## v0.8.1 (2026-03-31)
 
@@ -24,9 +28,6 @@
 - automate API release-truth injection so tagged version, SHA, and deploy timestamp are written into the directory image and verified live after deploy
 - isolate the remaining GitHub Pages Node 20 deprecation noise behind the explicit Node 24 opt-in workaround for JavaScript actions
 - add one repo-visible release smoke path for API, public site, docs, and npm, plus a checked-in baseline evidence report
-
-### Compatibility Note
-- No protocol-family change in this release train. Beam `0.8.1` remains on `beam/1`.
 
 ## v0.8.0 (2026-03-31)
 

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-03-30T19:00:00.000Z",
   "release": {
-    "version": "0.8.1",
+    "version": "0.9.0",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-03-30T19:00:00.000Z"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol-docs",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "devDependencies": {
         "vitepress": "1.6.4"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "0.8.1"
+  "version": "0.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.8.1",
+        "beam-protocol-sdk": "^0.9.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^0.8.1"
+        "beam-protocol-sdk": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.8.1",
+    "beam-protocol-sdk": "^0.9.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^0.8.1"
+    "beam-protocol-sdk": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary\n- bump Beam package and workspace versions to 0.9.0\n- move the changelog entry from draft to the dated 0.9.0 release block\n- align docs and lockfiles with the actual 0.9.0 cut\n\n## Verification\n- npm run build\n- npm test\n- cd docs && npm run build\n- cd packages/sdk-typescript && npm pack --dry-run\n- cd packages/cli && npm pack --dry-run