### PR TITLE
Add workspace overview API and dashboard surface

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -18,6 +18,7 @@ import OverviewPage from './pages/OverviewPage'
 import RegisterPage from './pages/RegisterPage'
 import SettingsPage from './pages/SettingsPage'
 import TraceDetailPage from './pages/TraceDetailPage'
+import WorkspacesPage from './pages/WorkspacesPage'
 
 function RequireAdminSession({ children }: { children: JSX.Element }) {
   const { session, loading } = useAdminAuth()
@@ -60,6 +61,7 @@ export default function App() {
             <Route path="alerts" element={<AlertsPage />} />
             <Route path="inbox" element={<OperatorInboxPage />} />
             <Route path="beta-requests" element={<BetaRequestsPage />} />
+            <Route path="workspaces" element={<WorkspacesPage />} />
             <Route path="dead-letter" element={<DeadLetterPage />} />
             <Route path="register" element={<RegisterPage />} />
             <Route path="settings" element={<SettingsPage />} />

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, NavLink, Outlet, useLocation } from 'react-router-dom'
-import { Activity, BellDot, Bot, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, TrendingUp, UserPlus, X, Zap } from 'lucide-react'
+import { Activity, BellDot, Bot, Building2, FileText, Globe2, Inbox, Menu, Moon, Radio, ScrollText, Settings, Shield, Sun, TriangleAlert, TrendingUp, UserPlus, X, Zap } from 'lucide-react'
 import { useAdminAuth } from '../lib/admin-auth'
 import { cn } from '../lib/utils'
 import { useThemeMode } from '../lib/theme'
@@ -16,6 +16,7 @@ const NAV_ITEMS = [
   { path: '/alerts', label: 'Alerts', icon: Shield },
   { path: '/inbox', label: 'Inbox', icon: BellDot },
   { path: '/beta-requests', label: 'Beta Requests', icon: FileText },
+  { path: '/workspaces', label: 'Workspaces', icon: Building2 },
   { path: '/dead-letter', label: 'Dead Letters', icon: Inbox },
   { path: '/register', label: 'Register', icon: UserPlus },
   { path: '/settings', label: 'Settings', icon: Settings },

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -10,6 +10,17 @@ export type BetaRequestAttention = 'unowned' | 'stale' | 'follow_up_due'
 export type BetaRequestExportFormat = 'json' | 'csv'
 export type OperatorNotificationStatus = 'new' | 'acknowledged' | 'acted'
 export type OperatorNotificationSource = 'beta_request' | 'critical_alert'
+export type WorkspaceStatus = 'active' | 'paused' | 'archived'
+export type WorkspaceThreadScope = 'internal' | 'handoff'
+export type WorkspaceBindingType = 'agent' | 'service' | 'partner'
+export type WorkspaceBindingStatus = 'active' | 'paused'
+export type WorkspaceOverviewAttentionCode =
+  | 'identity_missing'
+  | 'stale_check_in'
+  | 'binding_paused'
+  | 'workspace_handoffs_disabled'
+  | 'manual_review_required'
+export type WorkspaceOverviewHandoffDirection = 'outbound' | 'inbound'
 
 export interface DirectoryAgent {
   beamId: string
@@ -78,6 +89,110 @@ export interface RootStatsResponse {
   gitSha?: string | null
   deployedAt?: string
   release?: DirectoryReleaseInfo
+}
+
+export interface WorkspaceRecord {
+  id: number
+  slug: string
+  name: string
+  orgName: string | null
+  description: string | null
+  status: WorkspaceStatus
+  defaultThreadScope: WorkspaceThreadScope
+  externalHandoffsEnabled: boolean
+  createdAt: string
+  updatedAt: string
+  summary: {
+    identities: number
+    externalInitiators: number
+    members: number
+    partnerChannels: number
+  }
+  policyConfigured: boolean
+}
+
+export interface WorkspaceListResponse {
+  workspaces: WorkspaceRecord[]
+  total: number
+}
+
+export interface WorkspaceIdentityBinding {
+  id: number
+  workspaceId: number
+  beamId: string
+  bindingType: WorkspaceBindingType
+  owner: string | null
+  runtimeType: string | null
+  policyProfile: string | null
+  defaultThreadScope: WorkspaceThreadScope
+  canInitiateExternal: boolean
+  status: WorkspaceBindingStatus
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+  identity: {
+    existsLocally: boolean
+    beamId: string
+    displayName: string | null
+    org: string | null
+    personal: boolean
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+    capabilities: string[]
+    keyState: object | null
+  }
+}
+
+export interface WorkspaceOverviewAttentionItem {
+  binding: WorkspaceIdentityBinding
+  reasonCode: WorkspaceOverviewAttentionCode
+  reason: string
+  lastSeenAgeHours: number | null
+}
+
+export interface WorkspaceOverviewHandoff {
+  nonce: string
+  intentType: string
+  status: IntentLifecycleStatus
+  requestedAt: string
+  completedAt: string | null
+  latencyMs: number | null
+  errorCode: string | null
+  direction: WorkspaceOverviewHandoffDirection
+  fromBeamId: string
+  toBeamId: string
+  workspaceSide: {
+    beamId: string
+    displayName: string | null
+    bindingType: WorkspaceBindingType | null
+  }
+  counterparty: {
+    beamId: string
+    displayName: string | null
+    bindingType: WorkspaceBindingType | null
+    inWorkspace: boolean
+  }
+}
+
+export interface WorkspaceOverviewResponse {
+  workspace: WorkspaceRecord
+  generatedAt: string
+  staleAfterHours: number
+  summary: {
+    totalIdentities: number
+    activeIdentities: number
+    localIdentities: number
+    partnerIdentities: number
+    externalReadyIdentities: number
+    staleIdentities: number
+    pendingApprovals: number
+    blockedExternalMotion: number
+    recentExternalHandoffs: number
+  }
+  staleBindings: WorkspaceOverviewAttentionItem[]
+  blockedExternalMotion: WorkspaceOverviewAttentionItem[]
+  recentExternalHandoffs: WorkspaceOverviewHandoff[]
 }
 
 export interface BusHealth {
@@ -1165,6 +1280,8 @@ export const directoryApi = {
     return request<AgentSearchResponse>(`/agents/search${query.toString() ? `?${query.toString()}` : ''}`)
   },
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
+  listWorkspaces: () => request<WorkspaceListResponse>('/admin/workspaces', undefined, { admin: true }),
+  getWorkspaceOverview: (slug: string) => request<WorkspaceOverviewResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/overview`, undefined, { admin: true }),
   heartbeat: (beamId: string) => request<DirectoryAgent>(`/agents/${encodeURIComponent(beamId)}/heartbeat`, { method: 'POST' }),
   registerAgent: (input: RegisterAgentInput) => request<DirectoryAgent>('/agents/register', {
     method: 'POST',

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
+import {
+  ApiError,
+  directoryApi,
+  type IntentLifecycleStatus,
+  type WorkspaceOverviewAttentionCode,
+  type WorkspaceOverviewAttentionItem,
+  type WorkspaceOverviewResponse,
+  type WorkspaceRecord,
+  type WorkspaceStatus,
+} from '../lib/api'
+import { formatDateTime, formatLatency, formatNumber, formatRelativeTime } from '../lib/utils'
+
+function workspaceStatusTone(status: WorkspaceStatus): 'default' | 'success' | 'warning' {
+  switch (status) {
+    case 'active':
+      return 'success'
+    case 'paused':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function handoffStatusTone(status: IntentLifecycleStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'acked':
+      return 'success'
+    case 'failed':
+    case 'dead_letter':
+      return 'critical'
+    case 'delivered':
+    case 'dispatched':
+    case 'queued':
+    case 'validated':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function attentionTone(code: WorkspaceOverviewAttentionCode): 'default' | 'warning' | 'critical' {
+  switch (code) {
+    case 'identity_missing':
+    case 'workspace_handoffs_disabled':
+      return 'critical'
+    case 'binding_paused':
+    case 'stale_check_in':
+    case 'manual_review_required':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function attentionLabel(code: WorkspaceOverviewAttentionCode): string {
+  switch (code) {
+    case 'identity_missing':
+      return 'Missing identity'
+    case 'stale_check_in':
+      return 'Stale check-in'
+    case 'binding_paused':
+      return 'Paused'
+    case 'workspace_handoffs_disabled':
+      return 'Workspace blocked'
+    case 'manual_review_required':
+      return 'Manual review'
+    default:
+      return 'Attention'
+  }
+}
+
+function displayName(label: string | null, beamId: string): string {
+  return label || beamId
+}
+
+function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
+  const parts = [
+    item.binding.owner ? `Owner ${item.binding.owner}` : 'No owner',
+    item.binding.identity.lastSeen ? `Last seen ${formatRelativeTime(item.binding.identity.lastSeen)}` : 'No heartbeat yet',
+  ]
+
+  if (item.lastSeenAgeHours !== null) {
+    parts.push(`${Math.round(item.lastSeenAgeHours)}h old`)
+  }
+
+  return parts.join(' · ')
+}
+
+export default function WorkspacesPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [workspaces, setWorkspaces] = useState<WorkspaceRecord[]>([])
+  const [overview, setOverview] = useState<WorkspaceOverviewResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [overviewLoading, setOverviewLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const selectedSlug = searchParams.get('workspace') ?? ''
+  const selectedWorkspace = useMemo(
+    () => workspaces.find((entry) => entry.slug === selectedSlug) ?? workspaces[0] ?? null,
+    [selectedSlug, workspaces],
+  )
+
+  async function loadWorkspaces() {
+    try {
+      setLoading(true)
+      const response = await directoryApi.listWorkspaces()
+      setWorkspaces(response.workspaces)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load Beam workspaces')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function loadOverview(slug: string) {
+    try {
+      setOverviewLoading(true)
+      const response = await directoryApi.getWorkspaceOverview(slug)
+      setOverview(response)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load workspace overview')
+    } finally {
+      setOverviewLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadWorkspaces()
+  }, [])
+
+  useEffect(() => {
+    if (!selectedWorkspace) {
+      return
+    }
+
+    if (selectedWorkspace.slug !== selectedSlug) {
+      const next = new URLSearchParams(searchParams)
+      next.set('workspace', selectedWorkspace.slug)
+      setSearchParams(next, { replace: true })
+    }
+  }, [searchParams, selectedSlug, selectedWorkspace, setSearchParams])
+
+  useEffect(() => {
+    if (!selectedWorkspace) {
+      setOverview(null)
+      return
+    }
+
+    void loadOverview(selectedWorkspace.slug)
+  }, [selectedWorkspace?.slug])
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Workspaces"
+        description="Identity home, external handoff controls, and operator attention for Beam workspaces."
+        actions={(
+          <div className="flex flex-wrap items-center gap-2">
+            {workspaces.length > 0 ? (
+              <select
+                className="input-field min-w-56"
+                value={selectedWorkspace?.slug ?? ''}
+                onChange={(event) => {
+                  const next = new URLSearchParams(searchParams)
+                  next.set('workspace', event.target.value)
+                  setSearchParams(next, { replace: true })
+                }}
+              >
+                {workspaces.map((workspace) => (
+                  <option key={workspace.slug} value={workspace.slug}>
+                    {workspace.name}
+                  </option>
+                ))}
+              </select>
+            ) : null}
+            <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to="/beta-requests">
+              Beta requests
+            </Link>
+            <button
+              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+              type="button"
+              onClick={() => {
+                void loadWorkspaces()
+                if (selectedWorkspace) {
+                  void loadOverview(selectedWorkspace.slug)
+                }
+              }}
+            >
+              Refresh
+            </button>
+          </div>
+        )}
+      />
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-500/10 dark:text-red-300">
+          {error}
+        </div>
+      ) : null}
+
+      {!loading && workspaces.length === 0 ? (
+        <EmptyPanel label="No Beam workspaces exist yet. Create one from the admin API first, then this surface will show identity health and external motion." />
+      ) : null}
+
+      {selectedWorkspace ? (
+        <>
+          <section className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+            <MetricCard label="Active identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.activeIdentities)} hint={`${overview ? formatNumber(overview.summary.totalIdentities) : '—'} total bound identities`} />
+            <MetricCard label="External ready" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.externalReadyIdentities)} tone={(overview?.summary.externalReadyIdentities ?? 0) > 0 ? 'success' : 'default'} />
+            <MetricCard label="Stale identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.staleIdentities)} tone={(overview?.summary.staleIdentities ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Manual review" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.pendingApprovals)} tone={(overview?.summary.pendingApprovals ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Blocked motion" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.blockedExternalMotion)} tone={(overview?.summary.blockedExternalMotion ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Recent external handoffs" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.recentExternalHandoffs)} hint={`Stale after ${overview?.staleAfterHours ?? 24}h`} />
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[0.78fr,1.22fr]">
+            <div className="panel">
+              <div className="panel-title">Workspace roster</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Choose the workspace whose identity surface and outbound readiness you want to inspect.
+              </p>
+              <div className="mt-4 space-y-3">
+                {loading ? (
+                  <EmptyPanel label="Loading workspaces…" />
+                ) : (
+                  workspaces.map((workspace) => {
+                    const selected = workspace.slug === selectedWorkspace.slug
+                    return (
+                      <button
+                        key={workspace.slug}
+                        type="button"
+                        className={`w-full rounded-2xl border px-4 py-3 text-left transition ${
+                          selected
+                            ? 'border-orange-300 bg-orange-50/80 dark:border-orange-500/40 dark:bg-orange-500/10'
+                            : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-900'
+                        }`}
+                        onClick={() => {
+                          const next = new URLSearchParams(searchParams)
+                          next.set('workspace', workspace.slug)
+                          setSearchParams(next, { replace: true })
+                        }}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{workspace.name}</div>
+                            <div className="truncate text-xs text-slate-500 dark:text-slate-400">{workspace.slug}</div>
+                          </div>
+                          <StatusPill label={workspace.status} tone={workspaceStatusTone(workspace.status)} />
+                        </div>
+                        <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-500 dark:text-slate-400">
+                          <div>{formatNumber(workspace.summary.identities)} identities</div>
+                          <div>{formatNumber(workspace.summary.externalInitiators)} initiators</div>
+                          <div>{formatNumber(workspace.summary.partnerChannels)} partner channels</div>
+                          <div>{workspace.externalHandoffsEnabled ? 'External on' : 'External off'}</div>
+                        </div>
+                      </button>
+                    )
+                  })
+                )}
+              </div>
+            </div>
+
+            <div className="panel">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="panel-title">{selectedWorkspace.name}</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    {selectedWorkspace.description || 'Beam Workspace control plane for identities, internal work, and partner-facing motion.'}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <StatusPill label={selectedWorkspace.status} tone={workspaceStatusTone(selectedWorkspace.status)} />
+                  <StatusPill
+                    label={selectedWorkspace.externalHandoffsEnabled ? 'External handoffs enabled' : 'External handoffs disabled'}
+                    tone={selectedWorkspace.externalHandoffsEnabled ? 'success' : 'warning'}
+                  />
+                  <StatusPill label={selectedWorkspace.policyConfigured ? 'Policy configured' : 'Policy missing'} tone={selectedWorkspace.policyConfigured ? 'success' : 'warning'} />
+                </div>
+              </div>
+
+              <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <MetricCard label="Local identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.localIdentities)} />
+                <MetricCard label="Partner identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.partnerIdentities)} />
+                <MetricCard label="Workspace members" value={formatNumber(selectedWorkspace.summary.members)} />
+                <MetricCard label="Updated" value={formatRelativeTime(selectedWorkspace.updatedAt)} hint={formatDateTime(selectedWorkspace.updatedAt)} />
+              </div>
+
+              <div className="mt-5 rounded-2xl border border-slate-200 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                <div className="font-medium text-slate-900 dark:text-slate-100">What this page is telling you</div>
+                <div className="mt-1">
+                  Beam marks a workspace as risky when identities stop checking in, when outbound motion is paused or still manual,
+                  or when recent partner-facing traces are failing. Trace links below jump into the existing intent feed. Beta requests stay the
+                  operator surface for partner follow-up and proof-pack motion.
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-2">
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Stale identities</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Local identities that are missing or have not checked in within {overview?.staleAfterHours ?? 24} hours.
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 space-y-3">
+                {overviewLoading || !overview ? (
+                  <EmptyPanel label="Loading stale identity signals…" />
+                ) : overview.staleBindings.length === 0 ? (
+                  <EmptyPanel label="No stale workspace identities right now." />
+                ) : (
+                  overview.staleBindings.map((item) => (
+                    <div key={`${item.binding.id}-${item.reasonCode}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">
+                            {displayName(item.binding.identity.displayName, item.binding.beamId)}
+                          </div>
+                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{item.binding.beamId}</div>
+                        </div>
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          <StatusPill label={attentionLabel(item.reasonCode)} tone={attentionTone(item.reasonCode)} />
+                          <StatusPill label={item.binding.bindingType} />
+                        </div>
+                      </div>
+                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.reason}</div>
+                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{renderAttentionMeta(item)}</div>
+                      {item.binding.identity.existsLocally ? (
+                        <div className="mt-3">
+                          <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/agents/${encodeURIComponent(item.binding.beamId)}`}>
+                            Open agent profile
+                          </Link>
+                        </div>
+                      ) : null}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Blocked external motion</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Identities that cannot currently start partner-facing work from this workspace.
+                  </p>
+                </div>
+                <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/beta-requests">
+                  Open beta requests
+                </Link>
+              </div>
+              <div className="mt-4 space-y-3">
+                {overviewLoading || !overview ? (
+                  <EmptyPanel label="Loading blocked motion…" />
+                ) : overview.blockedExternalMotion.length === 0 ? (
+                  <EmptyPanel label="No outbound blockers are registered for this workspace." />
+                ) : (
+                  overview.blockedExternalMotion.map((item) => (
+                    <div key={`${item.binding.id}-${item.reasonCode}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">
+                            {displayName(item.binding.identity.displayName, item.binding.beamId)}
+                          </div>
+                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{item.binding.beamId}</div>
+                        </div>
+                        <div className="flex flex-wrap items-center justify-end gap-2">
+                          <StatusPill label={attentionLabel(item.reasonCode)} tone={attentionTone(item.reasonCode)} />
+                          <StatusPill label={item.binding.status} tone={item.binding.status === 'paused' ? 'warning' : 'default'} />
+                        </div>
+                      </div>
+                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.reason}</div>
+                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{renderAttentionMeta(item)}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="panel">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="panel-title">Recent external handoffs</div>
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  The latest partner-facing or outside-in traces touching this workspace. Use these links to jump straight into the intent feed.
+                </p>
+              </div>
+              <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/intents">
+                Open intent feed
+              </Link>
+            </div>
+            <div className="mt-4 space-y-3">
+              {overviewLoading || !overview ? (
+                <EmptyPanel label="Loading external handoffs…" />
+              ) : overview.recentExternalHandoffs.length === 0 ? (
+                <EmptyPanel label="No external handoffs were recorded for this workspace yet." />
+              ) : (
+                overview.recentExternalHandoffs.map((handoff) => (
+                  <div key={handoff.nonce} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium">
+                          {displayName(handoff.workspaceSide.displayName, handoff.workspaceSide.beamId)}
+                          <span className="mx-2 text-slate-400">→</span>
+                          {displayName(handoff.counterparty.displayName, handoff.counterparty.beamId)}
+                        </div>
+                        <div className="mt-1 truncate text-xs text-slate-500 dark:text-slate-400">
+                          {handoff.fromBeamId} → {handoff.toBeamId}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center justify-end gap-2">
+                        <StatusPill label={handoff.direction} tone={handoff.direction === 'outbound' ? 'success' : 'warning'} />
+                        <StatusPill label={handoff.status} tone={handoffStatusTone(handoff.status)} />
+                      </div>
+                    </div>
+
+                    <div className="mt-3 grid gap-2 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                      <div>
+                        <div className="text-xs uppercase tracking-wide text-slate-400">Intent</div>
+                        <div>{handoff.intentType}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-wide text-slate-400">Requested</div>
+                        <div>{formatRelativeTime(handoff.requestedAt)}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-wide text-slate-400">Latency</div>
+                        <div>{formatLatency(handoff.latencyMs)}</div>
+                      </div>
+                      <div>
+                        <div className="text-xs uppercase tracking-wide text-slate-400">Counterparty</div>
+                        <div>{handoff.counterparty.inWorkspace ? 'Bound partner identity' : 'Outside workspace'}</div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-4 text-sm">
+                      <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/intents/${encodeURIComponent(handoff.nonce)}`}>
+                        Open trace
+                      </Link>
+                      {handoff.errorCode ? <span className="text-red-600 dark:text-red-300">{handoff.errorCode}</span> : null}
+                      <span className="text-slate-500 dark:text-slate-400">{formatDateTime(handoff.requestedAt)}</span>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -18,6 +18,7 @@ import {
   updateWorkspaceIdentityBinding,
 } from '../db.js'
 import type {
+  IntentLogRow,
   WorkspaceIdentityBindingRow,
   WorkspaceIdentityBindingStatus,
   WorkspaceIdentityBindingType,
@@ -31,6 +32,97 @@ const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'h
 const WORKSPACE_BINDING_TYPE_SET = new Set<WorkspaceIdentityBindingType>(['agent', 'service', 'partner'])
 const WORKSPACE_BINDING_STATUS_SET = new Set<WorkspaceIdentityBindingStatus>(['active', 'paused'])
 const WORKSPACE_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+const WORKSPACE_OVERVIEW_STALE_AFTER_HOURS = 24
+const WORKSPACE_OVERVIEW_RECENT_HANDOFF_LIMIT = 8
+const WORKSPACE_OVERVIEW_INTENT_SCAN_LIMIT = 96
+
+type SerializedWorkspace = {
+  id: number
+  slug: string
+  name: string
+  orgName: string | null
+  description: string | null
+  status: WorkspaceRow['status']
+  defaultThreadScope: WorkspaceThreadScope
+  externalHandoffsEnabled: boolean
+  createdAt: string
+  updatedAt: string
+  summary: {
+    identities: number
+    externalInitiators: number
+    members: number
+    partnerChannels: number
+  }
+  policyConfigured: boolean
+}
+
+type SerializedWorkspaceIdentityBinding = {
+  id: number
+  workspaceId: number
+  beamId: string
+  bindingType: WorkspaceIdentityBindingType
+  owner: string | null
+  runtimeType: string | null
+  policyProfile: string | null
+  defaultThreadScope: WorkspaceThreadScope
+  canInitiateExternal: boolean
+  status: WorkspaceIdentityBindingStatus
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+  identity: {
+    existsLocally: boolean
+    beamId: string
+    displayName: string | null
+    org: string | null
+    personal: boolean
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+    capabilities: string[]
+    keyState: object | null
+  }
+}
+
+type WorkspaceOverviewAttentionCode =
+  | 'identity_missing'
+  | 'stale_check_in'
+  | 'binding_paused'
+  | 'workspace_handoffs_disabled'
+  | 'manual_review_required'
+
+type WorkspaceOverviewAttentionItem = {
+  binding: SerializedWorkspaceIdentityBinding
+  reasonCode: WorkspaceOverviewAttentionCode
+  reason: string
+  lastSeenAgeHours: number | null
+}
+
+type WorkspaceOverviewHandoffDirection = 'outbound' | 'inbound'
+
+type WorkspaceOverviewHandoff = {
+  nonce: string
+  intentType: string
+  status: IntentLogRow['status']
+  requestedAt: string
+  completedAt: string | null
+  latencyMs: number | null
+  errorCode: string | null
+  direction: WorkspaceOverviewHandoffDirection
+  fromBeamId: string
+  toBeamId: string
+  workspaceSide: {
+    beamId: string
+    displayName: string | null
+    bindingType: WorkspaceIdentityBindingType | null
+  }
+  counterparty: {
+    beamId: string
+    displayName: string | null
+    bindingType: WorkspaceIdentityBindingType | null
+    inWorkspace: boolean
+  }
+}
 
 function normalizeOptionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
@@ -99,7 +191,66 @@ function normalizeWorkspaceSlug(value: unknown, fallback: string): string | null
   return candidate
 }
 
-function serializeWorkspace(db: Database, row: WorkspaceRow): Record<string, unknown> {
+function hoursSince(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) {
+    return null
+  }
+
+  return Math.round(((Date.now() - timestamp) / 3_600_000) * 10) / 10
+}
+
+function isLocalWorkspaceBinding(row: WorkspaceIdentityBindingRow): boolean {
+  return row.binding_type !== 'partner'
+}
+
+function classifyWorkspaceHandoffDirection(
+  fromBinding: WorkspaceIdentityBindingRow | undefined,
+  toBinding: WorkspaceIdentityBindingRow | undefined,
+): WorkspaceOverviewHandoffDirection | null {
+  if (fromBinding && !toBinding) {
+    return fromBinding.binding_type === 'partner' ? null : 'outbound'
+  }
+
+  if (!fromBinding && toBinding) {
+    return toBinding.binding_type === 'partner' ? null : 'inbound'
+  }
+
+  if (fromBinding && toBinding) {
+    if (fromBinding.binding_type !== 'partner' && toBinding.binding_type === 'partner') {
+      return 'outbound'
+    }
+
+    if (fromBinding.binding_type === 'partner' && toBinding.binding_type !== 'partner') {
+      return 'inbound'
+    }
+  }
+
+  return null
+}
+
+function getDisplayNameForBeamId(
+  db: Database,
+  beamId: string,
+  binding: WorkspaceIdentityBindingRow | null = null,
+): string | null {
+  const agent = getAgent(db, beamId)
+  if (agent?.display_name) {
+    return agent.display_name
+  }
+
+  if (binding) {
+    return binding.beam_id.split('@')[0] ?? null
+  }
+
+  return null
+}
+
+function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspace {
   const summary = getWorkspaceSummary(db, row.id)
   const policy = getWorkspacePolicy(db, row.id)
 
@@ -124,7 +275,7 @@ function serializeWorkspace(db: Database, row: WorkspaceRow): Record<string, unk
   }
 }
 
-function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityBindingRow): Record<string, unknown> {
+function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityBindingRow): SerializedWorkspaceIdentityBinding {
   const agent = getAgent(db, row.beam_id)
   const keyState = agent ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) : null
 
@@ -165,6 +316,199 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
       capabilities: [],
       keyState,
     },
+  }
+}
+
+function listRecentWorkspaceExternalHandoffs(
+  db: Database,
+  bindings: WorkspaceIdentityBindingRow[],
+  limit = WORKSPACE_OVERVIEW_RECENT_HANDOFF_LIMIT,
+): WorkspaceOverviewHandoff[] {
+  if (bindings.length === 0) {
+    return []
+  }
+
+  const beamIds = [...new Set(bindings.map((row) => row.beam_id))]
+  const placeholders = beamIds.map(() => '?').join(', ')
+  const rows = db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE from_beam_id IN (${placeholders}) OR to_beam_id IN (${placeholders})
+    ORDER BY requested_at DESC, id DESC
+    LIMIT ?
+  `).all(...beamIds, ...beamIds, WORKSPACE_OVERVIEW_INTENT_SCAN_LIMIT) as IntentLogRow[]
+
+  const bindingByBeamId = new Map(bindings.map((row) => [row.beam_id, row]))
+  const handoffs: WorkspaceOverviewHandoff[] = []
+
+  for (const row of rows) {
+    const fromBinding = bindingByBeamId.get(row.from_beam_id)
+    const toBinding = bindingByBeamId.get(row.to_beam_id)
+    const direction = classifyWorkspaceHandoffDirection(fromBinding, toBinding)
+    if (!direction) {
+      continue
+    }
+
+    const workspaceBinding = direction === 'outbound'
+      ? (fromBinding && fromBinding.binding_type !== 'partner' ? fromBinding : fromBinding ?? null)
+      : (toBinding && toBinding.binding_type !== 'partner' ? toBinding : toBinding ?? null)
+
+    const counterpartyBeamId = direction === 'outbound' ? row.to_beam_id : row.from_beam_id
+    const counterpartyBinding = bindingByBeamId.get(counterpartyBeamId) ?? null
+
+    handoffs.push({
+      nonce: row.nonce,
+      intentType: row.intent_type,
+      status: row.status,
+      requestedAt: row.requested_at,
+      completedAt: row.completed_at,
+      latencyMs: row.round_trip_latency_ms,
+      errorCode: row.error_code,
+      direction,
+      fromBeamId: row.from_beam_id,
+      toBeamId: row.to_beam_id,
+      workspaceSide: {
+        beamId: workspaceBinding?.beam_id ?? (direction === 'outbound' ? row.from_beam_id : row.to_beam_id),
+        displayName: getDisplayNameForBeamId(
+          db,
+          workspaceBinding?.beam_id ?? (direction === 'outbound' ? row.from_beam_id : row.to_beam_id),
+          workspaceBinding,
+        ),
+        bindingType: workspaceBinding?.binding_type ?? null,
+      },
+      counterparty: {
+        beamId: counterpartyBeamId,
+        displayName: getDisplayNameForBeamId(db, counterpartyBeamId, counterpartyBinding),
+        bindingType: counterpartyBinding?.binding_type ?? null,
+        inWorkspace: Boolean(counterpartyBinding),
+      },
+    })
+
+    if (handoffs.length >= limit) {
+      break
+    }
+  }
+
+  return handoffs
+}
+
+function buildWorkspaceOverview(db: Database, workspace: WorkspaceRow) {
+  const bindings = listWorkspaceIdentityBindings(db, workspace.id)
+  const staleBindings: WorkspaceOverviewAttentionItem[] = []
+  const blockedExternalMotion: WorkspaceOverviewAttentionItem[] = []
+
+  let activeIdentities = 0
+  let localIdentities = 0
+  let partnerIdentities = 0
+  let externalReadyIdentities = 0
+  let pendingApprovals = 0
+
+  for (const row of bindings) {
+    const binding = serializeWorkspaceIdentityBinding(db, row)
+    const lastSeenAgeHours = hoursSince(binding.identity.lastSeen)
+    const isLocal = isLocalWorkspaceBinding(row)
+
+    if (row.status === 'active') {
+      activeIdentities += 1
+    }
+    if (isLocal) {
+      localIdentities += 1
+    } else {
+      partnerIdentities += 1
+    }
+    if (isLocal && row.status === 'active' && row.can_initiate_external === 1 && workspace.external_handoffs_enabled === 1) {
+      externalReadyIdentities += 1
+    }
+
+    if (isLocal) {
+      if (!binding.identity.existsLocally) {
+        staleBindings.push({
+          binding,
+          reasonCode: 'identity_missing',
+          reason: 'This workspace binding points to a local identity that is no longer registered in the directory.',
+          lastSeenAgeHours: null,
+        })
+      } else if (lastSeenAgeHours !== null && lastSeenAgeHours >= WORKSPACE_OVERVIEW_STALE_AFTER_HOURS) {
+        staleBindings.push({
+          binding,
+          reasonCode: 'stale_check_in',
+          reason: `This identity has not checked in within ${WORKSPACE_OVERVIEW_STALE_AFTER_HOURS} hours.`,
+          lastSeenAgeHours,
+        })
+      }
+
+      if (row.status !== 'active') {
+        blockedExternalMotion.push({
+          binding,
+          reasonCode: 'binding_paused',
+          reason: 'This identity binding is paused and cannot initiate external handoffs.',
+          lastSeenAgeHours,
+        })
+      } else if (workspace.external_handoffs_enabled !== 1) {
+        blockedExternalMotion.push({
+          binding,
+          reasonCode: 'workspace_handoffs_disabled',
+          reason: 'Workspace-level external handoffs are disabled, so outbound motion is blocked.',
+          lastSeenAgeHours,
+        })
+      } else if (row.can_initiate_external !== 1) {
+        blockedExternalMotion.push({
+          binding,
+          reasonCode: 'manual_review_required',
+          reason: 'This identity can work internally, but external motion still requires manual approval.',
+          lastSeenAgeHours,
+        })
+        pendingApprovals += 1
+      }
+    }
+  }
+
+  const recentExternalHandoffs = listRecentWorkspaceExternalHandoffs(db, bindings)
+
+  staleBindings.sort((left, right) => {
+    if (left.reasonCode === 'identity_missing' && right.reasonCode !== 'identity_missing') {
+      return -1
+    }
+    if (left.reasonCode !== 'identity_missing' && right.reasonCode === 'identity_missing') {
+      return 1
+    }
+    return (right.lastSeenAgeHours ?? 0) - (left.lastSeenAgeHours ?? 0)
+  })
+
+  blockedExternalMotion.sort((left, right) => {
+    const priority = (item: WorkspaceOverviewAttentionItem) => {
+      switch (item.reasonCode) {
+        case 'workspace_handoffs_disabled':
+          return 0
+        case 'binding_paused':
+          return 1
+        case 'manual_review_required':
+          return 2
+        default:
+          return 3
+      }
+    }
+
+    return priority(left) - priority(right)
+  })
+
+  return {
+    generatedAt: new Date().toISOString(),
+    staleAfterHours: WORKSPACE_OVERVIEW_STALE_AFTER_HOURS,
+    summary: {
+      totalIdentities: bindings.length,
+      activeIdentities,
+      localIdentities,
+      partnerIdentities,
+      externalReadyIdentities,
+      staleIdentities: staleBindings.length,
+      pendingApprovals,
+      blockedExternalMotion: blockedExternalMotion.length,
+      recentExternalHandoffs: recentExternalHandoffs.length,
+    },
+    staleBindings,
+    blockedExternalMotion,
+    recentExternalHandoffs,
   }
 }
 
@@ -290,6 +634,24 @@ export function workspacesRouter(db: Database): Hono {
 
     c.header('Cache-Control', 'no-store')
     return c.json({ workspace: serializeWorkspace(db, workspace) })
+  })
+
+  router.get('/:slug/overview', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      ...buildWorkspaceOverview(db, workspace),
+    })
   })
 
   router.get('/:slug/identities', (c) => {

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -2,7 +2,14 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 import { createAdminSession } from './admin-auth.js'
 import { createApp } from './server.js'
-import { assignDirectoryRole, createDatabase, registerAgent } from './db.js'
+import {
+  assignDirectoryRole,
+  createDatabase,
+  finalizeIntentLog,
+  logIntentStart,
+  registerAgent,
+  setIntentLifecycleStatus,
+} from './db.js'
 import { getLocalDirectoryUrl } from './federation.js'
 
 function createAdminHeaders(
@@ -215,6 +222,202 @@ test('workspace identity bindings can be created, listed, and updated through th
     assert.equal(patchBody.binding.status, 'paused')
     assert.equal(patchBody.binding.canInitiateExternal, false)
     assert.match(patchBody.binding.notes ?? '', /policy review/i)
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace overview surfaces stale identities, blocked external motion, and recent external handoffs', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['triage', 'handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAzJmQH9I0mL6MZzQ1+Qv6cMo5+2dH6+f8A6m2nYJ7rVY=',
+      personal: true,
+    })
+    registerAgent(db, {
+      beamId: 'triage-bot@beam.directory',
+      displayName: 'Triage Bot',
+      capabilities: ['triage'],
+      publicKey: 'MCowBQYDK2VwAyEATlqf7UPv1sX7aHqL13FQ+V6u6XgX+9x+4quAhzV8J8c=',
+      personal: true,
+    })
+
+    db.prepare('UPDATE agents SET last_seen = ? WHERE beam_id = ?').run(
+      '2026-03-29T08:00:00.000Z',
+      'triage-bot@beam.directory',
+    )
+
+    const app = createApp(db)
+
+    const workspaceResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Acme Ops Workspace',
+        slug: 'acme-ops',
+        description: 'Workspace for the first Beam production motion.',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+    assert.equal(workspaceResponse.status, 201)
+
+    const createBinding = async (payload: Record<string, unknown>) => app.request(new Request('http://localhost/admin/workspaces/acme-ops/identities', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }))
+
+    assert.equal((await createBinding({
+      beamId: 'ops-bot@beam.directory',
+      bindingType: 'agent',
+      owner: 'ops@example.com',
+      runtimeType: 'codex',
+      policyProfile: 'default',
+      canInitiateExternal: false,
+      notes: 'Primary operator identity.',
+    })).status, 201)
+
+    assert.equal((await createBinding({
+      beamId: 'triage-bot@beam.directory',
+      bindingType: 'service',
+      owner: 'ops@example.com',
+      runtimeType: 'worker',
+      policyProfile: 'triage',
+      canInitiateExternal: true,
+      status: 'paused',
+      notes: 'Paused after a stale health signal.',
+    })).status, 201)
+
+    assert.equal((await createBinding({
+      beamId: 'finance-agent@northwind.beam.directory',
+      bindingType: 'partner',
+      owner: 'northwind@example.com',
+      policyProfile: 'partner-finance',
+    })).status, 201)
+
+    logIntentStart(db, {
+      v: '1',
+      nonce: 'nonce-workspace-outbound',
+      from: 'ops-bot@beam.directory',
+      to: 'finance-agent@northwind.beam.directory',
+      intent: 'invoice.review',
+      payload: { invoiceId: 'INV-44' },
+      timestamp: '2026-03-31T09:00:00.000Z',
+      signature: 'sig-outbound',
+    })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-workspace-outbound', status: 'validated' })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-workspace-outbound', status: 'dispatched' })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-workspace-outbound', status: 'delivered' })
+    finalizeIntentLog(db, {
+      nonce: 'nonce-workspace-outbound',
+      fromBeamId: 'ops-bot@beam.directory',
+      toBeamId: 'finance-agent@northwind.beam.directory',
+      status: 'acked',
+      latencyMs: 420,
+      resultJson: JSON.stringify({ ok: true }),
+    })
+
+    logIntentStart(db, {
+      v: '1',
+      nonce: 'nonce-workspace-inbound',
+      from: 'seller-bot@outside.beam.directory',
+      to: 'ops-bot@beam.directory',
+      intent: 'partner.update',
+      payload: { orderId: 'ORD-91' },
+      timestamp: '2026-03-31T08:00:00.000Z',
+      signature: 'sig-inbound',
+    })
+    finalizeIntentLog(db, {
+      nonce: 'nonce-workspace-inbound',
+      fromBeamId: 'seller-bot@outside.beam.directory',
+      toBeamId: 'ops-bot@beam.directory',
+      status: 'failed',
+      latencyMs: 980,
+      errorCode: 'RECIPIENT_OFFLINE',
+    })
+
+    const overviewResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-ops/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewResponse.status, 200)
+
+    const overviewBody = await overviewResponse.json() as {
+      workspace: { slug: string }
+      staleAfterHours: number
+      summary: {
+        totalIdentities: number
+        activeIdentities: number
+        localIdentities: number
+        partnerIdentities: number
+        externalReadyIdentities: number
+        staleIdentities: number
+        pendingApprovals: number
+        blockedExternalMotion: number
+        recentExternalHandoffs: number
+      }
+      staleBindings: Array<{
+        reasonCode: string
+        binding: {
+          beamId: string
+        }
+      }>
+      blockedExternalMotion: Array<{
+        reasonCode: string
+        binding: {
+          beamId: string
+        }
+      }>
+      recentExternalHandoffs: Array<{
+        nonce: string
+        direction: string
+        workspaceSide: { beamId: string }
+        counterparty: { beamId: string; inWorkspace: boolean }
+      }>
+    }
+
+    assert.equal(overviewBody.workspace.slug, 'acme-ops')
+    assert.equal(overviewBody.staleAfterHours, 24)
+    assert.deepEqual(overviewBody.summary, {
+      totalIdentities: 3,
+      activeIdentities: 2,
+      localIdentities: 2,
+      partnerIdentities: 1,
+      externalReadyIdentities: 0,
+      staleIdentities: 1,
+      pendingApprovals: 1,
+      blockedExternalMotion: 2,
+      recentExternalHandoffs: 2,
+    })
+    assert.equal(overviewBody.staleBindings[0]?.binding.beamId, 'triage-bot@beam.directory')
+    assert.equal(overviewBody.staleBindings[0]?.reasonCode, 'stale_check_in')
+    assert.deepEqual(
+      overviewBody.blockedExternalMotion.map((entry) => entry.reasonCode).sort(),
+      ['binding_paused', 'manual_review_required'],
+    )
+    assert.deepEqual(
+      overviewBody.blockedExternalMotion.map((entry) => entry.binding.beamId).sort(),
+      ['ops-bot@beam.directory', 'triage-bot@beam.directory'],
+    )
+    assert.equal(overviewBody.recentExternalHandoffs[0]?.nonce, 'nonce-workspace-outbound')
+    assert.equal(overviewBody.recentExternalHandoffs[0]?.direction, 'outbound')
+    assert.equal(overviewBody.recentExternalHandoffs[0]?.workspaceSide.beamId, 'ops-bot@beam.directory')
+    assert.equal(overviewBody.recentExternalHandoffs[0]?.counterparty.beamId, 'finance-agent@northwind.beam.directory')
+    assert.equal(overviewBody.recentExternalHandoffs[0]?.counterparty.inWorkspace, true)
+    assert.equal(overviewBody.recentExternalHandoffs[1]?.nonce, 'nonce-workspace-inbound')
+    assert.equal(overviewBody.recentExternalHandoffs[1]?.direction, 'inbound')
+    assert.equal(overviewBody.recentExternalHandoffs[1]?.counterparty.beamId, 'seller-bot@outside.beam.directory')
+    assert.equal(overviewBody.recentExternalHandoffs[1]?.counterparty.inWorkspace, false)
   } finally {
     db.close()
   }


### PR DESCRIPTION
## Summary\n- add an admin workspace overview endpoint with stale identity, blocked motion, and recent external handoff signals\n- add dashboard workspace overview types, API client methods, routing, and a first operator-facing workspace page\n- cover the overview response shape with directory admin API tests\n\nCloses #114