### PR TITLE
Define the 1.0.0 workflow contract and onboarding path

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
     sidebar: [
       { text: 'Guide', items: [
         { text: 'Verified Partner Handoff', link: '/guide/partner-handoff' },
-        { text: 'Design-Partner Onboarding Pack', link: '/guide/design-partner-onboarding' },
+        { text: 'First Production Partner Workflow', link: '/guide/production-partner-workflow' },
+        { text: 'Production Partner Onboarding Pack', link: '/guide/design-partner-onboarding' },
+        { text: 'Production Go-Live Checklist', link: '/guide/production-go-live-checklist' },
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Hosted Quickstart', link: '/guide/hosted-quickstart' },
         { text: 'Compatibility', link: '/guide/compatibility' },

--- a/docs/guide/design-partner-onboarding.md
+++ b/docs/guide/design-partner-onboarding.md
@@ -1,44 +1,65 @@
-# Design-Partner Onboarding Pack
+# Production Partner Onboarding Pack
 
-Use this pack when a hosted Beam evaluation moves from "interesting" to "worth a real conversation."
+Use this pack when a Beam conversation moves from "interesting" to "we are seriously considering one production workflow."
 
-The public proof path stays here:
+This pack is buyer-facing first. It is the shared document both sides should be able to read before a call, before a pilot, and before a go-live discussion.
+
+The public path still starts here:
 
 - [Guided Evaluation](https://beam.directory/guided-evaluation.html)
 - [Hosted Beta Intake](https://beam.directory/hosted-beta.html)
 
-This page is the reusable operator and buyer pack that should support every external evaluation before the call starts.
+The canonical `1.0.0` production definition now lives here:
+
+- [First Production Partner Workflow Contract](/guide/production-partner-workflow)
+- [Production Go-Live Checklist](/guide/production-go-live-checklist)
 
 ## What This Pack Is For
 
-Use it to make sure the first Beam conversation stays narrow and honest:
+Use it to keep the first production conversation narrow and honest:
 
-1. one workflow,
+1. one named workflow,
 2. one sender and one recipient,
-3. one operator owner,
-4. one proof expectation,
-5. one next step if the fit is real.
+3. one buyer-side owner,
+4. one operator owner,
+5. one explicit success condition,
+6. one next decision after the first proof.
 
-Do not use Beam's first conversation as a broad "agent platform" tour. The first job is to decide whether one cross-company handoff deserves a pilot.
+Do not use the first production discussion as a broad "agent platform" tour. The first job is to decide whether the named workflow deserves a real go-live path.
+
+## Canonical 1.0.0 Workflow
+
+Beam `1.0.0` is anchored on one concrete production shape:
+
+**Quote Approval Partner Handoff**
+
+In plain language:
+
+1. a buyer-side procurement agent asks a supplier or partner-side operations agent for stock, delivery timing, and a quote,
+2. the partner-side agent responds on the same Beam thread,
+3. the buyer-side operator and finance owner can inspect the trace, the proof, and the next action without losing the request history.
+
+Read the full contract in [First Production Partner Workflow Contract](/guide/production-partner-workflow).
 
 ## Buyer Expectations Before The Evaluation
 
 Before the call starts, the external team should already know:
 
-- Beam is for one company handing work to another company's AI with a visible paper trail.
-- The first evaluation is scoped to one real workflow, not a broad rollout.
-- The goal is to inspect the proof and decide whether one hosted pilot is justified.
-- The likely next step after a good call is a narrow hosted pilot, not an open-ended beta promise.
+- Beam is for one company handing work to another company with a visible paper trail.
+- The first production path is scoped to one real workflow, not a broad rollout.
+- The goal is to inspect the proof and decide whether one hosted pilot and go-live checklist make sense.
+- The likely next step after a good call is a narrow workflow rollout, not an open-ended beta promise.
 
 ## What We Need Before Scheduling
 
-Collect these five inputs before the first session:
+Collect these six inputs before the first serious session:
 
 1. The first workflow in one sentence.
 2. The sender and receiver sides.
-3. The operator who will care when the handoff stalls.
-4. The success condition for the first pilot.
-5. The blocker or risk that makes visibility matter.
+3. The buyer-side business owner.
+4. The operator who will care when the handoff stalls.
+5. The success condition for the first pilot.
+6. The blocker or risk that makes visibility matter.
 
 ### Intake Checklist
 
@@ -50,15 +71,49 @@ Collect these five inputs before the first session:
 - Internal owner on the buyer side
 - Clear reason this workflow matters now
 
+## Production Readiness Prerequisites
+
+These are the six prerequisites Beam operators track directly in the dashboard before go-live:
+
+1. Workflow owner confirmed
+2. Sender and receiver confirmed
+3. Success metric confirmed
+4. Security review confirmed
+5. Go-live window confirmed
+6. Proof recipients confirmed
+
+If any of these are missing, the request should stay explicitly blocked. Do not hide go-live risk inside free-form notes.
+
+## Expected Timeline
+
+The first production motion should feel boring:
+
+1. **Guided evaluation**
+   - confirm the workflow and the operator proof path
+   - stop if the workflow is still vague
+2. **Scoped pilot**
+   - agree on one owner, one success condition, and one proof package
+   - record reminders, next meeting, and next action in the request record
+3. **Go-live review**
+   - walk the [Production Go-Live Checklist](/guide/production-go-live-checklist)
+   - mark any blocked prerequisites in the dashboard
+4. **First production window**
+   - keep one operator owner on the thread
+   - use the same trace, signal, and proof surfaces as the pilot
+5. **Proof recap and decision**
+   - send the proof pack
+   - decide whether to expand, narrow, or stop
+
 ## What The Guided Evaluation Should Cover
 
 The canonical sequence is:
 
 1. Restate the buyer workflow in plain language.
-2. Show the healthy Beam overview baseline.
-3. Open one request trace and walk stage by stage.
-4. Explain what happens when follow-up is async or delayed.
-5. Confirm what a hosted pilot would look like if the fit is real.
+2. Show the [First Production Partner Workflow Contract](/guide/production-partner-workflow).
+3. Show the healthy Beam overview baseline.
+4. Open one request trace and walk stage by stage.
+5. Explain what happens when follow-up is async or delayed.
+6. Confirm what a hosted pilot and go-live path would look like if the fit is real.
 
 ## Proof Checklist
 
@@ -69,6 +124,7 @@ Show all of these:
 - a healthy operator baseline,
 - one request trace from arrival to reply,
 - one explicit owner and next action,
+- where go-live blockers would be tracked,
 - what happens when the handoff needs follow-up later,
 - where an operator would look if the flow stalled.
 
@@ -80,6 +136,7 @@ At the end of the evaluation, the buyer should have:
 - a shared understanding of what the first pilot would cover,
 - one named owner on both sides,
 - one concrete next action,
+- one clear picture of what has to be true before go-live,
 - no confusion about whether self-hosting or repo setup is required first.
 
 ## Operator Preparation Checklist
@@ -87,10 +144,10 @@ At the end of the evaluation, the buyer should have:
 Before the call:
 
 - confirm the public guided evaluation page still reflects the current proof path,
-- make sure the screenshots and operator evidence are current,
+- make sure the workflow contract still matches the production story,
 - open the dashboard and confirm the system baseline is healthy,
 - know which follow-up template matches the likely request stage,
-- have the onboarding pack and hosted beta intake open in the same browser session.
+- have the onboarding pack and the go-live checklist open in the same browser session.
 
 After the call:
 
@@ -98,6 +155,7 @@ After the call:
 - assign or confirm owner,
 - record the next action,
 - record last contact time,
+- record blocked go-live prerequisites if any are missing,
 - send the correct follow-up template.
 
 ## Follow-Up Templates
@@ -108,13 +166,13 @@ These templates are intentionally short. The goal is clarity and next action, no
 ## Template: New Request Acknowledgement
 
 ```text
-Subject: Beam evaluation request received
+Subject: Beam production workflow review received
 
 Hi {{name}},
 
 We received your Beam request for {{company}}.
 
-The next step on our side is a quick workflow review so we can confirm whether one narrow pilot makes sense. We will use the workflow summary you sent to assign an operator owner and send the right proof path before the call.
+The next step on our side is a quick workflow review so we can confirm whether the first production-shaped handoff is narrow enough for a pilot. We will use the workflow summary you sent to assign an operator owner and send the right proof path before the call.
 
 What we need from you:
 - the first workflow in one sentence
@@ -124,7 +182,8 @@ What we need from you:
 
 Reference:
 - Guided evaluation: https://beam.directory/guided-evaluation.html
-- Hosted beta intake: https://beam.directory/hosted-beta.html
+- Workflow contract: https://docs.beam.directory/guide/production-partner-workflow
+- Onboarding pack: https://docs.beam.directory/guide/design-partner-onboarding
 
 Best,
 {{operator}}
@@ -138,16 +197,18 @@ Subject: Beam workflow clarification
 
 Hi {{name}},
 
-We reviewed the request and want to keep the first evaluation narrow.
+We reviewed the request and want to keep the first production discussion narrow.
 
 Before we schedule anything, please reply with:
 - the first sender and receiver in the workflow
 - the one handoff that matters most
 - the person who owns the result if it stalls
+- the success condition that would count as "ready to proceed"
 
-Beam works best when the first evaluation stays focused on one real partner handoff instead of a broad platform rollout.
+Beam works best when the first production path stays focused on one real partner handoff instead of a broad platform rollout.
 
 Reference pack:
+- https://docs.beam.directory/guide/production-partner-workflow
 - https://docs.beam.directory/guide/design-partner-onboarding
 
 Best,
@@ -158,7 +219,7 @@ Best,
 ## Template: Contacted / Next Action Sent
 
 ```text
-Subject: Beam evaluation next step
+Subject: Beam workflow next step
 
 Hi {{name}},
 
@@ -166,9 +227,10 @@ Thanks for the context. The next step is {{next_action}}.
 
 Before the session, please review:
 - the guided evaluation path: https://beam.directory/guided-evaluation.html
+- the workflow contract: https://docs.beam.directory/guide/production-partner-workflow
 - the onboarding pack: https://docs.beam.directory/guide/design-partner-onboarding
 
-The call will stay focused on one workflow, the proof Beam shows for it, and whether that workflow deserves a hosted pilot.
+The call will stay focused on one workflow, the proof Beam shows for it, and whether that workflow deserves a real pilot and go-live review.
 
 Best,
 {{operator}}
@@ -187,7 +249,7 @@ Your Beam evaluation is scheduled for {{date_time}}.
 What we will cover:
 - the workflow in plain language
 - the Beam proof path for one request
-- what a narrow hosted pilot would include if the fit is real
+- what a narrow hosted pilot and go-live checklist would include if the fit is real
 
 Please bring:
 - the business owner for the workflow
@@ -195,6 +257,7 @@ Please bring:
 - the success condition for the first pilot
 
 Reference pack:
+- https://docs.beam.directory/guide/production-partner-workflow
 - https://docs.beam.directory/guide/design-partner-onboarding
 
 Best,
@@ -214,7 +277,7 @@ Beam is now active for the scoped workflow we agreed on.
 Current owner: {{owner}}
 Current next action: {{next_action}}
 
-If the workflow stalls, we will use the operator path to inspect the trace, confirm the current stage, and decide the next recovery step. We will keep follow-up attached to the same request instead of starting a new thread.
+If the workflow stalls, we will use the operator path to inspect the trace, confirm the current stage, and decide the next recovery step. We will also keep any go-live blockers attached to the same request instead of splitting them across separate notes.
 
 Best,
 {{operator}}
@@ -224,13 +287,13 @@ Best,
 ## Template: Closed / Not The Right Fit Right Now
 
 ```text
-Subject: Beam evaluation follow-up
+Subject: Beam workflow follow-up
 
 Hi {{name}},
 
 Thanks again for the conversation.
 
-We are closing the current Beam request for now because the first workflow is not narrow enough yet or the timing is not right for a hosted pilot.
+We are closing the current Beam request for now because the first workflow is not narrow enough yet, the timing is not right for a hosted pilot, or the go-live prerequisites are not ready yet.
 
 If that changes, the best restart is:
 - one workflow
@@ -238,7 +301,7 @@ If that changes, the best restart is:
 - one recipient
 - one success condition
 
-When that exists, you can reopen the conversation through:
+When that exists, restart from:
 - https://beam.directory/guided-evaluation.html
 - https://beam.directory/hosted-beta.html
 
@@ -250,5 +313,7 @@ Best,
 
 - [Guided Evaluation](https://beam.directory/guided-evaluation.html)
 - [Hosted Beta Intake](https://beam.directory/hosted-beta.html)
+- [First Production Partner Workflow Contract](/guide/production-partner-workflow)
+- [Production Go-Live Checklist](/guide/production-go-live-checklist)
 - [Operator Runbook](/guide/operator-runbook)
 - [Hosted Quickstart](/guide/hosted-quickstart)

--- a/docs/guide/operator-runbook.md
+++ b/docs/guide/operator-runbook.md
@@ -5,7 +5,9 @@ This runbook is the shortest path from "something looks wrong" to a concrete Bea
 Use it together with:
 
 - [Hosted Quickstart](/guide/hosted-quickstart) for a local seeded demo stack
-- [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) for buyer expectations, evaluation prep, and follow-up templates
+- [First Production Partner Workflow Contract](/guide/production-partner-workflow) for the exact `1.0.0` workflow Beam is trying to make boring
+- [Production Partner Onboarding Pack](/guide/design-partner-onboarding) for buyer expectations, evaluation prep, and follow-up templates
+- [Production Go-Live Checklist](/guide/production-go-live-checklist) for explicit launch blockers and rollout readiness
 - [Operator Observability](/guide/operator-observability) for dashboards, exports, and retention controls
 - [Intent Lifecycle](/guide/intent-lifecycle) for status semantics
 
@@ -22,7 +24,7 @@ Use the inbox for two classes of work:
 - hosted beta requests that still need assignment, contact, or a next action
 - critical alerts that need triage, acknowledgement, and an explicit follow-up
 
-When the signal is a hosted beta request, pair the inbox with the [Design-Partner Onboarding Pack](/guide/design-partner-onboarding). The pack gives you the shared expectations and reply templates for `new`, `reviewing`, `contacted`, `scheduled`, `active`, and `closed` request states.
+When the signal is a hosted beta request, pair the inbox with the [Production Partner Onboarding Pack](/guide/design-partner-onboarding) and the [Production Go-Live Checklist](/guide/production-go-live-checklist). The pack gives you the shared expectations and reply templates for `new`, `reviewing`, `contacted`, `scheduled`, `active`, and `closed` request states, and the checklist gives you the explicit blockers Beam should keep visible before go-live.
 
 The shortest daily loop is:
 

--- a/docs/guide/production-go-live-checklist.md
+++ b/docs/guide/production-go-live-checklist.md
@@ -1,0 +1,76 @@
+# Production Go-Live Checklist
+
+Use this checklist when a hosted pilot is about to become a real production partner workflow.
+
+This page is operator-facing. Buyers should read the [Production Partner Onboarding Pack](/guide/design-partner-onboarding). Operators should use this checklist to decide whether the workflow is ready to go live or explicitly blocked.
+
+The workflow contract lives here:
+
+- [First Production Partner Workflow Contract](/guide/production-partner-workflow)
+
+## Hard Rule
+
+If any required item is still missing, record it as a blocked prerequisite on the partner request. Do not hide missing prerequisites inside free-form notes.
+
+## The Six Go-Live Prerequisites
+
+These are the exact checklist items Beam operators should track in the dashboard:
+
+1. **Workflow owner confirmed**
+   - the buyer-side business owner is named
+   - the partner-side owner is known
+2. **Sender and receiver confirmed**
+   - the first sender and first receiving system are fixed
+   - both sides agree this is the first production shape
+3. **Success metric confirmed**
+   - both sides agree what a "good" first production week means
+4. **Security review confirmed**
+   - compliance, trust, routing, and policy expectations are agreed
+5. **Go-live window confirmed**
+   - the initial rollout window has an owner, date, and rollback path
+6. **Proof recipients confirmed**
+   - both sides know who receives the recap and proof export
+
+## Before Go-Live
+
+- confirm the workflow still matches the [First Production Partner Workflow Contract](/guide/production-partner-workflow)
+- confirm the request has a visible owner and next action
+- confirm the latest walkthrough proof is attached to the same request
+- confirm the operator knows where to inspect trace, signal, alerts, and dead letters
+- confirm the partner thread has the correct reminder and next-meeting state
+
+## Day-Of Go-Live
+
+- confirm Beam overview is healthy
+- confirm no unrelated critical alert pressure is already open
+- confirm the correct sender and recipient identities are active
+- confirm policy and trust settings match the agreed workflow
+- confirm the operator signal path is clear before the first live request starts
+
+## First 24 Hours
+
+- check the first live requests in the trace view
+- confirm owner and next action stay attached if follow-up becomes async
+- check alerts and dead letters before declaring the rollout healthy
+- send the proof recap to the named recipients
+- record whether the workflow should expand, narrow, or pause
+
+## Rollback And Recovery
+
+If the first live window breaks:
+
+1. open the trace for the failing request
+2. open the linked operator signal
+3. check dead letters or retries only after the trace confirms that path
+4. record the owner and next recovery step on the same partner request
+5. do not declare the rollout healthy again until the reason for failure is explicit
+
+## Exit Condition
+
+The go-live checklist is complete only when:
+
+- no required prerequisite is blocked,
+- the first live requests are visible and legible,
+- the operator can explain the current state without ad hoc chat context,
+- the proof recap was sent to the named recipients,
+- the next commercial or operational decision is explicit.

--- a/docs/guide/production-partner-workflow.md
+++ b/docs/guide/production-partner-workflow.md
@@ -1,0 +1,117 @@
+# First Production Partner Workflow Contract
+
+This page defines the exact workflow Beam `1.0.0` treats as the first production-grade partner handoff.
+
+When the landing page, guided evaluation, onboarding pack, or operator queue says "one workflow," this is the workflow they mean.
+
+## Workflow Name
+
+**Quote Approval Partner Handoff**
+
+## Plain-Language Summary
+
+A buyer-side procurement agent asks a partner-side operations agent for stock, delivery timing, and a quote. The partner-side agent responds on the same Beam thread. A buyer-side operator and finance owner can inspect the request, the reply, and any delayed follow-up without losing the paper trail.
+
+## Why This Workflow
+
+This workflow is the right `1.0.0` anchor because it is:
+
+- cross-company,
+- async by nature,
+- operationally sensitive,
+- easy to explain to a non-technical stakeholder,
+- good at exposing whether Beam keeps proof and ownership intact when work slows down.
+
+## Named Roles
+
+### Sender
+
+- buyer-side procurement agent
+- example: `procurement@acme.beam.directory`
+
+### Recipient
+
+- partner-side operations or supplier desk agent
+- example: `partner-desk@northwind.beam.directory`
+
+### Buyer-Side Owner
+
+- the business owner who cares whether the quote and delivery answer arrives on time
+
+### Operator Owner
+
+- the person who will inspect traces, signal state, dead letters, and recovery steps if the workflow stalls
+
+## Expected Latency
+
+The production contract for this workflow is:
+
+1. **Trace visibility**
+   - the request should become visible in Beam within seconds
+2. **Operator visibility**
+   - an operator should be able to identify the current stage and owner within one minute
+3. **Workflow response**
+   - the partner side should either reply or record an explicit async follow-up state inside the same thread within the agreed workflow window
+4. **Escalation clarity**
+   - if the expected business reply window is missed, the operator signal and next action should already be visible
+
+The exact commercial SLA can vary by partner. The product contract does not: Beam must make the state legible, attached, and recoverable.
+
+## Acceptable Failure Handling
+
+The workflow is still acceptable if one of these happens, as long as Beam makes it explicit:
+
+- the recipient is temporarily unavailable and Beam retries,
+- policy or trust controls reject the request and the reason is visible,
+- the reply needs human or system follow-up later and the same thread carries the next action,
+- the request reaches dead-letter and the operator can point at the failure state without guessing.
+
+The workflow is **not** acceptable if:
+
+- a request disappears without a visible state,
+- the operator cannot say who owns the next step,
+- the proof depends on memory or ad hoc chat recap,
+- a buyer has to trust that the message moved without seeing the evidence.
+
+## Operator Proof Points
+
+For this workflow to count as production-ready, Beam must show:
+
+- a healthy operator baseline before the request starts,
+- one traceable request from arrival to reply or explicit async follow-up,
+- one owner and next action attached to the request,
+- visible retry, delay, or dead-letter state if the workflow degrades,
+- a proof package that can be shared without exposing operator-only detail.
+
+## Production-Ready Exit Criteria
+
+Beam `1.0.0` should treat this workflow as production-ready only when all of these are true:
+
+- the workflow can be explained in one sentence by a normal buyer,
+- the sender and recipient are fixed and visible,
+- the onboarding pack and go-live checklist both point at this same workflow,
+- the operator dashboard can show the current state, owner, and recovery path,
+- blocked go-live prerequisites can be recorded explicitly in the request,
+- the proof pack can be exported from live evidence,
+- backup, restore, and fire-drill paths have been rehearsed on the current architecture,
+- the final dry runs pass for buyer, operator, and production-partner views.
+
+## What This Contract Does Not Try To Cover
+
+This contract does not try to solve every Beam use case at once. It is intentionally narrow.
+
+It does **not** define:
+
+- a generic internal automation story,
+- a marketplace of many workflows,
+- broad enterprise rollout packaging,
+- a self-serve "bring all your agents" motion.
+
+If the first production partner workflow is not stable, Beam should not pretend the broader story is production-ready.
+
+## Related Guides
+
+- [Production Partner Onboarding Pack](/guide/design-partner-onboarding)
+- [Production Go-Live Checklist](/guide/production-go-live-checklist)
+- [Operator Runbook](/guide/operator-runbook)
+- [Hosted Quickstart](/guide/hosted-quickstart)

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,16 +41,19 @@ If you only do one thing, open the public [Guided Evaluation](https://beam.direc
 
 Use the docs when you need one of these supporting paths:
 
-1. The [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) for prerequisites, evaluation expectations, and operator follow-up templates.
-2. The [Hosted Quickstart](/guide/hosted-quickstart) if you want to run the same proof stack locally.
-3. The [Register page](https://beam.directory/register.html) once the use case is real and you want to wire your own agent.
+1. The [First Production Partner Workflow Contract](/guide/production-partner-workflow) if you want the exact `1.0.0` workflow Beam is anchoring on.
+2. The [Production Partner Onboarding Pack](/guide/design-partner-onboarding) for prerequisites, proof expectations, and operator follow-up templates.
+3. The [Production Go-Live Checklist](/guide/production-go-live-checklist) if the workflow is moving from pilot to production.
+4. The [Hosted Quickstart](/guide/hosted-quickstart) if you want to run the same proof stack locally.
+5. The [Register page](https://beam.directory/register.html) once the use case is real and you want to wire your own agent.
 
 ## Choose Your Path
 
 1. **See the proof first.** Open the [Guided Evaluation](https://beam.directory/guided-evaluation.html), inspect the real screenshots and operator evidence, then decide whether Beam is worth more time.
-2. **Prepare the evaluation properly.** Use the [Design-Partner Onboarding Pack](/guide/design-partner-onboarding) to align prerequisites, proof expectations, and next-step language before the call starts.
-3. **Request hosted beta.** If you want a guided rollout around one real partner workflow, use the [Hosted Beta page](https://beam.directory/hosted-beta.html).
-4. **Run the technical proof yourself.** Use the [Hosted Quickstart](/guide/hosted-quickstart) when you want to self-run the same baseline locally.
+2. **Check the exact workflow contract.** Open the [First Production Partner Workflow Contract](/guide/production-partner-workflow) to see the named sender, recipient, latency, failure handling, and proof contract for `1.0.0`.
+3. **Prepare the evaluation properly.** Use the [Production Partner Onboarding Pack](/guide/design-partner-onboarding) to align prerequisites, proof expectations, and next-step language before the call starts.
+4. **Request hosted beta.** If you want a guided rollout around one real partner workflow, use the [Hosted Beta page](https://beam.directory/hosted-beta.html).
+5. **Run the technical proof yourself.** Use the [Hosted Quickstart](/guide/hosted-quickstart) when you want to self-run the same baseline locally.
 
 ## What Beam Is For
 
@@ -65,7 +68,9 @@ If that is your problem, Beam is aimed directly at it. If it is not, Beam should
 ## Continue
 
 - [Guided Evaluation](https://beam.directory/guided-evaluation.html)
-- [Design-Partner Onboarding Pack](/guide/design-partner-onboarding)
+- [First Production Partner Workflow Contract](/guide/production-partner-workflow)
+- [Production Partner Onboarding Pack](/guide/design-partner-onboarding)
+- [Production Go-Live Checklist](/guide/production-go-live-checklist)
 - [Hosted Quickstart](/guide/hosted-quickstart)
 - [Register a Real Agent](https://beam.directory/register.html)
 - [Partner Handoff Guide](/guide/partner-handoff)

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -575,6 +575,7 @@ export interface BetaRequest {
   lastContactAt: string | null
   nextMeetingAt: string | null
   reminderAt: string | null
+  blockedPrerequisites: string[]
   stageEnteredAt: string
   stageAgeHours: number
   stageAgeLabel: string
@@ -696,6 +697,7 @@ export interface BetaRequestUpdateInput {
   nextMeetingAt?: string | null
   reminderAt?: string | null
   proofIntentNonce?: string | null
+  blockedPrerequisites?: string[] | null
 }
 
 export interface BetaRequestUpdateResponse {

--- a/packages/dashboard/src/pages/BetaRequestsPage.tsx
+++ b/packages/dashboard/src/pages/BetaRequestsPage.tsx
@@ -45,7 +45,17 @@ const SORT_OPTIONS = [
 type SortOption = typeof SORT_OPTIONS[number]['value']
 
 const ONBOARDING_PACK_URL = 'https://docs.beam.directory/guide/design-partner-onboarding'
+const WORKFLOW_CONTRACT_URL = 'https://docs.beam.directory/guide/production-partner-workflow'
+const GO_LIVE_CHECKLIST_URL = 'https://docs.beam.directory/guide/production-go-live-checklist'
 const GUIDED_EVALUATION_URL = 'https://beam.directory/guided-evaluation.html'
+const BLOCKED_PREREQUISITES = [
+  { value: 'workflow_owner_confirmed', label: 'Workflow owner confirmed', detail: 'The buyer-side business owner is named and reachable.' },
+  { value: 'sender_receiver_confirmed', label: 'Sender and receiver confirmed', detail: 'The first sender and first receiving system are fixed.' },
+  { value: 'success_metric_confirmed', label: 'Success metric confirmed', detail: 'The pilot has one explicit success condition.' },
+  { value: 'security_review_confirmed', label: 'Security review confirmed', detail: 'The compliance and security expectations are agreed.' },
+  { value: 'go_live_window_confirmed', label: 'Go-live window confirmed', detail: 'The first live rollout window is scheduled and owned.' },
+  { value: 'proof_recipients_confirmed', label: 'Proof recipients confirmed', detail: 'Both sides know who will receive the proof pack and recap.' },
+] as const
 
 export default function BetaRequestsPage() {
   const { session } = useAdminAuth()
@@ -92,6 +102,7 @@ export default function BetaRequestsPage() {
   const [draftNextMeetingAt, setDraftNextMeetingAt] = useState('')
   const [draftReminderAt, setDraftReminderAt] = useState('')
   const [draftProofIntentNonce, setDraftProofIntentNonce] = useState('')
+  const [draftBlockedPrerequisites, setDraftBlockedPrerequisites] = useState<string[]>([])
   const [draftNotes, setDraftNotes] = useState('')
 
   function updateSearchParam(key: string, value: string) {
@@ -125,6 +136,7 @@ export default function BetaRequestsPage() {
       setDraftNextMeetingAt('')
       setDraftReminderAt('')
       setDraftProofIntentNonce('')
+      setDraftBlockedPrerequisites([])
       setDraftNotes('')
       return
     }
@@ -136,6 +148,7 @@ export default function BetaRequestsPage() {
     setDraftNextMeetingAt(toDateTimeLocalValue(detailRequest.nextMeetingAt))
     setDraftReminderAt(toDateTimeLocalValue(detailRequest.reminderAt))
     setDraftProofIntentNonce(detailRequest.proofIntentNonce ?? '')
+    setDraftBlockedPrerequisites(detailRequest.blockedPrerequisites ?? [])
     setDraftNotes(detailRequest.operatorNotes ?? '')
   }, [detailRequest])
 
@@ -206,6 +219,7 @@ export default function BetaRequestsPage() {
         nextMeetingAt: draftNextMeetingAt || null,
         reminderAt: draftReminderAt || null,
         proofIntentNonce: draftProofIntentNonce || null,
+        blockedPrerequisites: draftBlockedPrerequisites,
         operatorNotes: draftNotes || null,
       })
       setRequests((current) => current.map((entry) => (
@@ -369,6 +383,9 @@ export default function BetaRequestsPage() {
                     <div className="flex flex-wrap items-center gap-2">
                       <StatusPill label={entry.stage} tone={stageTone(entry.stage)} />
                       {entry.notificationStatus ? <StatusPill label={`signal ${entry.notificationStatus}`} tone={signalTone(entry.notificationStatus)} /> : null}
+                      {entry.blockedPrerequisites.length > 0 ? (
+                        <StatusPill label={`blocked ${entry.blockedPrerequisites.length}`} tone="warning" />
+                      ) : null}
                       {entry.attentionFlags.map((flag) => (
                         <StatusPill key={`${entry.id}-${flag}`} label={formatAttentionFlag(flag)} tone={flag === 'unowned' ? 'critical' : 'warning'} />
                       ))}
@@ -453,6 +470,36 @@ export default function BetaRequestsPage() {
                       </Link>
                     </div>
                   ) : null}
+                </div>
+
+                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Production workflow contract</div>
+                  <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                    Beam `1.0.0` is anchored on the quote approval handoff. Every production-partner request should map back to that contract before go-live.
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-3">
+                    <a className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" href={WORKFLOW_CONTRACT_URL} rel="noreferrer" target="_blank">
+                      Open workflow contract
+                    </a>
+                    <a className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" href={GO_LIVE_CHECKLIST_URL} rel="noreferrer" target="_blank">
+                      Open go-live checklist
+                    </a>
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Blocked go-live prerequisites</div>
+                  {detailRequest.blockedPrerequisites.length === 0 ? (
+                    <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                      No blocked prerequisites are recorded for this partner yet.
+                    </div>
+                  ) : (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {detailRequest.blockedPrerequisites.map((entry) => (
+                        <StatusPill key={entry} label={formatBlockedPrerequisiteLabel(entry)} tone="warning" />
+                      ))}
+                    </div>
+                  )}
                 </div>
 
                 {detailRequest.staleReason || detailRequest.followUpReason ? (
@@ -667,6 +714,41 @@ export default function BetaRequestsPage() {
                   </span>
                 </label>
 
+                <div className="space-y-3 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div>
+                    <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Blocked go-live prerequisites</div>
+                    <div className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                      Mark the specific items that still block a production rollout. Clear them when the partner is ready.
+                    </div>
+                  </div>
+                  <div className="grid gap-3">
+                    {BLOCKED_PREREQUISITES.map((entry) => {
+                      const checked = draftBlockedPrerequisites.includes(entry.value)
+                      return (
+                        <label key={entry.value} className="flex items-start gap-3 rounded-xl border border-slate-200 px-3 py-3 text-sm dark:border-slate-800">
+                          <input
+                            checked={checked}
+                            className="mt-1 h-4 w-4"
+                            disabled={!canEdit || saving}
+                            onChange={() => {
+                              setDraftBlockedPrerequisites((current) => (
+                                current.includes(entry.value)
+                                  ? current.filter((item) => item !== entry.value)
+                                  : [...current, entry.value]
+                              ))
+                            }}
+                            type="checkbox"
+                          />
+                          <span className="space-y-1">
+                            <span className="block font-medium text-slate-900 dark:text-slate-100">{entry.label}</span>
+                            <span className="block text-slate-500 dark:text-slate-400">{entry.detail}</span>
+                          </span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                </div>
+
                 <div className="flex flex-wrap gap-3">
                   {session?.email ? (
                     <button
@@ -736,6 +818,15 @@ export default function BetaRequestsPage() {
                     <CheckCircle2 size={16} />
                     <span>Mark follow-up active</span>
                   </button>
+                  <button
+                    className="btn-secondary"
+                    disabled={!canEdit || saving || draftBlockedPrerequisites.length === 0}
+                    onClick={() => setDraftBlockedPrerequisites([])}
+                    type="button"
+                  >
+                    <CheckCircle2 size={16} />
+                    <span>Clear blockers</span>
+                  </button>
                 </div>
 
                 <label className="block space-y-2">
@@ -771,9 +862,17 @@ export default function BetaRequestsPage() {
           <div className="panel space-y-4">
             <div className="panel-title">Onboarding pack</div>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Keep external evaluations on the same script: public proof first, then the onboarding pack, then the stage-specific follow-up template.
+              Keep production-partner work on the same script: workflow contract first, then the onboarding pack, then the operator go-live checklist.
             </p>
             <div className="grid gap-3">
+              <a
+                className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
+                href={WORKFLOW_CONTRACT_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open workflow contract
+              </a>
               <a
                 className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
                 href={GUIDED_EVALUATION_URL}
@@ -789,6 +888,14 @@ export default function BetaRequestsPage() {
                 target="_blank"
               >
                 Open onboarding pack
+              </a>
+              <a
+                className="rounded-xl border border-slate-200 px-4 py-3 text-sm font-medium text-slate-900 transition hover:border-orange-300 hover:bg-orange-50 dark:border-slate-800 dark:text-slate-100 dark:hover:border-orange-400/40 dark:hover:bg-orange-500/10"
+                href={GO_LIVE_CHECKLIST_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Open go-live checklist
               </a>
               {detailRequest ? (
                 <a
@@ -838,6 +945,25 @@ function formatAttentionFlag(flag: BetaRequestAttention): string {
     case 'stale':
     default:
       return 'stale'
+  }
+}
+
+function formatBlockedPrerequisiteLabel(value: string): string {
+  switch (value) {
+    case 'workflow_owner_confirmed':
+      return 'workflow owner confirmed'
+    case 'sender_receiver_confirmed':
+      return 'sender and receiver confirmed'
+    case 'success_metric_confirmed':
+      return 'success metric confirmed'
+    case 'security_review_confirmed':
+      return 'security review confirmed'
+    case 'go_live_window_confirmed':
+      return 'go-live window confirmed'
+    case 'proof_recipients_confirmed':
+      return 'proof recipients confirmed'
+    default:
+      return value.split('_').join(' ')
   }
 }
 

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -255,11 +255,12 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.ok(waitlistColumns.some((column) => column.name === 'last_contact_at'))
     assert.ok(waitlistColumns.some((column) => column.name === 'next_meeting_at'))
     assert.ok(waitlistColumns.some((column) => column.name === 'reminder_at'))
+    assert.ok(waitlistColumns.some((column) => column.name === 'blocked_prerequisites'))
     assert.ok(waitlistColumns.some((column) => column.name === 'stage_entered_at'))
     assert.ok(waitlistColumns.some((column) => column.name === 'updated_at'))
 
     const waitlistRow = db.prepare(`
-      SELECT email, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, stage_entered_at, updated_at, created_at
+      SELECT email, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, blocked_prerequisites, stage_entered_at, updated_at, created_at
       FROM waitlist
       LIMIT 1
     `).get() as {
@@ -271,6 +272,7 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
       last_contact_at: string | null
       next_meeting_at: string | null
       reminder_at: string | null
+      blocked_prerequisites: string | null
       stage_entered_at: string
       updated_at: string
       created_at: string
@@ -285,6 +287,7 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     assert.equal(waitlistRow?.last_contact_at ?? null, null)
     assert.equal(waitlistRow?.next_meeting_at ?? null, null)
     assert.equal(waitlistRow?.reminder_at ?? null, null)
+    assert.equal(waitlistRow?.blocked_prerequisites ?? null, null)
     assert.equal(waitlistRow?.stage_entered_at, waitlistRow?.created_at)
     assert.equal(waitlistRow?.updated_at, waitlistRow?.created_at)
 

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -167,6 +167,7 @@ function initSchema(db: DB): void {
       operator_notes TEXT,
       next_action TEXT,
       last_contact_at TEXT,
+      blocked_prerequisites TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -533,6 +534,7 @@ function initSchema(db: DB): void {
   ensureColumn(db, 'waitlist', 'last_contact_at', 'TEXT')
   ensureColumn(db, 'waitlist', 'next_meeting_at', 'TEXT')
   ensureColumn(db, 'waitlist', 'reminder_at', 'TEXT')
+  ensureColumn(db, 'waitlist', 'blocked_prerequisites', 'TEXT')
   ensureColumn(db, 'waitlist', 'stage_entered_at', 'TEXT')
   ensureColumn(db, 'waitlist', 'updated_at', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_waitlist_status ON waitlist(status, created_at DESC)')

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -611,6 +611,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         status: 'reviewing',
         owner: 'operator@example.com',
         operatorNotes: 'Intro email sent, follow-up call pending.',
+        blockedPrerequisites: ['workflow_owner_confirmed', 'security_review_confirmed'],
       }),
     }))
     assert.equal(updateResponse.status, 200)
@@ -624,6 +625,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         operatorNotes: string
         notificationStatus: string
         attentionFlags: string[]
+        blockedPrerequisites: string[]
       }
     }
     assert.equal(updated.ok, true)
@@ -633,6 +635,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.match(updated.request.operatorNotes, /Intro email/)
     assert.equal(updated.request.notificationStatus, 'acknowledged')
     assert.deepEqual(updated.request.attentionFlags, [])
+    assert.deepEqual(updated.request.blockedPrerequisites, ['workflow_owner_confirmed', 'security_review_confirmed'])
 
     const proofNonce = 'pilot-proof-demo-0001'
     registerAgent(db, {
@@ -745,6 +748,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         nextMeetingAt: meetingTimestamp,
         reminderAt: reminderTimestamp,
         proofIntentNonce: proofNonce,
+        blockedPrerequisites: ['go_live_window_confirmed'],
       }),
     }))
     assert.equal(contactResponse.status, 200)
@@ -760,6 +764,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         proofIntentNonce: string | null
         notificationStatus: string
         attentionFlags: string[]
+        blockedPrerequisites: string[]
       }
     }
     assert.equal(contacted.ok, true)
@@ -771,6 +776,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(contacted.request.proofIntentNonce, proofNonce)
     assert.equal(contacted.request.notificationStatus, 'acted')
     assert.deepEqual(contacted.request.attentionFlags, ['follow_up_due'])
+    assert.deepEqual(contacted.request.blockedPrerequisites, ['go_live_window_confirmed'])
 
     const detailResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
@@ -783,6 +789,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
         stage: string
         proofIntentNonce: string | null
         notificationStatus: string | null
+        blockedPrerequisites: string[]
       }
       activity: Array<{
         title: string
@@ -820,6 +827,7 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
     assert.equal(detail.request.stage, 'scheduled')
     assert.equal(detail.request.proofIntentNonce, proofNonce)
     assert.equal(detail.request.notificationStatus, 'acted')
+    assert.deepEqual(detail.request.blockedPrerequisites, ['go_live_window_confirmed'])
     assert.ok(detail.activity.length >= 6)
     assert.ok(detail.activity.some((entry) => entry.title === 'Hosted beta request captured'))
     assert.ok(detail.activity.some((entry) => entry.title === 'Stage moved to Scheduled'))

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -78,6 +78,13 @@ type WaitlistSignupInput = {
 
 type BetaRequestStatus = 'new' | 'reviewing' | 'contacted' | 'scheduled' | 'active' | 'closed'
 type BetaRequestAttention = 'unowned' | 'stale' | 'follow_up_due'
+type BetaRequestBlockedPrerequisite =
+  | 'workflow_owner_confirmed'
+  | 'sender_receiver_confirmed'
+  | 'success_metric_confirmed'
+  | 'security_review_confirmed'
+  | 'go_live_window_confirmed'
+  | 'proof_recipients_confirmed'
 type BetaRequestSort = 'attention' | 'updated_desc' | 'created_desc' | 'stage' | 'owner' | 'last_contact_desc'
 type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 type OperatorNotificationSource = 'beta_request' | 'critical_alert'
@@ -115,6 +122,7 @@ type BetaRequestUpdateInput = {
   nextMeetingAt?: string | null
   reminderAt?: string | null
   proofIntentNonce?: string | null
+  blockedPrerequisites?: BetaRequestBlockedPrerequisite[] | null
 }
 
 type BetaRequestFilters = {
@@ -162,6 +170,7 @@ type WaitlistRow = {
   last_contact_at: string | null
   next_meeting_at: string | null
   reminder_at: string | null
+  blocked_prerequisites: string | null
   stage_entered_at: string | null
   created_at: string
   updated_at: string
@@ -227,6 +236,15 @@ const BETA_REQUEST_STATUS_SET = new Set<string>(BETA_REQUEST_STATUSES)
 const BETA_REQUEST_SORTS: BetaRequestSort[] = ['attention', 'updated_desc', 'created_desc', 'stage', 'owner', 'last_contact_desc']
 const BETA_REQUEST_SORT_SET = new Set<string>(BETA_REQUEST_SORTS)
 const BETA_REQUEST_ATTENTION_SET = new Set<BetaRequestAttention>(['unowned', 'stale', 'follow_up_due'])
+const BETA_REQUEST_BLOCKED_PREREQUISITES: BetaRequestBlockedPrerequisite[] = [
+  'workflow_owner_confirmed',
+  'sender_receiver_confirmed',
+  'success_metric_confirmed',
+  'security_review_confirmed',
+  'go_live_window_confirmed',
+  'proof_recipients_confirmed',
+]
+const BETA_REQUEST_BLOCKED_PREREQUISITE_SET = new Set<string>(BETA_REQUEST_BLOCKED_PREREQUISITES)
 const OPERATOR_NOTIFICATION_STATUSES: OperatorNotificationStatus[] = ['new', 'acknowledged', 'acted']
 const OPERATOR_NOTIFICATION_STATUS_SET = new Set<string>(OPERATOR_NOTIFICATION_STATUSES)
 const OPERATOR_NOTIFICATION_SOURCES: OperatorNotificationSource[] = ['beta_request', 'critical_alert']
@@ -345,6 +363,80 @@ function normalizeBetaRequestSort(value: unknown): BetaRequestSort {
   }
 
   return normalized as BetaRequestSort
+}
+
+function normalizeBlockedPrerequisites(value: unknown): BetaRequestBlockedPrerequisite[] | null {
+  if (value == null) {
+    return []
+  }
+
+  if (!Array.isArray(value)) {
+    return null
+  }
+
+  const normalized: BetaRequestBlockedPrerequisite[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'string') {
+      return null
+    }
+
+    const next = entry.trim().toLowerCase()
+    if (!BETA_REQUEST_BLOCKED_PREREQUISITE_SET.has(next)) {
+      return null
+    }
+
+    if (!normalized.includes(next as BetaRequestBlockedPrerequisite)) {
+      normalized.push(next as BetaRequestBlockedPrerequisite)
+    }
+  }
+
+  return normalized
+}
+
+function parseBlockedPrerequisites(value: string | null | undefined): BetaRequestBlockedPrerequisite[] {
+  if (!value) {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed.filter((entry): entry is BetaRequestBlockedPrerequisite => (
+      typeof entry === 'string' && BETA_REQUEST_BLOCKED_PREREQUISITE_SET.has(entry)
+    ))
+  } catch {
+    return []
+  }
+}
+
+function serializeBlockedPrerequisites(value: BetaRequestBlockedPrerequisite[] | null | undefined): string | null {
+  if (!value || value.length === 0) {
+    return null
+  }
+
+  return JSON.stringify(value)
+}
+
+function formatBlockedPrerequisiteLabel(value: BetaRequestBlockedPrerequisite): string {
+  switch (value) {
+    case 'workflow_owner_confirmed':
+      return 'workflow owner confirmed'
+    case 'sender_receiver_confirmed':
+      return 'sender and receiver confirmed'
+    case 'success_metric_confirmed':
+      return 'success metric confirmed'
+    case 'security_review_confirmed':
+      return 'security review confirmed'
+    case 'go_live_window_confirmed':
+      return 'go-live window confirmed'
+    case 'proof_recipients_confirmed':
+      return 'proof recipients confirmed'
+    default:
+      return String(value).split('_').join(' ')
+  }
 }
 
 function normalizeOperatorNotificationStatus(value: unknown): OperatorNotificationStatus | null {
@@ -592,6 +684,7 @@ function serializeBetaRequest(
 ) {
   const attention = getBetaRequestAttention(row)
   const nextAction = row.next_action ?? getBetaRequestNextStep(row.status)
+  const blockedPrerequisites = parseBlockedPrerequisites(row.blocked_prerequisites)
   return {
     id: row.id,
     email: row.email,
@@ -609,6 +702,7 @@ function serializeBetaRequest(
     lastContactAt: row.last_contact_at,
     nextMeetingAt: row.next_meeting_at,
     reminderAt: row.reminder_at,
+    blockedPrerequisites,
     stageEnteredAt: attention.stageEnteredAt,
     stageAgeHours: attention.stageAgeHours,
     stageAgeLabel: attention.stageAgeLabel,
@@ -687,6 +781,15 @@ function describeBetaRequestAuditEntry(log: AuditLogRow): BetaRequestActivityEnt
     detailParts.push('Pilot proof trace updated.')
   }
 
+  if (details?.blockedPrerequisitesChanged === true) {
+    const count = typeof details?.blockedPrerequisiteCount === 'number' ? details.blockedPrerequisiteCount : null
+    detailParts.push(
+      count && count > 0
+        ? `Go-live blockers: ${count}.`
+        : 'Go-live blockers cleared.',
+    )
+  }
+
   let kind: BetaRequestActivityKind = 'request_updated'
   let title = 'Operator updated the partner request'
   let tone: BetaRequestActivityTone = 'default'
@@ -705,6 +808,9 @@ function describeBetaRequestAuditEntry(log: AuditLogRow): BetaRequestActivityEnt
   } else if (details?.reminderChanged === true) {
     kind = 'reminder'
     title = 'Follow-up reminder changed'
+    tone = 'warning'
+  } else if (details?.blockedPrerequisitesChanged === true) {
+    title = 'Go-live blockers updated'
     tone = 'warning'
   }
 
@@ -856,6 +962,21 @@ function buildBetaRequestActivityTimeline(
       tone: reminderDue ? 'warning' : 'default',
       href: requestHref,
       upcoming: !reminderDue,
+    })
+  }
+
+  const blockedPrerequisites = parseBlockedPrerequisites(row.blocked_prerequisites)
+  if (blockedPrerequisites.length > 0) {
+    activities.push({
+      key: `request-${row.id}-blocked-${row.updated_at}`,
+      kind: 'request_updated',
+      timestamp: row.updated_at,
+      title: 'Go-live blockers recorded',
+      detail: `Still blocked on ${blockedPrerequisites.map(formatBlockedPrerequisiteLabel).join(', ')}.`,
+      actor: row.owner,
+      tone: 'warning',
+      href: requestHref,
+      upcoming: false,
     })
   }
 
@@ -1329,6 +1450,7 @@ function listBetaRequestRows(db: Database, filters: {
       last_contact_at,
       next_meeting_at,
       reminder_at,
+      blocked_prerequisites,
       stage_entered_at,
       created_at,
       updated_at
@@ -1368,6 +1490,7 @@ function getBetaRequestById(db: Database, id: number): WaitlistRow | null {
       last_contact_at,
       next_meeting_at,
       reminder_at,
+      blocked_prerequisites,
       stage_entered_at,
       created_at,
       updated_at
@@ -1397,6 +1520,7 @@ function listPartnerAnalyticsRows(db: Database, sinceIso: string): WaitlistRow[]
       last_contact_at,
       next_meeting_at,
       reminder_at,
+      blocked_prerequisites,
       stage_entered_at,
       created_at,
       updated_at
@@ -1515,6 +1639,7 @@ function buildBetaRequestCsv(
     'last_contact_at',
     'next_meeting_at',
     'reminder_at',
+    'blocked_prerequisites',
     'stage_entered_at',
     'stage_age_hours',
     'follow_up_due',
@@ -1545,6 +1670,7 @@ function buildBetaRequestCsv(
       row.last_contact_at,
       row.next_meeting_at,
       row.reminder_at,
+      parseBlockedPrerequisites(row.blocked_prerequisites).join('|'),
       getBetaRequestStageTimestamp(row),
       attention.stageAgeHours.toFixed(1),
       attention.followUpDue ? 'true' : 'false',
@@ -2848,6 +2974,14 @@ export function createApp(db: Database): Hono {
       patch.proofIntentNonce = proofIntentNonce
     }
 
+    if ('blockedPrerequisites' in raw) {
+      const blockedPrerequisites = normalizeBlockedPrerequisites(raw.blockedPrerequisites)
+      if (raw.blockedPrerequisites !== null && !blockedPrerequisites) {
+        return c.json({ error: 'Invalid blockedPrerequisites', errorCode: 'INVALID_BLOCKED_PREREQUISITES' }, 400)
+      }
+      patch.blockedPrerequisites = blockedPrerequisites ?? []
+    }
+
     if (
       !('status' in patch)
       && !('owner' in patch)
@@ -2857,6 +2991,7 @@ export function createApp(db: Database): Hono {
       && !('nextMeetingAt' in patch)
       && !('reminderAt' in patch)
       && !('proofIntentNonce' in patch)
+      && !('blockedPrerequisites' in patch)
     ) {
       return c.json({ error: 'No supported fields to update', errorCode: 'EMPTY_PATCH' }, 400)
     }
@@ -2875,6 +3010,9 @@ export function createApp(db: Database): Hono {
       const nextMeetingAt = 'nextMeetingAt' in patch ? patch.nextMeetingAt ?? null : existing.next_meeting_at
       const nextReminderAt = 'reminderAt' in patch ? patch.reminderAt ?? null : existing.reminder_at
       const nextProofIntentNonce = 'proofIntentNonce' in patch ? patch.proofIntentNonce ?? null : existing.proof_intent_nonce
+      const nextBlockedPrerequisites = 'blockedPrerequisites' in patch
+        ? (patch.blockedPrerequisites ?? [])
+        : parseBlockedPrerequisites(existing.blocked_prerequisites)
       const updatedAt = new Date().toISOString()
       const nextStageEnteredAt = 'status' in patch && patch.status && patch.status !== existing.status
         ? updatedAt
@@ -2890,9 +3028,9 @@ export function createApp(db: Database): Hono {
 
       db.prepare(`
         UPDATE waitlist
-        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, next_meeting_at = ?, reminder_at = ?, proof_intent_nonce = ?, stage_entered_at = ?, updated_at = ?
+        SET status = ?, owner = ?, operator_notes = ?, next_action = ?, last_contact_at = ?, next_meeting_at = ?, reminder_at = ?, proof_intent_nonce = ?, blocked_prerequisites = ?, stage_entered_at = ?, updated_at = ?
         WHERE id = ?
-      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, nextMeetingAt, nextReminderAt, nextProofIntentNonce, nextStageEnteredAt, updatedAt, id)
+      `).run(nextStatus, nextOwner, nextOperatorNotes, nextAction, nextLastContactAt, nextMeetingAt, nextReminderAt, nextProofIntentNonce, serializeBlockedPrerequisites(nextBlockedPrerequisites), nextStageEnteredAt, updatedAt, id)
 
       const updated = getBetaRequestById(db, id)
       if (!updated) {
@@ -2917,6 +3055,9 @@ export function createApp(db: Database): Hono {
           nextMeetingChanged: 'nextMeetingAt' in patch,
           reminderChanged: 'reminderAt' in patch,
           proofIntentChanged: 'proofIntentNonce' in patch,
+          blockedPrerequisitesChanged: 'blockedPrerequisites' in patch,
+          blockedPrerequisiteCount: nextBlockedPrerequisites.length,
+          blockedPrerequisites: nextBlockedPrerequisites,
           proofIntentNonce: nextProofIntentNonce,
         },
       })
@@ -3400,7 +3541,7 @@ export function createApp(db: Database): Hono {
 
     try {
       const existing = db.prepare(`
-        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, stage_entered_at, created_at, updated_at
+        SELECT id, email, source, company, agent_count, workflow_type, workflow_summary, status, owner, operator_notes, next_action, last_contact_at, next_meeting_at, reminder_at, blocked_prerequisites, stage_entered_at, created_at, updated_at
         FROM waitlist
         WHERE email = ?
         ORDER BY created_at DESC, id DESC

--- a/packages/public-site/guided-evaluation.html
+++ b/packages/public-site/guided-evaluation.html
@@ -712,6 +712,7 @@
         <div class="top-links">
           <a href="/">Home</a>
           <a data-beam-cta="guided_eval_hosted_beta_nav" href="/hosted-beta.html">Request pilot</a>
+          <a href="https://docs.beam.directory/guide/production-partner-workflow">Workflow contract</a>
           <a class="primary" data-beam-cta="guided_eval_onboarding_nav" href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
         </div>
       </nav>
@@ -747,6 +748,10 @@
             <div class="hero-point">
               <strong>One workflow, one proof pack, one next step</strong>
               <span>The goal is not a platform tour. The goal is to decide whether one handoff deserves a real pilot and to leave with something you can share internally.</span>
+            </div>
+            <div class="hero-point">
+              <strong>One named production contract</strong>
+              <span>The current Beam production path is the <a href="https://docs.beam.directory/guide/production-partner-workflow">Quote Approval Partner Handoff</a>.</span>
             </div>
           </div>
         </div>
@@ -924,6 +929,7 @@
 
           <div class="proof-links">
             <a class="btn btn-primary" data-beam-cta="guided_eval_hosted_beta_proof" href="/hosted-beta.html">Request a guided pilot</a>
+            <a class="btn btn-ghost" href="https://docs.beam.directory/guide/production-partner-workflow">Open workflow contract</a>
             <a class="btn btn-ghost" data-beam-cta="guided_eval_onboarding_proof" href="https://docs.beam.directory/guide/design-partner-onboarding">Open full onboarding pack</a>
           </div>
         </div>
@@ -950,6 +956,7 @@
       <div>Beam Protocol · guided evaluation path for cross-company AI work</div>
       <div class="footer-links">
         <a href="/hosted-beta.html">Hosted beta</a>
+        <a href="https://docs.beam.directory/guide/production-partner-workflow">Workflow contract</a>
         <a href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
         <a href="https://docs.beam.directory">Docs</a>
       </div>

--- a/packages/public-site/hosted-beta.html
+++ b/packages/public-site/hosted-beta.html
@@ -708,6 +708,7 @@
 
         <div class="top-links">
           <a data-beam-cta="hosted_beta_guided_eval_nav" href="/guided-evaluation.html">Guided evaluation</a>
+          <a href="https://docs.beam.directory/guide/production-partner-workflow">Workflow contract</a>
           <a href="https://docs.beam.directory/guide/design-partner-onboarding">Onboarding pack</a>
           <a class="primary" href="#faq">Common questions</a>
         </div>
@@ -724,7 +725,7 @@
           <p>
             If your AI needs another company's AI to do something real, Beam can scope a small
             pilot around that handoff. We start narrow, prove it, write down the recap, and only
-            expand if the first pilot earns a bigger footprint.
+            expand if the first pilot earns a bigger footprint. The `1.0.0` production contract is the <a href="https://docs.beam.directory/guide/production-partner-workflow">Quote Approval Partner Handoff</a>.
           </p>
           <ul>
             <li>One workflow first, not a platform rollout.</li>
@@ -894,6 +895,7 @@
                 <li>What happens after the call if the fit is real</li>
               </ul>
               <div class="submit-row" style="margin-top: 18px;">
+                <a class="btn ghost" href="https://docs.beam.directory/guide/production-partner-workflow">Open workflow contract</a>
                 <a class="btn ghost" href="https://docs.beam.directory/guide/design-partner-onboarding">Open onboarding pack</a>
               </div>
             </div>

--- a/packages/public-site/index.html
+++ b/packages/public-site/index.html
@@ -1639,6 +1639,7 @@
         <li><a href="#paths">Next step</a></li>
         <li><a href="#faq">FAQ</a></li>
         <li><a href="/guided-evaluation.html">Guided eval</a></li>
+        <li><a href="https://docs.beam.directory/guide/production-partner-workflow" target="_blank" rel="noreferrer">Workflow contract</a></li>
         <li><a href="https://docs.beam.directory" target="_blank" rel="noreferrer">Docs</a></li>
         <li><a href="https://github.com/Beam-directory/beam-protocol" target="_blank" rel="noreferrer">GitHub</a></li>
       </ul>
@@ -1682,6 +1683,10 @@
             <div class="proof-item">
               <strong>Leave with a pilot proof pack</strong>
               <span>Beam is strongest when the first conversation ends with a recap, proof links, and one next decision.</span>
+            </div>
+            <div class="proof-item">
+              <strong>Current 1.0.0 workflow contract</strong>
+              <span><a href="https://docs.beam.directory/guide/production-partner-workflow" target="_blank" rel="noreferrer">Quote Approval Partner Handoff</a> is the named production path Beam is optimizing for.</span>
             </div>
           </div>
         </div>
@@ -1772,7 +1777,7 @@
           <p>
             Use Beam when your AI needs another company's AI to do something real: quote stock,
             confirm delivery, route support, or ask for approval. Start with one handoff, not a
-            platform rollout.
+            platform rollout. The current production contract is the <a href="https://docs.beam.directory/guide/production-partner-workflow" target="_blank" rel="noreferrer">Quote Approval Partner Handoff</a>.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- define the first production partner workflow contract and exit criteria
- add a production onboarding pack and go-live checklist to the docs and public funnel
- let operators track blocked go-live prerequisites on hosted beta requests

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build

Closes #101
Closes #102