### PR TITLE
Add Beam Workspace foundation and identity bindings

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         { text: 'First Production Partner Workflow', link: '/guide/production-partner-workflow' },
         { text: 'Production Partner Onboarding Pack', link: '/guide/design-partner-onboarding' },
         { text: 'Production Go-Live Checklist', link: '/guide/production-go-live-checklist' },
+        { text: 'Beam Workspaces', link: '/guide/beam-workspaces' },
         { text: 'Getting Started', link: '/guide/getting-started' },
         { text: 'Hosted Quickstart', link: '/guide/hosted-quickstart' },
         { text: 'Compatibility', link: '/guide/compatibility' },

--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -1,0 +1,101 @@
+# Beam Workspaces
+
+Beam Workspaces are the identity and control-plane layer for teams that need more than a raw agent directory.
+
+The goal is not to clone a generic chat workspace. The goal is to give operators one place to answer four questions:
+
+1. Which Beam identities belong to this team?
+2. Which identities are allowed to initiate external handoffs?
+3. Which partner channels and policies apply to this workspace?
+4. Who owns the operational state when a partner-facing workflow stalls?
+
+## The First Data Model
+
+The first workspace foundation adds these records to the directory:
+
+- `workspaces`
+  - named control-plane containers for a team or company workflow
+- `workspace_members`
+  - humans, agents, services, or partner principals attached to a workspace
+- `workspace_identity_bindings`
+  - Beam identities that are active inside the workspace roster
+- `workspace_partner_channels`
+  - explicit partner relationships reserved for later routing and health surfaces
+- `workspace_policies`
+  - the future policy document for external initiation and approval rules
+
+In the first slice, the operator-facing API focuses on workspaces and identity bindings. Partner channels, overview surfaces, and policy enforcement are reserved for the next milestone issues.
+
+## Why Beam Needs This
+
+Beam already has strong external handoff mechanics: identity, signatures, traces, retries, audit, and operator visibility.
+
+What it did not have was a first-class answer to:
+
+- which identities belong together as one operational unit
+- which identity can speak for a given workflow
+- which workspace is responsible for a partner-facing action
+
+Beam Workspaces close that gap.
+
+## Current Admin API
+
+The first routes are all admin-authenticated:
+
+- `GET /admin/workspaces`
+- `POST /admin/workspaces`
+- `GET /admin/workspaces/:slug`
+- `GET /admin/workspaces/:slug/identities`
+- `POST /admin/workspaces/:slug/identities`
+- `PATCH /admin/workspaces/:slug/identities/:id`
+
+### Create a workspace
+
+```json
+{
+  "name": "Acme Ops Workspace",
+  "slug": "acme-ops",
+  "description": "Control plane for internal and partner-facing identities.",
+  "defaultThreadScope": "internal",
+  "externalHandoffsEnabled": true
+}
+```
+
+### Bind a Beam identity
+
+```json
+{
+  "beamId": "ops-bot@beam.directory",
+  "bindingType": "agent",
+  "owner": "ops@example.com",
+  "runtimeType": "codex",
+  "policyProfile": "default",
+  "defaultThreadScope": "internal",
+  "canInitiateExternal": true,
+  "notes": "Primary internal operator agent."
+}
+```
+
+## Design Boundary
+
+Beam Workspaces are intentionally narrower than products like OpenAgents Workspace.
+
+Beam is not trying to be the full shared browser, shared files, runtime launcher, and collaboration surface in the first slice.
+
+The differentiator is:
+
+- identity ownership
+- external handoff control
+- auditability
+- policy and operator accountability
+
+That is why Workspaces start as a control-plane surface first.
+
+## What Comes Next
+
+The next issues in the workspace milestone add:
+
+1. richer identity binding and roster behavior
+2. a workspace overview API and dashboard page
+3. internal vs external thread modeling
+4. policy engine v1 for external initiation and approval requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,8 @@ Use the docs when you need one of these supporting paths:
 2. The [Production Partner Onboarding Pack](/guide/design-partner-onboarding) for prerequisites, proof expectations, and operator follow-up templates.
 3. The [Production Go-Live Checklist](/guide/production-go-live-checklist) if the workflow is moving from pilot to production.
 4. The [Hosted Quickstart](/guide/hosted-quickstart) if you want to run the same proof stack locally.
-5. The [Register page](https://beam.directory/register.html) once the use case is real and you want to wire your own agent.
+5. The [Beam Workspaces guide](/guide/beam-workspaces) if you want the first identity and control-plane model for teams, agents, and partner-facing access.
+6. The [Register page](https://beam.directory/register.html) once the use case is real and you want to wire your own agent.
 
 ## Choose Your Path
 
@@ -71,6 +72,7 @@ If that is your problem, Beam is aimed directly at it. If it is not, Beam should
 - [First Production Partner Workflow Contract](/guide/production-partner-workflow)
 - [Production Partner Onboarding Pack](/guide/design-partner-onboarding)
 - [Production Go-Live Checklist](/guide/production-go-live-checklist)
+- [Beam Workspaces](/guide/beam-workspaces)
 - [Hosted Quickstart](/guide/hosted-quickstart)
 - [Register a Real Agent](https://beam.directory/register.html)
 - [Partner Handoff Guide](/guide/partner-handoff)

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -325,3 +325,72 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
     rmSync(root, { force: true, recursive: true })
   }
 })
+
+test('createDatabase adds beam workspace foundation tables to legacy databases', () => {
+  const { root, dbPath } = createTempDbPath()
+  const legacyDb = new Database(dbPath)
+
+  try {
+    legacyDb.exec(`
+      CREATE TABLE agents (
+        beam_id TEXT PRIMARY KEY,
+        org TEXT,
+        personal INTEGER NOT NULL DEFAULT 0,
+        display_name TEXT NOT NULL,
+        capabilities TEXT NOT NULL DEFAULT '[]',
+        public_key TEXT NOT NULL,
+        api_key_hash TEXT,
+        email TEXT,
+        email_verified INTEGER NOT NULL DEFAULT 0,
+        description TEXT,
+        logo_url TEXT,
+        website TEXT,
+        trust_score REAL NOT NULL DEFAULT 0.5,
+        verified INTEGER NOT NULL DEFAULT 0,
+        verification_tier TEXT NOT NULL DEFAULT 'basic',
+        email_token TEXT,
+        created_at TEXT NOT NULL,
+        last_seen TEXT NOT NULL
+      );
+    `)
+  } finally {
+    legacyDb.close()
+  }
+
+  const db = createDatabase(dbPath)
+
+  try {
+    const tables = db.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'table'
+        AND name IN (
+          'workspaces',
+          'workspace_members',
+          'workspace_identity_bindings',
+          'workspace_partner_channels',
+          'workspace_policies'
+        )
+      ORDER BY name ASC
+    `).all() as Array<{ name: string }>
+
+    assert.deepEqual(
+      tables.map((row) => row.name),
+      [
+        'workspace_identity_bindings',
+        'workspace_members',
+        'workspace_partner_channels',
+        'workspace_policies',
+        'workspaces',
+      ],
+    )
+
+    const bindingColumns = db.prepare('PRAGMA table_info(workspace_identity_bindings)').all() as Array<{ name: string }>
+    assert.ok(bindingColumns.some((column) => column.name === 'default_thread_scope'))
+    assert.ok(bindingColumns.some((column) => column.name === 'can_initiate_external'))
+    assert.ok(bindingColumns.some((column) => column.name === 'runtime_type'))
+  } finally {
+    db.close()
+    rmSync(root, { force: true, recursive: true })
+  }
+})

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -25,6 +25,9 @@ import type {
   ShieldAuditLogRow,
   TrustScoreRow,
   VerificationTier,
+  WorkspaceIdentityBindingRow,
+  WorkspacePolicyRow,
+  WorkspaceRow,
 } from './types.js'
 import { generateDIDDocument, generateDIDDocumentWithKeys, toBeamDID, type DIDDocument } from './did.js'
 import {
@@ -174,6 +177,93 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_waitlist_created_at
       ON waitlist(created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS workspaces (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      slug TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      org_name TEXT,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'paused', 'archived')),
+      default_thread_scope TEXT NOT NULL DEFAULT 'internal' CHECK(default_thread_scope IN ('internal', 'handoff')),
+      external_handoffs_enabled INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (org_name) REFERENCES orgs(name) ON DELETE SET NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspaces_status
+      ON workspaces(status, updated_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_workspaces_org_name
+      ON workspaces(org_name, updated_at DESC);
+
+    CREATE TABLE IF NOT EXISTS workspace_members (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id INTEGER NOT NULL,
+      principal_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL CHECK(principal_type IN ('human', 'agent', 'service', 'partner')),
+      role TEXT NOT NULL CHECK(role IN ('owner', 'operator', 'viewer')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+      UNIQUE(workspace_id, principal_id, principal_type)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_members_workspace
+      ON workspace_members(workspace_id, role, principal_id);
+
+    CREATE TABLE IF NOT EXISTS workspace_identity_bindings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id INTEGER NOT NULL,
+      beam_id TEXT NOT NULL,
+      binding_type TEXT NOT NULL CHECK(binding_type IN ('agent', 'service', 'partner')),
+      owner TEXT,
+      runtime_type TEXT,
+      policy_profile TEXT,
+      default_thread_scope TEXT NOT NULL DEFAULT 'internal' CHECK(default_thread_scope IN ('internal', 'handoff')),
+      can_initiate_external INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'paused')),
+      notes TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+      UNIQUE(workspace_id, beam_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_identity_bindings_workspace
+      ON workspace_identity_bindings(workspace_id, status, beam_id);
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_identity_bindings_beam_id
+      ON workspace_identity_bindings(beam_id, status);
+
+    CREATE TABLE IF NOT EXISTS workspace_partner_channels (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id INTEGER NOT NULL,
+      partner_beam_id TEXT NOT NULL,
+      label TEXT,
+      owner TEXT,
+      status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active', 'trial', 'blocked')),
+      notes TEXT,
+      last_success_at TEXT,
+      last_failure_at TEXT,
+      last_intent_nonce TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+      UNIQUE(workspace_id, partner_beam_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_partner_channels_workspace
+      ON workspace_partner_channels(workspace_id, status, partner_beam_id);
+
+    CREATE TABLE IF NOT EXISTS workspace_policies (
+      workspace_id INTEGER PRIMARY KEY,
+      policy_json TEXT NOT NULL DEFAULT '{}',
+      updated_at TEXT NOT NULL,
+      updated_by TEXT,
+      FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+    );
 
     CREATE TABLE IF NOT EXISTS operator_notifications (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -829,6 +919,277 @@ export function createOrg(
 export function getOrg(db: DB, name: string): OrgRow | null {
   const row = db.prepare('SELECT * FROM orgs WHERE name = ?').get(name) as OrgRow | undefined
   return row ?? null
+}
+
+function ensureWorkspacePolicyRecord(db: DB, workspaceId: number, updatedAt: string, updatedBy: string | null = null): void {
+  db.prepare(`
+    INSERT OR IGNORE INTO workspace_policies (workspace_id, policy_json, updated_at, updated_by)
+    VALUES (?, '{}', ?, ?)
+  `).run(workspaceId, updatedAt, updatedBy)
+}
+
+export function createWorkspace(
+  db: DB,
+  input: {
+    slug: string
+    name: string
+    orgName?: string | null
+    description?: string | null
+    status?: WorkspaceRow['status']
+    defaultThreadScope?: WorkspaceRow['default_thread_scope']
+    externalHandoffsEnabled?: boolean
+  },
+): WorkspaceRow {
+  const now = nowIso()
+
+  const result = db.prepare(`
+    INSERT INTO workspaces (
+      slug,
+      name,
+      org_name,
+      description,
+      status,
+      default_thread_scope,
+      external_handoffs_enabled,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.slug,
+    input.name,
+    input.orgName ?? null,
+    input.description ?? null,
+    input.status ?? 'active',
+    input.defaultThreadScope ?? 'internal',
+    input.externalHandoffsEnabled ? 1 : 0,
+    now,
+    now,
+  )
+
+  const workspace = getWorkspaceById(db, Number(result.lastInsertRowid))
+  if (!workspace) {
+    throw new Error('Workspace insert succeeded but row was not found')
+  }
+
+  ensureWorkspacePolicyRecord(db, workspace.id, now)
+  return workspace
+}
+
+export function getWorkspaceById(db: DB, id: number): WorkspaceRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspaces
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as WorkspaceRow | undefined
+
+  return row ?? null
+}
+
+export function getWorkspaceBySlug(db: DB, slug: string): WorkspaceRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspaces
+    WHERE slug = ?
+    LIMIT 1
+  `).get(slug) as WorkspaceRow | undefined
+
+  return row ?? null
+}
+
+export function listWorkspaces(db: DB): WorkspaceRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM workspaces
+    ORDER BY datetime(updated_at) DESC, slug ASC
+  `).all() as WorkspaceRow[]
+}
+
+export function getWorkspaceSummary(
+  db: DB,
+  workspaceId: number,
+): {
+  identityCount: number
+  externalInitiatorCount: number
+  memberCount: number
+  partnerChannelCount: number
+} {
+  const identityCount = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM workspace_identity_bindings
+    WHERE workspace_id = ?
+  `).get(workspaceId) as { count: number } | undefined)?.count ?? 0
+
+  const externalInitiatorCount = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM workspace_identity_bindings
+    WHERE workspace_id = ? AND can_initiate_external = 1 AND status = 'active'
+  `).get(workspaceId) as { count: number } | undefined)?.count ?? 0
+
+  const memberCount = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM workspace_members
+    WHERE workspace_id = ?
+  `).get(workspaceId) as { count: number } | undefined)?.count ?? 0
+
+  const partnerChannelCount = (db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM workspace_partner_channels
+    WHERE workspace_id = ?
+  `).get(workspaceId) as { count: number } | undefined)?.count ?? 0
+
+  return {
+    identityCount,
+    externalInitiatorCount,
+    memberCount,
+    partnerChannelCount,
+  }
+}
+
+export function getWorkspacePolicy(db: DB, workspaceId: number): WorkspacePolicyRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_policies
+    WHERE workspace_id = ?
+    LIMIT 1
+  `).get(workspaceId) as WorkspacePolicyRow | undefined
+
+  return row ?? null
+}
+
+export function getWorkspaceIdentityBindingById(db: DB, id: number): WorkspaceIdentityBindingRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_identity_bindings
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as WorkspaceIdentityBindingRow | undefined
+
+  return row ?? null
+}
+
+export function getWorkspaceIdentityBindingByBeamId(
+  db: DB,
+  workspaceId: number,
+  beamId: string,
+): WorkspaceIdentityBindingRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_identity_bindings
+    WHERE workspace_id = ? AND beam_id = ?
+    LIMIT 1
+  `).get(workspaceId, beamId) as WorkspaceIdentityBindingRow | undefined
+
+  return row ?? null
+}
+
+export function listWorkspaceIdentityBindings(db: DB, workspaceId: number): WorkspaceIdentityBindingRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM workspace_identity_bindings
+    WHERE workspace_id = ?
+    ORDER BY
+      CASE status
+        WHEN 'active' THEN 0
+        ELSE 1
+      END ASC,
+      COALESCE(owner, '') ASC,
+      beam_id ASC
+  `).all(workspaceId) as WorkspaceIdentityBindingRow[]
+}
+
+export function createWorkspaceIdentityBinding(
+  db: DB,
+  input: {
+    workspaceId: number
+    beamId: string
+    bindingType: WorkspaceIdentityBindingRow['binding_type']
+    owner?: string | null
+    runtimeType?: string | null
+    policyProfile?: string | null
+    defaultThreadScope?: WorkspaceIdentityBindingRow['default_thread_scope']
+    canInitiateExternal?: boolean
+    status?: WorkspaceIdentityBindingRow['status']
+    notes?: string | null
+  },
+): WorkspaceIdentityBindingRow {
+  const now = nowIso()
+  const result = db.prepare(`
+    INSERT INTO workspace_identity_bindings (
+      workspace_id,
+      beam_id,
+      binding_type,
+      owner,
+      runtime_type,
+      policy_profile,
+      default_thread_scope,
+      can_initiate_external,
+      status,
+      notes,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.workspaceId,
+    input.beamId,
+    input.bindingType,
+    input.owner ?? null,
+    input.runtimeType ?? null,
+    input.policyProfile ?? null,
+    input.defaultThreadScope ?? 'internal',
+    input.canInitiateExternal ? 1 : 0,
+    input.status ?? 'active',
+    input.notes ?? null,
+    now,
+    now,
+  )
+
+  const binding = getWorkspaceIdentityBindingById(db, Number(result.lastInsertRowid))
+  if (!binding) {
+    throw new Error('Workspace identity binding insert succeeded but row was not found')
+  }
+
+  return binding
+}
+
+export function updateWorkspaceIdentityBinding(
+  db: DB,
+  input: {
+    id: number
+    owner: string | null
+    runtimeType: string | null
+    policyProfile: string | null
+    defaultThreadScope: WorkspaceIdentityBindingRow['default_thread_scope']
+    canInitiateExternal: boolean
+    status: WorkspaceIdentityBindingRow['status']
+    notes: string | null
+  },
+): WorkspaceIdentityBindingRow | null {
+  const updatedAt = nowIso()
+  db.prepare(`
+    UPDATE workspace_identity_bindings
+    SET owner = ?,
+        runtime_type = ?,
+        policy_profile = ?,
+        default_thread_scope = ?,
+        can_initiate_external = ?,
+        status = ?,
+        notes = ?,
+        updated_at = ?
+    WHERE id = ?
+  `).run(
+    input.owner,
+    input.runtimeType,
+    input.policyProfile,
+    input.defaultThreadScope,
+    input.canInitiateExternal ? 1 : 0,
+    input.status,
+    input.notes,
+    updatedAt,
+    input.id,
+  )
+
+  return getWorkspaceIdentityBindingById(db, input.id)
 }
 
 export function listOrgAgents(db: DB, orgName: string): Array<OrgAgentRow & Partial<AgentRow>> {

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -1,0 +1,514 @@
+import { Hono } from 'hono'
+import type { Database } from 'better-sqlite3'
+import { requireAdminRole } from '../admin-auth.js'
+import {
+  createWorkspace,
+  createWorkspaceIdentityBinding,
+  getAgent,
+  getOrg,
+  getWorkspaceBySlug,
+  getWorkspaceIdentityBindingByBeamId,
+  getWorkspaceIdentityBindingById,
+  getWorkspacePolicy,
+  getWorkspaceSummary,
+  listAgentKeys,
+  listWorkspaceIdentityBindings,
+  listWorkspaces,
+  logAuditEvent,
+  updateWorkspaceIdentityBinding,
+} from '../db.js'
+import type {
+  WorkspaceIdentityBindingRow,
+  WorkspaceIdentityBindingStatus,
+  WorkspaceIdentityBindingType,
+  WorkspaceRow,
+  WorkspaceThreadScope,
+} from '../types.js'
+import { serializeAgentKeyState } from '../utils/serialize.js'
+
+const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
+const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'handoff'])
+const WORKSPACE_BINDING_TYPE_SET = new Set<WorkspaceIdentityBindingType>(['agent', 'service', 'partner'])
+const WORKSPACE_BINDING_STATUS_SET = new Set<WorkspaceIdentityBindingStatus>(['active', 'paused'])
+const WORKSPACE_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-')
+    .slice(0, 64)
+}
+
+function normalizeWorkspaceStatus(value: unknown): WorkspaceRow['status'] | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceRow['status']
+  return WORKSPACE_STATUS_SET.has(normalized) ? normalized : null
+}
+
+function normalizeWorkspaceThreadScope(value: unknown): WorkspaceThreadScope | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceThreadScope
+  return WORKSPACE_THREAD_SCOPE_SET.has(normalized) ? normalized : null
+}
+
+function normalizeBindingType(value: unknown): WorkspaceIdentityBindingType | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceIdentityBindingType
+  return WORKSPACE_BINDING_TYPE_SET.has(normalized) ? normalized : null
+}
+
+function normalizeBindingStatus(value: unknown): WorkspaceIdentityBindingStatus | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceIdentityBindingStatus
+  return WORKSPACE_BINDING_STATUS_SET.has(normalized) ? normalized : null
+}
+
+function normalizeBoolean(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  return null
+}
+
+function normalizeWorkspaceSlug(value: unknown, fallback: string): string | null {
+  const candidate = typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : slugify(fallback)
+  if (!candidate || !WORKSPACE_SLUG_RE.test(candidate)) {
+    return null
+  }
+
+  return candidate
+}
+
+function serializeWorkspace(db: Database, row: WorkspaceRow): Record<string, unknown> {
+  const summary = getWorkspaceSummary(db, row.id)
+  const policy = getWorkspacePolicy(db, row.id)
+
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    orgName: row.org_name,
+    description: row.description,
+    status: row.status,
+    defaultThreadScope: row.default_thread_scope,
+    externalHandoffsEnabled: row.external_handoffs_enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    summary: {
+      identities: summary.identityCount,
+      externalInitiators: summary.externalInitiatorCount,
+      members: summary.memberCount,
+      partnerChannels: summary.partnerChannelCount,
+    },
+    policyConfigured: policy !== null,
+  }
+}
+
+function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityBindingRow): Record<string, unknown> {
+  const agent = getAgent(db, row.beam_id)
+  const keyState = agent ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) : null
+
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    beamId: row.beam_id,
+    bindingType: row.binding_type,
+    owner: row.owner,
+    runtimeType: row.runtime_type,
+    policyProfile: row.policy_profile,
+    defaultThreadScope: row.default_thread_scope,
+    canInitiateExternal: row.can_initiate_external === 1,
+    status: row.status,
+    notes: row.notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    identity: agent ? {
+      existsLocally: true,
+      beamId: agent.beam_id,
+      displayName: agent.display_name,
+      org: agent.org,
+      personal: agent.personal === 1,
+      verificationTier: agent.verification_tier,
+      trustScore: agent.trust_score,
+      lastSeen: agent.last_seen,
+      capabilities: JSON.parse(agent.capabilities) as string[],
+      keyState,
+    } : {
+      existsLocally: false,
+      beamId: row.beam_id,
+      displayName: null,
+      org: null,
+      personal: false,
+      verificationTier: null,
+      trustScore: null,
+      lastSeen: null,
+      capabilities: [],
+      keyState,
+    },
+  }
+}
+
+function isUniqueConstraintError(err: unknown, target: string): boolean {
+  return err instanceof Error && err.message.includes(`UNIQUE constraint failed: ${target}`)
+}
+
+export function workspacesRouter(db: Database): Hono {
+  const router = new Hono()
+
+  router.get('/', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const rows = listWorkspaces(db)
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspaces: rows.map((row) => serializeWorkspace(db, row)),
+      total: rows.length,
+    })
+  })
+
+  router.post('/', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const name = normalizeOptionalString(raw.name)
+    if (!name) {
+      return c.json({ error: 'name is required', errorCode: 'INVALID_WORKSPACE_NAME' }, 400)
+    }
+
+    const slug = normalizeWorkspaceSlug(raw.slug, name)
+    if (!slug) {
+      return c.json({ error: 'slug must contain lowercase letters, numbers, and dashes only', errorCode: 'INVALID_WORKSPACE_SLUG' }, 400)
+    }
+
+    const orgName = normalizeOptionalString(raw.orgName)
+    if (orgName && !getOrg(db, orgName)) {
+      return c.json({ error: 'orgName was not found', errorCode: 'ORG_NOT_FOUND' }, 404)
+    }
+
+    const description = normalizeOptionalString(raw.description)
+    const status = 'status' in raw ? normalizeWorkspaceStatus(raw.status) : 'active'
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid workspace status', errorCode: 'INVALID_WORKSPACE_STATUS' }, 400)
+    }
+
+    const defaultThreadScope = 'defaultThreadScope' in raw
+      ? normalizeWorkspaceThreadScope(raw.defaultThreadScope)
+      : 'internal'
+    if ('defaultThreadScope' in raw && !defaultThreadScope) {
+      return c.json({ error: 'Invalid defaultThreadScope', errorCode: 'INVALID_WORKSPACE_SCOPE' }, 400)
+    }
+
+    const externalHandoffsEnabled = 'externalHandoffsEnabled' in raw
+      ? normalizeBoolean(raw.externalHandoffsEnabled)
+      : false
+    if ('externalHandoffsEnabled' in raw && externalHandoffsEnabled === null) {
+      return c.json({ error: 'externalHandoffsEnabled must be boolean', errorCode: 'INVALID_EXTERNAL_HANDOFFS_ENABLED' }, 400)
+    }
+
+    try {
+      const workspace = createWorkspace(db, {
+        slug,
+        name,
+        orgName,
+        description,
+        status: status ?? 'active',
+        defaultThreadScope: defaultThreadScope ?? 'internal',
+        externalHandoffsEnabled: externalHandoffsEnabled ?? false,
+      })
+
+      logAuditEvent(db, {
+        action: 'admin.workspace.created',
+        actor: auth.session.email,
+        target: workspace.slug,
+        details: {
+          role: auth.session.role,
+          orgName: workspace.org_name,
+          defaultThreadScope: workspace.default_thread_scope,
+          externalHandoffsEnabled: workspace.external_handoffs_enabled === 1,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({ workspace: serializeWorkspace(db, workspace) }, 201)
+    } catch (err) {
+      if (isUniqueConstraintError(err, 'workspaces.slug')) {
+        return c.json({ error: 'Workspace slug already exists', errorCode: 'WORKSPACE_SLUG_TAKEN' }, 409)
+      }
+
+      console.error('Workspace create error:', err)
+      return c.json({ error: 'Failed to create workspace', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  router.get('/:slug', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({ workspace: serializeWorkspace(db, workspace) })
+  })
+
+  router.get('/:slug/identities', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const rows = listWorkspaceIdentityBindings(db, workspace.id)
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      bindings: rows.map((row) => serializeWorkspaceIdentityBinding(db, row)),
+      total: rows.length,
+    })
+  })
+
+  router.post('/:slug/identities', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const beamId = normalizeOptionalString(raw.beamId)
+    if (!beamId) {
+      return c.json({ error: 'beamId is required', errorCode: 'INVALID_BEAM_ID' }, 400)
+    }
+
+    const bindingType = normalizeBindingType(raw.bindingType)
+    if (!bindingType) {
+      return c.json({ error: 'Invalid bindingType', errorCode: 'INVALID_BINDING_TYPE' }, 400)
+    }
+
+    if ((bindingType === 'agent' || bindingType === 'service') && !getAgent(db, beamId)) {
+      return c.json({ error: 'Local Beam identity not found', errorCode: 'AGENT_NOT_FOUND' }, 404)
+    }
+
+    const owner = normalizeOptionalString(raw.owner)
+    const runtimeType = normalizeOptionalString(raw.runtimeType)
+    const policyProfile = normalizeOptionalString(raw.policyProfile)
+    const defaultThreadScope = 'defaultThreadScope' in raw
+      ? normalizeWorkspaceThreadScope(raw.defaultThreadScope)
+      : 'internal'
+    if ('defaultThreadScope' in raw && !defaultThreadScope) {
+      return c.json({ error: 'Invalid defaultThreadScope', errorCode: 'INVALID_WORKSPACE_SCOPE' }, 400)
+    }
+
+    const canInitiateExternal = 'canInitiateExternal' in raw
+      ? normalizeBoolean(raw.canInitiateExternal)
+      : false
+    if ('canInitiateExternal' in raw && canInitiateExternal === null) {
+      return c.json({ error: 'canInitiateExternal must be boolean', errorCode: 'INVALID_CAN_INITIATE_EXTERNAL' }, 400)
+    }
+
+    const status = 'status' in raw ? normalizeBindingStatus(raw.status) : 'active'
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid binding status', errorCode: 'INVALID_BINDING_STATUS' }, 400)
+    }
+
+    const notes = normalizeOptionalString(raw.notes)
+
+    try {
+      const existing = getWorkspaceIdentityBindingByBeamId(db, workspace.id, beamId)
+      if (existing) {
+        return c.json({ error: 'Workspace identity already exists', errorCode: 'WORKSPACE_IDENTITY_EXISTS' }, 409)
+      }
+
+      const binding = createWorkspaceIdentityBinding(db, {
+        workspaceId: workspace.id,
+        beamId,
+        bindingType,
+        owner,
+        runtimeType,
+        policyProfile,
+        defaultThreadScope: defaultThreadScope ?? 'internal',
+        canInitiateExternal: canInitiateExternal ?? false,
+        status: status ?? 'active',
+        notes,
+      })
+
+      logAuditEvent(db, {
+        action: 'admin.workspace_identity.created',
+        actor: auth.session.email,
+        target: `${workspace.slug}:${beamId}`,
+        details: {
+          role: auth.session.role,
+          bindingType,
+          owner,
+          runtimeType,
+          canInitiateExternal: binding.can_initiate_external === 1,
+          status: binding.status,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({ binding: serializeWorkspaceIdentityBinding(db, binding) }, 201)
+    } catch (err) {
+      if (isUniqueConstraintError(err, 'workspace_identity_bindings.workspace_id, workspace_identity_bindings.beam_id')) {
+        return c.json({ error: 'Workspace identity already exists', errorCode: 'WORKSPACE_IDENTITY_EXISTS' }, 409)
+      }
+
+      console.error('Workspace identity create error:', err)
+      return c.json({ error: 'Failed to create workspace identity', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  router.patch('/:slug/identities/:id', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const bindingId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(bindingId) || bindingId <= 0) {
+      return c.json({ error: 'Invalid identity binding id', errorCode: 'INVALID_BINDING_ID' }, 400)
+    }
+
+    const existing = getWorkspaceIdentityBindingById(db, bindingId)
+    if (!existing || existing.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const owner = 'owner' in raw ? normalizeOptionalString(raw.owner) : existing.owner
+    const runtimeType = 'runtimeType' in raw ? normalizeOptionalString(raw.runtimeType) : existing.runtime_type
+    const policyProfile = 'policyProfile' in raw ? normalizeOptionalString(raw.policyProfile) : existing.policy_profile
+    const defaultThreadScope = 'defaultThreadScope' in raw
+      ? normalizeWorkspaceThreadScope(raw.defaultThreadScope)
+      : existing.default_thread_scope
+    if ('defaultThreadScope' in raw && !defaultThreadScope) {
+      return c.json({ error: 'Invalid defaultThreadScope', errorCode: 'INVALID_WORKSPACE_SCOPE' }, 400)
+    }
+
+    const canInitiateExternal = 'canInitiateExternal' in raw
+      ? normalizeBoolean(raw.canInitiateExternal)
+      : existing.can_initiate_external === 1
+    if ('canInitiateExternal' in raw && canInitiateExternal === null) {
+      return c.json({ error: 'canInitiateExternal must be boolean', errorCode: 'INVALID_CAN_INITIATE_EXTERNAL' }, 400)
+    }
+
+    const status = 'status' in raw ? normalizeBindingStatus(raw.status) : existing.status
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid binding status', errorCode: 'INVALID_BINDING_STATUS' }, 400)
+    }
+
+    const notes = 'notes' in raw ? normalizeOptionalString(raw.notes) : existing.notes
+
+    const updated = updateWorkspaceIdentityBinding(db, {
+      id: existing.id,
+      owner,
+      runtimeType,
+      policyProfile,
+      defaultThreadScope: defaultThreadScope ?? existing.default_thread_scope,
+      canInitiateExternal: canInitiateExternal ?? (existing.can_initiate_external === 1),
+      status: status ?? existing.status,
+      notes,
+    })
+
+    if (!updated) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_identity.updated',
+      actor: auth.session.email,
+      target: `${workspace.slug}:${existing.beam_id}`,
+      details: {
+        role: auth.session.role,
+        owner,
+        runtimeType,
+        policyProfile,
+        defaultThreadScope: updated.default_thread_scope,
+        canInitiateExternal: updated.can_initiate_external === 1,
+        status: updated.status,
+        notesChanged: 'notes' in raw,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({ binding: serializeWorkspaceIdentityBinding(db, updated) })
+  })
+
+  return router
+}

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -22,6 +22,7 @@ import { buildAlerts, buildAlertsWithNotificationState, buildOverviewPayload, ob
 import { reportsRouter } from './routes/reports.js'
 import { shieldRouter } from './routes/shield.js'
 import { verificationRouter } from './routes/verify.js'
+import { workspacesRouter } from './routes/workspaces.js'
 import { createTrustGateMiddleware } from './middleware/trust-gate.js'
 import {
   createWebSocketServer,
@@ -3276,6 +3277,8 @@ export function createApp(db: Database): Hono {
       return c.json({ error: 'Failed to load audit log', errorCode: 'DB_ERROR' }, 500)
     }
   })
+
+  app.route('/admin/workspaces', workspacesRouter(db))
 
   // List all agents with connection status (before sub-router to avoid conflict)
   app.get('/directory/agents', (c) => {

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -159,6 +159,75 @@ export interface OperatorNotificationRow {
   details_json: string | null
 }
 
+export type WorkspaceStatus = 'active' | 'paused' | 'archived'
+export type WorkspaceThreadScope = 'internal' | 'handoff'
+export type WorkspaceMemberRole = 'owner' | 'operator' | 'viewer'
+export type WorkspacePrincipalType = 'human' | 'agent' | 'service' | 'partner'
+export type WorkspaceIdentityBindingType = 'agent' | 'service' | 'partner'
+export type WorkspaceIdentityBindingStatus = 'active' | 'paused'
+export type WorkspacePartnerChannelStatus = 'active' | 'trial' | 'blocked'
+
+export interface WorkspaceRow {
+  id: number
+  slug: string
+  name: string
+  org_name: string | null
+  description: string | null
+  status: WorkspaceStatus
+  default_thread_scope: WorkspaceThreadScope
+  external_handoffs_enabled: number
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkspaceMemberRow {
+  id: number
+  workspace_id: number
+  principal_id: string
+  principal_type: WorkspacePrincipalType
+  role: WorkspaceMemberRole
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkspaceIdentityBindingRow {
+  id: number
+  workspace_id: number
+  beam_id: string
+  binding_type: WorkspaceIdentityBindingType
+  owner: string | null
+  runtime_type: string | null
+  policy_profile: string | null
+  default_thread_scope: WorkspaceThreadScope
+  can_initiate_external: number
+  status: WorkspaceIdentityBindingStatus
+  notes: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkspacePartnerChannelRow {
+  id: number
+  workspace_id: number
+  partner_beam_id: string
+  label: string | null
+  owner: string | null
+  status: WorkspacePartnerChannelStatus
+  notes: string | null
+  last_success_at: string | null
+  last_failure_at: string | null
+  last_intent_nonce: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkspacePolicyRow {
+  workspace_id: number
+  policy_json: string
+  updated_at: string
+  updated_by: string | null
+}
+
 export type FunnelEventCategory = 'page_view' | 'cta_click' | 'request' | 'demo_milestone'
 
 export interface FunnelEventRow {

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -1,0 +1,221 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createAdminSession } from './admin-auth.js'
+import { createApp } from './server.js'
+import { assignDirectoryRole, createDatabase, registerAgent } from './db.js'
+import { getLocalDirectoryUrl } from './federation.js'
+
+function createAdminHeaders(
+  db: ReturnType<typeof createDatabase>,
+  email = 'ops@example.com',
+  role: 'admin' | 'operator' | 'viewer' = 'admin',
+) {
+  process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+  assignDirectoryRole(db, {
+    userId: email,
+    role,
+    directoryUrl: getLocalDirectoryUrl(),
+  })
+  const session = createAdminSession(db, { email, role })
+  return {
+    Authorization: `Bearer ${session.token}`,
+  }
+}
+
+test('admins can create and inspect beam workspaces through the admin API', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const app = createApp(db)
+
+    const createResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Acme Ops Workspace',
+        slug: 'acme-ops',
+        description: 'Control plane for internal and partner-facing identities.',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    assert.equal(createResponse.status, 201)
+    const createdBody = await createResponse.json() as {
+      workspace: {
+        slug: string
+        name: string
+        description: string | null
+        externalHandoffsEnabled: boolean
+        policyConfigured: boolean
+        summary: {
+          identities: number
+          partnerChannels: number
+        }
+      }
+    }
+    assert.equal(createdBody.workspace.slug, 'acme-ops')
+    assert.equal(createdBody.workspace.name, 'Acme Ops Workspace')
+    assert.match(createdBody.workspace.description ?? '', /Control plane/i)
+    assert.equal(createdBody.workspace.externalHandoffsEnabled, true)
+    assert.equal(createdBody.workspace.policyConfigured, true)
+    assert.equal(createdBody.workspace.summary.identities, 0)
+    assert.equal(createdBody.workspace.summary.partnerChannels, 0)
+
+    const listResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listResponse.status, 200)
+    const listBody = await listResponse.json() as {
+      total: number
+      workspaces: Array<{ slug: string }>
+    }
+    assert.equal(listBody.total, 1)
+    assert.equal(listBody.workspaces[0]?.slug, 'acme-ops')
+
+    const detailResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-ops', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(detailResponse.status, 200)
+    const detailBody = await detailResponse.json() as {
+      workspace: {
+        slug: string
+        defaultThreadScope: string
+      }
+    }
+    assert.equal(detailBody.workspace.slug, 'acme-ops')
+    assert.equal(detailBody.workspace.defaultThreadScope, 'internal')
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace identity bindings can be created, listed, and updated through the admin API', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['triage', 'handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAEHzHjWwTn/RZiC407+hCtk8nde/GEVUn85iOaZBH2Bw=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+
+    const workspaceResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Northwind Partner Ops',
+        slug: 'northwind-partner-ops',
+      }),
+    }))
+    assert.equal(workspaceResponse.status, 201)
+
+    const bindLocalResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-partner-ops/identities', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex',
+        policyProfile: 'default',
+        canInitiateExternal: true,
+        notes: 'Primary internal operator agent.',
+      }),
+    }))
+    assert.equal(bindLocalResponse.status, 201)
+    const localBindingBody = await bindLocalResponse.json() as {
+      binding: {
+        id: number
+        owner: string | null
+        canInitiateExternal: boolean
+        identity: {
+          existsLocally: boolean
+          displayName: string | null
+          keyState: {
+            active: { beamId: string } | null
+          } | null
+        }
+      }
+    }
+    assert.equal(localBindingBody.binding.owner, 'ops@example.com')
+    assert.equal(localBindingBody.binding.canInitiateExternal, true)
+    assert.equal(localBindingBody.binding.identity.existsLocally, true)
+    assert.equal(localBindingBody.binding.identity.displayName, 'Ops Bot')
+    assert.equal(localBindingBody.binding.identity.keyState?.active?.beamId, 'ops-bot@beam.directory')
+
+    const bindPartnerResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-partner-ops/identities', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        beamId: 'finance-agent@northwind.beam.directory',
+        bindingType: 'partner',
+        owner: 'bizops@example.com',
+        policyProfile: 'partner-finance',
+      }),
+    }))
+    assert.equal(bindPartnerResponse.status, 201)
+
+    const listResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-partner-ops/identities', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listResponse.status, 200)
+    const listBody = await listResponse.json() as {
+      total: number
+      bindings: Array<{
+        id: number
+        beamId: string
+        status: string
+        identity: {
+          existsLocally: boolean
+        }
+      }>
+    }
+    assert.equal(listBody.total, 2)
+    const partnerBinding = listBody.bindings.find((entry) => entry.beamId === 'finance-agent@northwind.beam.directory')
+    assert.equal(partnerBinding?.identity.existsLocally, false)
+
+    const patchResponse = await app.request(new Request(`http://localhost/admin/workspaces/northwind-partner-ops/identities/${localBindingBody.binding.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'paused',
+        canInitiateExternal: false,
+        notes: 'Paused pending policy review.',
+      }),
+    }))
+    assert.equal(patchResponse.status, 200)
+    const patchBody = await patchResponse.json() as {
+      binding: {
+        status: string
+        canInitiateExternal: boolean
+        notes: string | null
+      }
+    }
+    assert.equal(patchBody.binding.status, 'paused')
+    assert.equal(patchBody.binding.canInitiateExternal, false)
+    assert.match(patchBody.binding.notes ?? '', /policy review/i)
+  } finally {
+    db.close()
+  }
+})


### PR DESCRIPTION
## Summary
- add the first Beam Workspace schema, policy seed, and admin APIs in the directory
- add workspace identity binding roster endpoints with owner, runtime, and external-initiation controls
- document Beam Workspaces and cover the new migration and admin surface with tests

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build

Closes #112
Closes #113