### PR TITLE
Record 0.9.0 release evidence

### DIFF
--- a/reports/0.9.0-rc1-checklist.md
+++ b/reports/0.9.0-rc1-checklist.md
@@ -6,7 +6,7 @@ This checklist is the explicit cut-control path for `0.9.0`.
 
 Current release decision:
 
-- `GO`
+- `RELEASED`
 
 Current blocker set:
 
@@ -25,6 +25,8 @@ Current blocker set:
   - [0.9.0-release-notes-draft.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-release-notes-draft.md)
 - [x] one explicit operator rerun exists on the actual `0.9.0` candidate:
   - [0.9.0-operator-candidate-rerun.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-candidate-rerun.md)
+- [x] one final post-tag release smoke report exists:
+  - [0.9.0-release-smoke.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-release-smoke.md)
 
 ## Must Be True Before Tagging
 
@@ -33,22 +35,23 @@ Current blocker set:
 - [x] a reproducible admin-auth path exists for release dry runs without relying on one personal mailbox
 - [x] the operator dry run is rerun against that candidate surface and ends in a real admin session
 - [x] the rerun reaches the hosted-beta queue, funnel review, and proof-summary surfaces
-- [ ] `npm run release:smoke` passes against the final live `0.9.0` surfaces after the tag
-- [ ] the changelog and release-notes draft match what is actually live
+- [x] `npm run release:smoke` passes against the final live `0.9.0` surfaces after the tag
+- [x] the changelog and release-notes draft match what is actually live
 
-## Final Week Sequence
+## Completed Release Sequence
 
-1. Tag `v0.9.0` from the verified `0.9.0-rc1` candidate line.
-2. Run `npm run release:smoke` against the final live `0.9.0` surfaces.
-3. Update this checklist and the release-notes draft with the final tagged evidence.
-4. Publish the GitHub release once the smoke is boring.
+1. Tagged `v0.9.0` from the verified candidate line at `a358803656d13239b098a1a591cc7eec462d0b4c`.
+2. Ran `npm run release:smoke` against the final live `0.9.0` surfaces.
+3. Updated this checklist and the release-notes file with final tagged evidence.
+4. Published the GitHub release after the smoke passed.
 
 ## Release Decision
 
-As of `2026-03-31`, `0.9.0` is ready for final release mechanics.
+As of `2026-03-31`, `0.9.0` is live and closed.
 
 Reason:
 
 - the buyer path already passes
-- the operator path has now been rerun on the actual `0.9.0-rc1` candidate
-- the remaining work is release mechanics only: tag, smoke, and release publication
+- the operator path was rerun on the actual `0.9.0-rc1` candidate before tag
+- the post-tag smoke passed on the final live surfaces
+- the tagged release, npm packages, API release truth, docs, and public site all align on `0.9.0`

--- a/reports/0.9.0-release-notes-draft.md
+++ b/reports/0.9.0-release-notes-draft.md
@@ -1,9 +1,9 @@
-# Beam 0.9.0 Release Notes Draft
+# Beam 0.9.0 Release Notes
 
 Status:
 
-- draft only
-- publish once `v0.9.0` is tagged and `npm run release:smoke` passes against the final live surfaces
+- published as `v0.9.0` on `2026-03-31`
+- `npm run release:smoke` passed against the final live surfaces
 
 ## Summary
 
@@ -44,9 +44,10 @@ No protocol-family change is planned in this release train. Beam `0.9.0` remains
 - [0.9.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-dry-run.md)
 - [0.9.0-operator-candidate-rerun.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-operator-candidate-rerun.md)
 - [0.9.0-rc1-checklist.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-rc1-checklist.md)
+- [0.9.0-release-smoke.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/0.9.0-release-smoke.md)
 
-## Remaining Release Work
+## Release Status
 
-- tag `v0.9.0` from the verified candidate line
-- run `npm run release:smoke` against the final live `0.9.0` surfaces
-- publish the release notes once the live evidence matches the tagged cut
+- GitHub release published: `v0.9.0`
+- npm latest now points to `beam-protocol-sdk@0.9.0` and `beam-protocol-cli@0.9.0`
+- live API release truth reports `0.9.0 / a358803`

--- a/reports/0.9.0-release-smoke.md
+++ b/reports/0.9.0-release-smoke.md
@@ -1,0 +1,64 @@
+# Beam 0.9.0 Release Smoke
+
+## Context
+
+- run date: `2026-03-31`
+- repo branch at run time: `codex/0-9-0-post-release-evidence`
+- tagged release:
+  - tag: `v0.9.0`
+  - git SHA: `a358803656d13239b098a1a591cc7eec462d0b4c`
+- release workflow:
+  - run: `23799963272`
+- GitHub release:
+  - `https://github.com/Beam-directory/beam-protocol/releases/tag/v0.9.0`
+
+## Smoke Command
+
+```bash
+npm run release:smoke
+```
+
+## Result
+
+`PASS`
+
+Observed smoke payload:
+
+```json
+{
+  "ok": true,
+  "expectedVersion": "0.9.0",
+  "api": {
+    "release": {
+      "version": "0.9.0",
+      "gitSha": "a358803656d13239b098a1a591cc7eec462d0b4c",
+      "deployedAt": "2026-03-31T13:34:15.000Z"
+    },
+    "healthStatus": "ok"
+  },
+  "publicSite": {
+    "homeUrl": "https://beam.directory/",
+    "hostedBetaUrl": "https://beam.directory/hosted-beta.html",
+    "statusUrl": "https://beam.directory/status.html"
+  },
+  "docs": {
+    "url": "https://docs.beam.directory/guide/hosted-quickstart"
+  },
+  "npmPackages": [
+    {
+      "name": "beam-protocol-sdk",
+      "version": "0.9.0"
+    },
+    {
+      "name": "beam-protocol-cli",
+      "version": "0.9.0"
+    }
+  ]
+}
+```
+
+## Final Verification Notes
+
+- `GET /release` and `GET /health` both report `0.9.0 / a358803`.
+- npm now serves `beam-protocol-sdk@0.9.0` and `beam-protocol-cli@0.9.0` as `latest`.
+- the GitHub release is published and not marked prerelease or draft.


### PR DESCRIPTION
## Summary\n- add a repo-visible 0.9.0 release smoke report\n- flip the 0.9.0 RC checklist to RELEASED\n- update the release-notes file from pre-cut draft status to published status\n\n## Verification\n- npm run release:smoke\n- gh release view v0.9.0 --json tagName,isDraft,isPrerelease,publishedAt,url\n- curl -s https://api.beam.directory/release\n- curl -s https://api.beam.directory/health