### PR TITLE
Add 1.0.0 first production partner plan

### DIFF
--- a/reports/1.0.0-first-production-partner-plan.md
+++ b/reports/1.0.0-first-production-partner-plan.md
@@ -1,0 +1,317 @@
+# Beam 1.0.0 First Production Partner Plan
+
+## Goal
+
+Beam `1.0.0` should move from "design-partner launch motion" to "one boring, repeatable production partner workflow".
+
+The milestone goal is:
+
+**turn Beam into a product that can onboard, operate, recover, and recap one real external production workflow without improvising the process in chat**
+
+At the end of `1.0.0`, Beam should feel less like a strong pilot system and more like a production partner system with explicit ownership, proof, recovery, and release discipline.
+
+## Target Outcome
+
+By **June 29, 2026**, the team should be able to do this cleanly:
+
+1. a named partner workflow is defined with clear actors, timing, proof points, and exit criteria,
+2. the partner can be onboarded through a repeatable pack and go-live checklist,
+3. the operator dashboard shows partner health, breach risk, incidents, and next action without spreadsheet glue,
+4. follow-up rhythm is procedural through reminders and digests rather than memory,
+5. Beam can export a redaction-safe proof pack from live evidence,
+6. backup, restore, and environment-parity drills have been rehearsed,
+7. a production-like fire drill can be run on demand,
+8. buyer, operator, and production-partner dry runs all pass on the release candidate,
+9. `1.0.0` is cut only from explicit evidence and go/no-go gates.
+
+## North Star
+
+Beam `1.0.0` succeeds if one external production workflow can move through the full path:
+
+`first contact -> qualification -> onboarding -> go-live -> monitored production run -> proof export -> next commercial decision`
+
+without heroics, hidden operator steps, or release-day guesswork.
+
+## Non-Goals
+
+`1.0.0` is not for:
+
+- widening Beam into a generic multi-agent platform,
+- adding major new protocol primitives as headline work,
+- chasing broad new SDK or framework surface area,
+- building self-serve enterprise billing or packaging,
+- multiplying partner motions before one production motion is stable,
+- polishing secondary demos ahead of the first production workflow.
+
+## Current Position After 0.9.0
+
+Beam already has the right foundation:
+
+- a live public story that is less technical and more buyer-readable,
+- a guided evaluation path and hosted-beta intake,
+- an operator inbox, beta-request pipeline, follow-up state, and analytics,
+- live proof surfaces for traces, alerts, dead letters, and release truth,
+- automated release, public-site deployment, and release-smoke verification,
+- a clean `0.9.0` release with repo-visible dry runs and evidence.
+
+What is still missing is not protocol credibility. It is production discipline:
+
+- the first production workflow is not yet formalized as a contract with explicit exit criteria,
+- onboarding and go-live still need a tighter operator path,
+- partner health and SLA/breach visibility need a more production-shaped surface,
+- proof export exists as live evidence but not yet as a redaction-safe package for external sharing,
+- operational recovery has not yet been drilled deeply enough to claim production readiness,
+- the release decision for the first production partner still needs a stricter go/no-go frame.
+
+## Product Thesis For 1.0.0
+
+The key product bet for `1.0.0` is this:
+
+**Beam becomes credible when one external production workflow is operationally boring, not when the protocol becomes broader.**
+
+That means the milestone should optimize for:
+
+- production reliability over novelty,
+- one workflow contract over many vague use cases,
+- operator clarity over more surface area,
+- proof export over internal explanations,
+- recovery drills over release optimism.
+
+## Operating Rule
+
+`0.9.1` is a hotfix and hygiene lane only.
+
+All material product and operator work should land under the `1.0.0 First Production Partner` track. If a live regression appears, fix it directly as a narrow hotfix without changing the `1.0.0` scope.
+
+## Success Criteria
+
+`1.0.0` is done when all of the following are true:
+
+- one named production workflow is documented end to end with sender, recipient, timing, failure handling, proof, owner, and exit criteria,
+- onboarding and go-live can be run from a repo-visible pack and checklist,
+- the operator dashboard makes partner health, SLA risk, follow-up due items, and incidents operationally obvious,
+- recurring partner-thread review can happen through product surfaces and digests rather than manual memory,
+- a redaction-safe proof pack can be exported from live data and handed to an external stakeholder,
+- recovery and parity drills have been executed and documented on the current production architecture,
+- one repeatable fire drill has been run successfully,
+- the final candidate passes three documented passes:
+  - buyer-like,
+  - operator-like,
+  - production-partner / go-live-like,
+- the final release decision is made from a repo-visible checklist and explicit go/no-go criteria.
+
+## Workstreams
+
+### 1. Production Workflow Contract
+
+Goal: choose one production workflow and remove ambiguity around what "production-ready" means.
+
+Primary issue:
+
+- [#101](https://github.com/Beam-directory/beam-protocol/issues/101) Define the first production partner workflow contract and exit criteria
+
+Scope:
+
+- name the first production workflow,
+- document actors, handoff shape, expected latency, failure modes, proof points, and owner,
+- define explicit exit criteria for a `1.0.0` ship decision,
+- point landing, docs, and operator surfaces at the same workflow.
+
+### 2. Onboarding And Go-Live Pack
+
+Goal: make onboarding and go-live procedural.
+
+Primary issue:
+
+- [#102](https://github.com/Beam-directory/beam-protocol/issues/102) Add a production onboarding pack and go-live checklist
+
+Scope:
+
+- buyer-facing onboarding pack,
+- operator-facing go-live checklist,
+- prerequisites, rollout timeline, proof expectations, and escalation path,
+- ability to mark blocked prerequisites in the pipeline.
+
+### 3. Partner Health And SLA Surface
+
+Goal: let operators see production risk before the partner reports it.
+
+Primary issue:
+
+- [#103](https://github.com/Beam-directory/beam-protocol/issues/103) Add partner health, SLA breach, and incident surfaces to the dashboard
+
+Scope:
+
+- partner health by owner, workflow, and current state,
+- SLA or latency breach visibility,
+- incident and dead-letter attribution to partner workflow,
+- one-step jump from alert to the relevant partner record.
+
+### 4. Recurring Operator Rhythm
+
+Goal: make follow-through procedural and reviewable.
+
+Primary issue:
+
+- [#104](https://github.com/Beam-directory/beam-protocol/issues/104) Add recurring operator digest and reminder delivery for partner threads
+
+Scope:
+
+- overdue follow-up digest,
+- reminders for next meeting and next action,
+- weekly review rhythm without spreadsheets,
+- repo-visible docs for the recurring path.
+
+### 5. Redaction-Safe Proof Pack
+
+Goal: turn live evidence into something external stakeholders can consume.
+
+Primary issue:
+
+- [#105](https://github.com/Beam-directory/beam-protocol/issues/105) Add a redaction-safe proof pack export from live evidence
+
+Scope:
+
+- concise workflow summary,
+- reliability and trace proof,
+- redacted screenshots or references,
+- explicit next-step recommendation,
+- clean separation between internal operator detail and external proof.
+
+### 6. Backup, Restore, And Environment Parity
+
+Goal: prove Beam can survive operational stress.
+
+Primary issue:
+
+- [#106](https://github.com/Beam-directory/beam-protocol/issues/106) Add backup, restore, and environment-parity drills for Beam operations
+
+Scope:
+
+- documented and tested backup/restore path,
+- environment-parity checks for production-critical surfaces,
+- one recovery drill report committed to the repo.
+
+### 7. Production Fire Drill
+
+Goal: rehearse the ugly path before the release, not after it.
+
+Primary issue:
+
+- [#107](https://github.com/Beam-directory/beam-protocol/issues/107) Add a repeatable production fire drill and dogfood path
+
+Scope:
+
+- one scripted or documented fire drill,
+- operator investigation path exercised end to end,
+- rerunnable before release and after major operational changes.
+
+### 8. Final Dry Runs
+
+Goal: make the release candidate earn the release.
+
+Primary issue:
+
+- [#108](https://github.com/Beam-directory/beam-protocol/issues/108) Run 1.0.0 buyer, operator, and production-partner dry runs
+
+Scope:
+
+- one buyer-like pass,
+- one operator-like pass,
+- one go-live or production-partner pass,
+- new blockers filed as GitHub issues instead of being hand-waved away.
+
+### 9. Cut Control
+
+Goal: keep the first production release disciplined.
+
+Primary issue:
+
+- [#109](https://github.com/Beam-directory/beam-protocol/issues/109) Prepare the 1.0.0 cut checklist, release notes, and go-no-go gates
+
+Scope:
+
+- repo-visible cut checklist,
+- draft release notes,
+- explicit go/no-go gates,
+- final release only after smoke and evidence are boring.
+
+## Sequence
+
+### Phase 1: Contract And Onboarding
+
+**April 1, 2026 to April 14, 2026**
+
+- close the workflow contract,
+- define exit criteria,
+- build the onboarding pack and go-live checklist,
+- ensure every public and operator surface talks about the same production motion.
+
+Primary issues:
+
+- [#101](https://github.com/Beam-directory/beam-protocol/issues/101)
+- [#102](https://github.com/Beam-directory/beam-protocol/issues/102)
+
+### Phase 2: Operator Production Surface
+
+**April 15, 2026 to May 5, 2026**
+
+- add partner health and SLA visibility,
+- make follow-up rhythm recurring and procedural,
+- reduce operator dependence on memory or ad hoc notes.
+
+Primary issues:
+
+- [#103](https://github.com/Beam-directory/beam-protocol/issues/103)
+- [#104](https://github.com/Beam-directory/beam-protocol/issues/104)
+
+### Phase 3: Proof And Recovery Discipline
+
+**May 6, 2026 to May 26, 2026**
+
+- build the redaction-safe proof export,
+- drill backup/restore and environment parity,
+- run at least one production-like fire drill.
+
+Primary issues:
+
+- [#105](https://github.com/Beam-directory/beam-protocol/issues/105)
+- [#106](https://github.com/Beam-directory/beam-protocol/issues/106)
+- [#107](https://github.com/Beam-directory/beam-protocol/issues/107)
+
+### Phase 4: Candidate Validation
+
+**May 27, 2026 to June 16, 2026**
+
+- run buyer, operator, and production-partner dry runs,
+- burn down blockers immediately,
+- do not cut a candidate until failures are repo-visible and owned.
+
+Primary issue:
+
+- [#108](https://github.com/Beam-directory/beam-protocol/issues/108)
+
+### Phase 5: Cut Control And Release Decision
+
+**June 17, 2026 to June 29, 2026**
+
+- finalize the checklist,
+- freeze the release notes,
+- execute the final smoke,
+- make the release decision from the evidence, not momentum.
+
+Primary issue:
+
+- [#109](https://github.com/Beam-directory/beam-protocol/issues/109)
+
+## Release Decision
+
+`1.0.0` should ship only when Beam can support one external production workflow end to end with:
+
+- explicit ownership,
+- explicit recovery,
+- explicit proof,
+- explicit go-live process,
+- explicit release evidence.
+
+If any one of those still depends on operator memory or last-minute chat coordination, the release is not ready.


### PR DESCRIPTION
## Summary
- add the repo-visible 1.0.0 first production partner plan
- anchor the plan to issues #101 through #109 and the new milestone
- define phases, success criteria, and release rules after 0.9.0

## Testing
- not run (reports-only change)