### PR TITLE
Add workspace threads and policy control surface

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -11,7 +11,7 @@ The goal is not to clone a generic chat workspace. The goal is to give operators
 
 ## The First Data Model
 
-The first workspace foundation adds these records to the directory:
+The workspace foundation now adds these records to the directory:
 
 - `workspaces`
   - named control-plane containers for a team or company workflow
@@ -21,10 +21,14 @@ The first workspace foundation adds these records to the directory:
   - Beam identities that are active inside the workspace roster
 - `workspace_partner_channels`
   - explicit partner relationships reserved for later routing and health surfaces
+- `workspace_threads`
+  - internal-only preparation threads and external handoff threads on one operator timeline
+- `workspace_thread_participants`
+  - humans, agents, services, and partner identities attached to a workspace thread
 - `workspace_policies`
-  - the future policy document for external initiation and approval rules
+  - the policy document for external initiation and approval rules
 
-In the first slice, the operator-facing API focuses on workspaces and identity bindings. Partner channels, overview surfaces, and policy enforcement are reserved for the next milestone issues.
+The current operator-facing surface now covers workspace creation, identity bindings, overview metrics, thread timelines, and policy previews.
 
 ## Why Beam Needs This
 
@@ -45,9 +49,15 @@ The first routes are all admin-authenticated:
 - `GET /admin/workspaces`
 - `POST /admin/workspaces`
 - `GET /admin/workspaces/:slug`
+- `GET /admin/workspaces/:slug/overview`
 - `GET /admin/workspaces/:slug/identities`
 - `POST /admin/workspaces/:slug/identities`
 - `PATCH /admin/workspaces/:slug/identities/:id`
+- `GET /admin/workspaces/:slug/threads`
+- `GET /admin/workspaces/:slug/threads/:id`
+- `POST /admin/workspaces/:slug/threads`
+- `GET /admin/workspaces/:slug/policy`
+- `PATCH /admin/workspaces/:slug/policy`
 
 ### Create a workspace
 
@@ -76,6 +86,90 @@ The first routes are all admin-authenticated:
 }
 ```
 
+### Create an internal workspace thread
+
+```json
+{
+  "kind": "internal",
+  "title": "Prepare approval handoff",
+  "summary": "Align buyer owner and evidence before external send.",
+  "owner": "ops@example.com",
+  "participants": [
+    {
+      "principalId": "ops@example.com",
+      "principalType": "human",
+      "displayName": "Ops Owner",
+      "role": "owner"
+    },
+    {
+      "principalId": "ops-bot@beam.directory",
+      "principalType": "agent",
+      "beamId": "ops-bot@beam.directory",
+      "workspaceBindingId": 12,
+      "role": "participant"
+    }
+  ]
+}
+```
+
+### Create a linked handoff thread
+
+```json
+{
+  "kind": "handoff",
+  "title": "Quote approval handoff",
+  "summary": "External finance approval with async proof.",
+  "owner": "ops@example.com",
+  "workflowType": "quote.approval",
+  "linkedIntentNonce": "nonce-thread-handoff",
+  "participants": [
+    {
+      "principalId": "ops-bot@beam.directory",
+      "principalType": "agent",
+      "beamId": "ops-bot@beam.directory",
+      "workspaceBindingId": 12,
+      "role": "owner"
+    },
+    {
+      "principalId": "finance@northwind.beam.directory",
+      "principalType": "partner",
+      "beamId": "finance@northwind.beam.directory",
+      "workspaceBindingId": 13,
+      "role": "participant"
+    }
+  ]
+}
+```
+
+### Patch a workspace policy
+
+```json
+{
+  "defaults": {
+    "externalInitiation": "deny",
+    "allowedPartners": ["*@northwind.beam.directory"]
+  },
+  "bindingRules": [
+    {
+      "policyProfile": "finance-outbound",
+      "externalInitiation": "allow",
+      "allowedPartners": ["finance@northwind.beam.directory"]
+    }
+  ],
+  "workflowRules": [
+    {
+      "workflowType": "quote.approval",
+      "requireApproval": true,
+      "allowedPartners": ["finance@northwind.beam.directory"],
+      "approvers": ["ops@example.com", "approvals@example.com"]
+    }
+  ],
+  "metadata": {
+    "notes": "Finance outbound handoffs need named approvers."
+  }
+}
+```
+
 ## Design Boundary
 
 Beam Workspaces are intentionally narrower than products like OpenAgents Workspace.
@@ -91,11 +185,12 @@ The differentiator is:
 
 That is why Workspaces start as a control-plane surface first.
 
-## What Comes Next
+## Current Operator View
 
-The next issues in the workspace milestone add:
+The dashboard now surfaces:
 
-1. richer identity binding and roster behavior
-2. a workspace overview API and dashboard page
-3. internal vs external thread modeling
-4. policy engine v1 for external initiation and approval requirements
+1. workspace overview metrics for stale identities, manual review, and blocked outbound motion
+2. internal and external workspace threads on one page, with direct trace links for handoff threads
+3. policy previews showing which bindings can initiate external motion and which workflows require approvals
+
+This keeps Beam Workspace focused on identity ownership, policy, and cross-company control instead of drifting into a generic collaboration product.

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -14,6 +14,12 @@ export type WorkspaceStatus = 'active' | 'paused' | 'archived'
 export type WorkspaceThreadScope = 'internal' | 'handoff'
 export type WorkspaceBindingType = 'agent' | 'service' | 'partner'
 export type WorkspaceBindingStatus = 'active' | 'paused'
+export type WorkspacePrincipalType = 'human' | 'agent' | 'service' | 'partner'
+export type WorkspaceThreadKind = 'internal' | 'handoff'
+export type WorkspaceThreadStatus = 'open' | 'blocked' | 'closed'
+export type WorkspaceThreadParticipantRole = 'owner' | 'participant' | 'observer' | 'approver'
+export type WorkspacePolicyDefaultExternalInitiation = 'binding' | 'deny'
+export type WorkspacePolicyRuleExternalInitiation = 'inherit' | 'allow' | 'deny'
 export type WorkspaceOverviewAttentionCode =
   | 'identity_missing'
   | 'stale_check_in'
@@ -194,6 +200,128 @@ export interface WorkspaceOverviewResponse {
   blockedExternalMotion: WorkspaceOverviewAttentionItem[]
   recentExternalHandoffs: WorkspaceOverviewHandoff[]
 }
+
+export interface WorkspaceThreadTrace {
+  nonce: string
+  status: IntentLifecycleStatus
+  intentType: string
+  fromBeamId: string
+  toBeamId: string
+  requestedAt: string
+  completedAt: string | null
+  latencyMs: number | null
+  errorCode: string | null
+  href: string
+}
+
+export interface WorkspaceThread {
+  id: number
+  workspaceId: number
+  kind: WorkspaceThreadKind
+  title: string
+  summary: string | null
+  owner: string | null
+  status: WorkspaceThreadStatus
+  workflowType: string | null
+  linkedIntentNonce: string | null
+  lastActivityAt: string
+  createdAt: string
+  updatedAt: string
+  participantCount: number
+  trace: WorkspaceThreadTrace | null
+}
+
+export interface WorkspaceThreadParticipant {
+  id: number
+  threadId: number
+  principalId: string
+  principalType: WorkspacePrincipalType
+  displayName: string | null
+  beamId: string | null
+  workspaceBindingId: number | null
+  role: WorkspaceThreadParticipantRole
+  createdAt: string
+  updatedAt: string
+  identity: {
+    existsLocally: boolean
+    displayName: string | null
+    org: string | null
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+  } | null
+}
+
+export interface WorkspaceThreadsResponse {
+  workspace: WorkspaceRecord
+  threads: WorkspaceThread[]
+  total: number
+}
+
+export interface WorkspaceThreadDetailResponse {
+  workspace: WorkspaceRecord
+  thread: WorkspaceThread
+  participants: WorkspaceThreadParticipant[]
+}
+
+export interface WorkspacePolicyBindingRule {
+  beamId: string | null
+  bindingType: WorkspaceBindingType | null
+  policyProfile: string | null
+  externalInitiation: WorkspacePolicyRuleExternalInitiation
+  allowedPartners: string[]
+}
+
+export interface WorkspacePolicyWorkflowRule {
+  workflowType: string
+  requireApproval: boolean
+  allowedPartners: string[]
+  approvers: string[]
+}
+
+export interface WorkspacePolicyDocument {
+  version: 1
+  defaults: {
+    externalInitiation: WorkspacePolicyDefaultExternalInitiation
+    allowedPartners: string[]
+  }
+  bindingRules: WorkspacePolicyBindingRule[]
+  workflowRules: WorkspacePolicyWorkflowRule[]
+  metadata: {
+    notes: string | null
+  }
+}
+
+export interface WorkspacePolicyPreview {
+  beamId: string
+  bindingType: WorkspaceBindingType
+  policyProfile: string | null
+  externalInitiation: 'allow' | 'deny'
+  allowedPartners: string[]
+  approvalRequired: boolean
+  approvers: string[]
+  matchedBindingRules: number
+  matchedWorkflowRules: number
+  workflowType: string | null
+}
+
+export interface WorkspaceWorkflowPolicyPreview {
+  workflowType: string
+  bindings: WorkspacePolicyPreview[]
+}
+
+export interface WorkspacePolicyResponse {
+  workspace: WorkspaceRecord
+  policy: WorkspacePolicyDocument
+  updatedAt: string | null
+  updatedBy: string | null
+  previews: {
+    bindings: WorkspacePolicyPreview[]
+    workflows: WorkspaceWorkflowPolicyPreview[]
+  }
+}
+
+export type WorkspacePolicyPatchInput = Partial<WorkspacePolicyDocument>
 
 export interface BusHealth {
   status: string
@@ -1282,6 +1410,13 @@ export const directoryApi = {
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
   listWorkspaces: () => request<WorkspaceListResponse>('/admin/workspaces', undefined, { admin: true }),
   getWorkspaceOverview: (slug: string) => request<WorkspaceOverviewResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/overview`, undefined, { admin: true }),
+  listWorkspaceThreads: (slug: string) => request<WorkspaceThreadsResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads`, undefined, { admin: true }),
+  getWorkspaceThread: (slug: string, id: number) => request<WorkspaceThreadDetailResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads/${id}`, undefined, { admin: true }),
+  getWorkspacePolicy: (slug: string) => request<WorkspacePolicyResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, undefined, { admin: true }),
+  updateWorkspacePolicy: (slug: string, input: WorkspacePolicyPatchInput) => request<WorkspacePolicyResponse & { updated: boolean }>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   heartbeat: (beamId: string) => request<DirectoryAgent>(`/agents/${encodeURIComponent(beamId)}/heartbeat`, { method: 'POST' }),
   registerAgent: (input: RegisterAgentInput) => request<DirectoryAgent>('/agents/register', {
     method: 'POST',

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -8,8 +8,13 @@ import {
   type WorkspaceOverviewAttentionCode,
   type WorkspaceOverviewAttentionItem,
   type WorkspaceOverviewResponse,
+  type WorkspacePolicyPreview,
+  type WorkspacePolicyResponse,
   type WorkspaceRecord,
   type WorkspaceStatus,
+  type WorkspaceThread,
+  type WorkspaceThreadDetailResponse,
+  type WorkspaceThreadStatus,
 } from '../lib/api'
 import { formatDateTime, formatLatency, formatNumber, formatRelativeTime } from '../lib/utils'
 
@@ -72,8 +77,23 @@ function attentionLabel(code: WorkspaceOverviewAttentionCode): string {
   }
 }
 
+function threadStatusTone(status: WorkspaceThreadStatus): 'default' | 'success' | 'warning' {
+  switch (status) {
+    case 'closed':
+      return 'success'
+    case 'blocked':
+      return 'warning'
+    default:
+      return 'default'
+  }
+}
+
 function displayName(label: string | null, beamId: string): string {
   return label || beamId
+}
+
+function summarizeList(values: string[], fallback: string): string {
+  return values.length > 0 ? values.join(', ') : fallback
 }
 
 function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
@@ -89,18 +109,52 @@ function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
   return parts.join(' · ')
 }
 
+function renderPolicyMeta(preview: WorkspacePolicyPreview): string {
+  const parts = [
+    preview.policyProfile ? `Profile ${preview.policyProfile}` : 'No policy profile',
+    preview.matchedBindingRules > 0 ? `${preview.matchedBindingRules} binding rule${preview.matchedBindingRules === 1 ? '' : 's'}` : 'Binding defaults only',
+  ]
+
+  if (preview.matchedWorkflowRules > 0) {
+    parts.push(`${preview.matchedWorkflowRules} workflow rule${preview.matchedWorkflowRules === 1 ? '' : 's'}`)
+  }
+
+  return parts.join(' · ')
+}
+
 export default function WorkspacesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [workspaces, setWorkspaces] = useState<WorkspaceRecord[]>([])
   const [overview, setOverview] = useState<WorkspaceOverviewResponse | null>(null)
+  const [threads, setThreads] = useState<WorkspaceThread[]>([])
+  const [threadDetail, setThreadDetail] = useState<WorkspaceThreadDetailResponse | null>(null)
+  const [policy, setPolicy] = useState<WorkspacePolicyResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [overviewLoading, setOverviewLoading] = useState(false)
+  const [threadsLoading, setThreadsLoading] = useState(false)
+  const [threadDetailLoading, setThreadDetailLoading] = useState(false)
+  const [policyLoading, setPolicyLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const selectedSlug = searchParams.get('workspace') ?? ''
+  const selectedThreadId = useMemo(() => {
+    const raw = searchParams.get('thread')
+    if (!raw) {
+      return null
+    }
+
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }, [searchParams])
+
   const selectedWorkspace = useMemo(
     () => workspaces.find((entry) => entry.slug === selectedSlug) ?? workspaces[0] ?? null,
     [selectedSlug, workspaces],
+  )
+
+  const selectedThread = useMemo(
+    () => threads.find((entry) => entry.id === selectedThreadId) ?? threads[0] ?? null,
+    [selectedThreadId, threads],
   )
 
   async function loadWorkspaces() {
@@ -129,6 +183,45 @@ export default function WorkspacesPage() {
     }
   }
 
+  async function loadThreads(slug: string) {
+    try {
+      setThreadsLoading(true)
+      const response = await directoryApi.listWorkspaceThreads(slug)
+      setThreads(response.threads)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load workspace threads')
+    } finally {
+      setThreadsLoading(false)
+    }
+  }
+
+  async function loadThreadDetail(slug: string, threadId: number) {
+    try {
+      setThreadDetailLoading(true)
+      const response = await directoryApi.getWorkspaceThread(slug, threadId)
+      setThreadDetail(response)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load workspace thread detail')
+    } finally {
+      setThreadDetailLoading(false)
+    }
+  }
+
+  async function loadPolicy(slug: string) {
+    try {
+      setPolicyLoading(true)
+      const response = await directoryApi.getWorkspacePolicy(slug)
+      setPolicy(response)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Failed to load workspace policy')
+    } finally {
+      setPolicyLoading(false)
+    }
+  }
+
   useEffect(() => {
     void loadWorkspaces()
   }, [])
@@ -148,17 +241,52 @@ export default function WorkspacesPage() {
   useEffect(() => {
     if (!selectedWorkspace) {
       setOverview(null)
+      setThreads([])
+      setThreadDetail(null)
+      setPolicy(null)
       return
     }
 
     void loadOverview(selectedWorkspace.slug)
+    void loadThreads(selectedWorkspace.slug)
+    void loadPolicy(selectedWorkspace.slug)
   }, [selectedWorkspace?.slug])
+
+  useEffect(() => {
+    if (!selectedWorkspace) {
+      return
+    }
+
+    const current = searchParams.get('thread')
+    const next = new URLSearchParams(searchParams)
+    if (selectedThread) {
+      if (current !== String(selectedThread.id)) {
+        next.set('thread', String(selectedThread.id))
+        setSearchParams(next, { replace: true })
+      }
+      return
+    }
+
+    if (current) {
+      next.delete('thread')
+      setSearchParams(next, { replace: true })
+    }
+  }, [searchParams, selectedThread, selectedWorkspace, setSearchParams])
+
+  useEffect(() => {
+    if (!selectedWorkspace || !selectedThread) {
+      setThreadDetail(null)
+      return
+    }
+
+    void loadThreadDetail(selectedWorkspace.slug, selectedThread.id)
+  }, [selectedWorkspace?.slug, selectedThread?.id])
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Workspaces"
-        description="Identity home, external handoff controls, and operator attention for Beam workspaces."
+        description="Identity home, external handoff controls, thread timelines, and operator policy previews for Beam workspaces."
         actions={(
           <div className="flex flex-wrap items-center gap-2">
             {workspaces.length > 0 ? (
@@ -168,6 +296,7 @@ export default function WorkspacesPage() {
                 onChange={(event) => {
                   const next = new URLSearchParams(searchParams)
                   next.set('workspace', event.target.value)
+                  next.delete('thread')
                   setSearchParams(next, { replace: true })
                 }}
               >
@@ -188,6 +317,11 @@ export default function WorkspacesPage() {
                 void loadWorkspaces()
                 if (selectedWorkspace) {
                   void loadOverview(selectedWorkspace.slug)
+                  void loadThreads(selectedWorkspace.slug)
+                  void loadPolicy(selectedWorkspace.slug)
+                  if (selectedThread) {
+                    void loadThreadDetail(selectedWorkspace.slug, selectedThread.id)
+                  }
                 }
               }}
             >
@@ -204,7 +338,7 @@ export default function WorkspacesPage() {
       ) : null}
 
       {!loading && workspaces.length === 0 ? (
-        <EmptyPanel label="No Beam workspaces exist yet. Create one from the admin API first, then this surface will show identity health and external motion." />
+        <EmptyPanel label="No Beam workspaces exist yet. Create one from the admin API first, then this surface will show identity health, threads, and partner policy previews." />
       ) : null}
 
       {selectedWorkspace ? (
@@ -222,7 +356,7 @@ export default function WorkspacesPage() {
             <div className="panel">
               <div className="panel-title">Workspace roster</div>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                Choose the workspace whose identity surface and outbound readiness you want to inspect.
+                Choose the workspace whose identity surface, thread timeline, and outbound readiness you want to inspect.
               </p>
               <div className="mt-4 space-y-3">
                 {loading ? (
@@ -242,6 +376,7 @@ export default function WorkspacesPage() {
                         onClick={() => {
                           const next = new URLSearchParams(searchParams)
                           next.set('workspace', workspace.slug)
+                          next.delete('thread')
                           setSearchParams(next, { replace: true })
                         }}
                       >
@@ -279,7 +414,7 @@ export default function WorkspacesPage() {
                     label={selectedWorkspace.externalHandoffsEnabled ? 'External handoffs enabled' : 'External handoffs disabled'}
                     tone={selectedWorkspace.externalHandoffsEnabled ? 'success' : 'warning'}
                   />
-                  <StatusPill label={selectedWorkspace.policyConfigured ? 'Policy configured' : 'Policy missing'} tone={selectedWorkspace.policyConfigured ? 'success' : 'warning'} />
+                  <StatusPill label={selectedWorkspace.policyConfigured ? 'Policy configured' : 'Policy default-only'} tone={selectedWorkspace.policyConfigured ? 'success' : 'warning'} />
                 </div>
               </div>
 
@@ -294,8 +429,8 @@ export default function WorkspacesPage() {
                 <div className="font-medium text-slate-900 dark:text-slate-100">What this page is telling you</div>
                 <div className="mt-1">
                   Beam marks a workspace as risky when identities stop checking in, when outbound motion is paused or still manual,
-                  or when recent partner-facing traces are failing. Trace links below jump into the existing intent feed. Beta requests stay the
-                  operator surface for partner follow-up and proof-pack motion.
+                  or when recent partner-facing traces are failing. Threads below distinguish internal prep from cross-company motion, and the policy
+                  preview shows which bindings can move outward and which workflows still need explicit approval.
                 </div>
               </div>
             </div>
@@ -380,6 +515,332 @@ export default function WorkspacesPage() {
                       </div>
                       <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.reason}</div>
                       <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{renderAttentionMeta(item)}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[0.9fr,1.1fr]">
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Workspace threads</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Internal prep stays separate from external Beam handoffs, but both live on one operator timeline.
+                  </p>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">
+                  {threadsLoading ? 'Loading…' : `${formatNumber(threads.length)} threads`}
+                </div>
+              </div>
+              <div className="mt-4 space-y-3">
+                {threadsLoading ? (
+                  <EmptyPanel label="Loading workspace threads…" />
+                ) : threads.length === 0 ? (
+                  <EmptyPanel label="No workspace threads were recorded yet." />
+                ) : (
+                  threads.map((thread) => {
+                    const selected = thread.id === selectedThread?.id
+                    return (
+                      <button
+                        key={thread.id}
+                        type="button"
+                        className={`w-full rounded-2xl border px-4 py-4 text-left transition ${
+                          selected
+                            ? 'border-orange-300 bg-orange-50/80 dark:border-orange-500/40 dark:bg-orange-500/10'
+                            : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-900'
+                        }`}
+                        onClick={() => {
+                          const next = new URLSearchParams(searchParams)
+                          next.set('workspace', selectedWorkspace.slug)
+                          next.set('thread', String(thread.id))
+                          setSearchParams(next, { replace: true })
+                        }}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium">{thread.title}</div>
+                            <div className="mt-1 truncate text-xs text-slate-500 dark:text-slate-400">
+                              {thread.summary || 'No thread summary yet.'}
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap justify-end gap-2">
+                            <StatusPill label={thread.kind} tone={thread.kind === 'handoff' ? 'success' : 'default'} />
+                            <StatusPill label={thread.status} tone={threadStatusTone(thread.status)} />
+                            {thread.trace ? <StatusPill label={thread.trace.status} tone={handoffStatusTone(thread.trace.status)} /> : null}
+                          </div>
+                        </div>
+
+                        <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                          <div>{thread.workflowType ? `Workflow ${thread.workflowType}` : 'Internal-only thread'}</div>
+                          <div>{formatNumber(thread.participantCount)} participants</div>
+                          <div>{thread.owner ? `Owner ${thread.owner}` : 'No owner assigned'}</div>
+                          <div>Last active {formatRelativeTime(thread.lastActivityAt)}</div>
+                        </div>
+                      </button>
+                    )
+                  })
+                )}
+              </div>
+            </div>
+
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Thread detail</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Read the participant set, linked Beam trace, and the exact workflow mode for the selected thread.
+                  </p>
+                </div>
+                {selectedThread ? (
+                  <StatusPill label={selectedThread.kind === 'handoff' ? 'Cross-company motion' : 'Internal prep'} tone={selectedThread.kind === 'handoff' ? 'success' : 'default'} />
+                ) : null}
+              </div>
+
+              <div className="mt-4">
+                {threadDetailLoading ? (
+                  <EmptyPanel label="Loading thread detail…" />
+                ) : !threadDetail ? (
+                  <EmptyPanel label="Select a workspace thread to inspect participants, trace linkage, and workflow state." />
+                ) : (
+                  <div className="space-y-4">
+                    <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{threadDetail.thread.title}</div>
+                          <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                            {threadDetail.thread.summary || 'No thread summary is attached yet.'}
+                          </div>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={threadDetail.thread.kind} tone={threadDetail.thread.kind === 'handoff' ? 'success' : 'default'} />
+                          <StatusPill label={threadDetail.thread.status} tone={threadStatusTone(threadDetail.thread.status)} />
+                          {threadDetail.thread.trace ? <StatusPill label={threadDetail.thread.trace.status} tone={handoffStatusTone(threadDetail.thread.trace.status)} /> : null}
+                        </div>
+                      </div>
+
+                      <div className="mt-4 grid gap-3 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-slate-400">Workflow</div>
+                          <div>{threadDetail.thread.workflowType || 'Internal coordination'}</div>
+                        </div>
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-slate-400">Owner</div>
+                          <div>{threadDetail.thread.owner || 'Unassigned'}</div>
+                        </div>
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-slate-400">Participants</div>
+                          <div>{formatNumber(threadDetail.thread.participantCount)}</div>
+                        </div>
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-slate-400">Last activity</div>
+                          <div>{formatRelativeTime(threadDetail.thread.lastActivityAt)}</div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Participants</div>
+                        <div className="text-xs text-slate-500 dark:text-slate-400">{formatNumber(threadDetail.participants.length)} total</div>
+                      </div>
+                      <div className="mt-3 space-y-3">
+                        {threadDetail.participants.map((participant) => (
+                          <div key={participant.id} className="rounded-2xl border border-slate-200 p-3 dark:border-slate-800">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                                  {participant.displayName || participant.beamId || participant.principalId}
+                                </div>
+                                <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                                  {participant.beamId || participant.principalId}
+                                </div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <StatusPill label={participant.role} />
+                                <StatusPill label={participant.principalType} tone={participant.principalType === 'partner' ? 'warning' : 'default'} />
+                              </div>
+                            </div>
+                            <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                              {participant.identity?.lastSeen
+                                ? `Last seen ${formatRelativeTime(participant.identity.lastSeen)}`
+                                : participant.identity
+                                  ? 'Local identity without heartbeat yet'
+                                  : 'Manual participant record'}
+                              {participant.workspaceBindingId ? ` · Binding #${participant.workspaceBindingId}` : ''}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Beam trace linkage</div>
+                        {threadDetail.thread.trace ? (
+                          <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={threadDetail.thread.trace.href}>
+                            Open trace
+                          </Link>
+                        ) : null}
+                      </div>
+                      {threadDetail.thread.trace ? (
+                        <div className="mt-3 grid gap-3 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Intent</div>
+                            <div>{threadDetail.thread.trace.intentType}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Path</div>
+                            <div>{threadDetail.thread.trace.fromBeamId} → {threadDetail.thread.trace.toBeamId}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Requested</div>
+                            <div>{formatRelativeTime(threadDetail.thread.trace.requestedAt)}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Latency</div>
+                            <div>{formatLatency(threadDetail.thread.trace.latencyMs)}</div>
+                          </div>
+                          {threadDetail.thread.trace.errorCode ? (
+                            <div className="md:col-span-2 xl:col-span-4 text-red-600 dark:text-red-300">
+                              {threadDetail.thread.trace.errorCode}
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <div className="mt-3 text-sm text-slate-500 dark:text-slate-400">
+                          Internal threads do not need a linked Beam nonce. Use them to organize prep, approvals, and operator work before external motion starts.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-6 xl:grid-cols-[0.95fr,1.05fr]">
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Policy surface</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    These previews show which workspace bindings can initiate external motion and what partner scope they inherit.
+                  </p>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">
+                  {policyLoading ? 'Loading…' : policy?.updatedAt ? `Updated ${formatRelativeTime(policy.updatedAt)}` : 'Default policy'}
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <MetricCard label="Default external initiation" value={policyLoading || !policy ? '—' : policy.policy.defaults.externalInitiation} tone={policy?.policy.defaults.externalInitiation === 'deny' ? 'warning' : 'default'} />
+                <MetricCard label="Default partner allowlist" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.defaults.allowedPartners.length)} />
+                <MetricCard label="Binding rules" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.bindingRules.length)} />
+                <MetricCard label="Workflow rules" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.workflowRules.length)} hint={policy?.updatedBy ? `Updated by ${policy.updatedBy}` : 'No explicit updater yet'} />
+              </div>
+
+              <div className="mt-4 rounded-2xl border border-slate-200 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                <div className="font-medium text-slate-900 dark:text-slate-100">Operator note</div>
+                <div className="mt-1">
+                  {policyLoading || !policy
+                    ? 'Loading workspace policy notes…'
+                    : policy.policy.metadata.notes || 'No workspace-specific note is attached yet. The workspace is using its default policy envelope.'}
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                {policyLoading || !policy ? (
+                  <EmptyPanel label="Loading binding previews…" />
+                ) : policy.previews.bindings.length === 0 ? (
+                  <EmptyPanel label="No local bindings are available for policy preview yet." />
+                ) : (
+                  policy.previews.bindings.map((preview) => (
+                    <div key={preview.beamId} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{preview.beamId}</div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{renderPolicyMeta(preview)}</div>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={preview.bindingType} />
+                          <StatusPill label={preview.externalInitiation} tone={preview.externalInitiation === 'allow' ? 'success' : 'warning'} />
+                        </div>
+                      </div>
+                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                        {summarizeList(preview.allowedPartners, 'No explicit partner allowlist. The binding relies on workspace defaults or downstream approval rules.')}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Workflow approvals</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Workflow-level previews show when a handoff can leave the workspace immediately and when Beam should stop for named approvers.
+                  </p>
+                </div>
+                <a
+                  className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300"
+                  href="https://docs.beam.directory/guide/beam-workspaces"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Workspace guide
+                </a>
+              </div>
+
+              <div className="mt-4 space-y-4">
+                {policyLoading || !policy ? (
+                  <EmptyPanel label="Loading workflow previews…" />
+                ) : policy.previews.workflows.length === 0 ? (
+                  <EmptyPanel label="No workflow-specific approval rules are configured for this workspace yet." />
+                ) : (
+                  policy.previews.workflows.map((workflow) => (
+                    <div key={workflow.workflowType} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{workflow.workflowType}</div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                            {formatNumber(workflow.bindings.length)} binding previews
+                          </div>
+                        </div>
+                        <StatusPill
+                          label={workflow.bindings.some((binding) => binding.approvalRequired) ? 'Approval path present' : 'Direct path only'}
+                          tone={workflow.bindings.some((binding) => binding.approvalRequired) ? 'warning' : 'success'}
+                        />
+                      </div>
+
+                      <div className="mt-3 space-y-3">
+                        {workflow.bindings.map((binding) => (
+                          <div key={`${workflow.workflowType}-${binding.beamId}`} className="rounded-2xl border border-slate-200 p-3 dark:border-slate-800">
+                            <div className="flex flex-wrap items-start justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{binding.beamId}</div>
+                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{renderPolicyMeta(binding)}</div>
+                              </div>
+                              <div className="flex flex-wrap gap-2">
+                                <StatusPill label={binding.externalInitiation} tone={binding.externalInitiation === 'allow' ? 'success' : 'warning'} />
+                                <StatusPill label={binding.approvalRequired ? 'Approval required' : 'No approval'} tone={binding.approvalRequired ? 'warning' : 'success'} />
+                              </div>
+                            </div>
+                            <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                              <div>{summarizeList(binding.allowedPartners, 'No additional workflow-scoped partner allowlist.')}</div>
+                              {binding.approvalRequired ? (
+                                <div className="mt-2">
+                                  Approvers: {summarizeList(binding.approvers, 'No approvers listed')}
+                                </div>
+                              ) : null}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   ))
                 )}

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -326,7 +326,7 @@ test('createDatabase migrates legacy waitlist tables before creating status inde
   }
 })
 
-test('createDatabase adds beam workspace foundation tables to legacy databases', () => {
+test('createDatabase adds beam workspace control-plane tables to legacy databases', () => {
   const { root, dbPath } = createTempDbPath()
   const legacyDb = new Database(dbPath)
 
@@ -369,7 +369,9 @@ test('createDatabase adds beam workspace foundation tables to legacy databases',
           'workspace_members',
           'workspace_identity_bindings',
           'workspace_partner_channels',
-          'workspace_policies'
+          'workspace_policies',
+          'workspace_threads',
+          'workspace_thread_participants'
         )
       ORDER BY name ASC
     `).all() as Array<{ name: string }>
@@ -381,6 +383,8 @@ test('createDatabase adds beam workspace foundation tables to legacy databases',
         'workspace_members',
         'workspace_partner_channels',
         'workspace_policies',
+        'workspace_thread_participants',
+        'workspace_threads',
         'workspaces',
       ],
     )
@@ -389,6 +393,14 @@ test('createDatabase adds beam workspace foundation tables to legacy databases',
     assert.ok(bindingColumns.some((column) => column.name === 'default_thread_scope'))
     assert.ok(bindingColumns.some((column) => column.name === 'can_initiate_external'))
     assert.ok(bindingColumns.some((column) => column.name === 'runtime_type'))
+
+    const threadColumns = db.prepare('PRAGMA table_info(workspace_threads)').all() as Array<{ name: string }>
+    assert.ok(threadColumns.some((column) => column.name === 'kind'))
+    assert.ok(threadColumns.some((column) => column.name === 'linked_intent_nonce'))
+
+    const participantColumns = db.prepare('PRAGMA table_info(workspace_thread_participants)').all() as Array<{ name: string }>
+    assert.ok(participantColumns.some((column) => column.name === 'principal_type'))
+    assert.ok(participantColumns.some((column) => column.name === 'workspace_binding_id'))
   } finally {
     db.close()
     rmSync(root, { force: true, recursive: true })

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -26,8 +26,11 @@ import type {
   TrustScoreRow,
   VerificationTier,
   WorkspaceIdentityBindingRow,
+  WorkspacePolicy,
   WorkspacePolicyRow,
   WorkspaceRow,
+  WorkspaceThreadParticipantRow,
+  WorkspaceThreadRow,
 } from './types.js'
 import { generateDIDDocument, generateDIDDocumentWithKeys, toBeamDID, type DIDDocument } from './did.js'
 import {
@@ -43,6 +46,7 @@ import {
   parsePublicEndpointShieldPolicy,
   type PublicEndpointShieldPolicy,
 } from './shield/policies.js'
+import { mergeWorkspacePolicy, parseWorkspacePolicy } from './workspace-policy.js'
 
 const BEAM_DOMAIN_SUFFIX = 'beam.directory'
 const PUBLIC_ENDPOINT_POLICY_KEY = 'public-endpoints'
@@ -256,6 +260,48 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_workspace_partner_channels_workspace
       ON workspace_partner_channels(workspace_id, status, partner_beam_id);
+
+    CREATE TABLE IF NOT EXISTS workspace_threads (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workspace_id INTEGER NOT NULL,
+      kind TEXT NOT NULL CHECK(kind IN ('internal', 'handoff')),
+      title TEXT NOT NULL,
+      summary TEXT,
+      owner TEXT,
+      status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'blocked', 'closed')),
+      workflow_type TEXT,
+      linked_intent_nonce TEXT,
+      last_activity_at TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+      FOREIGN KEY (linked_intent_nonce) REFERENCES intent_log(nonce) ON DELETE SET NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_threads_workspace
+      ON workspace_threads(workspace_id, status, last_activity_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_threads_nonce
+      ON workspace_threads(linked_intent_nonce);
+
+    CREATE TABLE IF NOT EXISTS workspace_thread_participants (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      thread_id INTEGER NOT NULL,
+      principal_id TEXT NOT NULL,
+      principal_type TEXT NOT NULL CHECK(principal_type IN ('human', 'agent', 'service', 'partner')),
+      display_name TEXT,
+      beam_id TEXT,
+      workspace_binding_id INTEGER,
+      role TEXT NOT NULL DEFAULT 'participant' CHECK(role IN ('owner', 'participant', 'observer', 'approver')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (thread_id) REFERENCES workspace_threads(id) ON DELETE CASCADE,
+      FOREIGN KEY (workspace_binding_id) REFERENCES workspace_identity_bindings(id) ON DELETE SET NULL,
+      UNIQUE(thread_id, principal_id, principal_type, role)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_workspace_thread_participants_thread
+      ON workspace_thread_participants(thread_id, role, principal_type);
 
     CREATE TABLE IF NOT EXISTS workspace_policies (
       workspace_id INTEGER PRIMARY KEY,
@@ -1190,6 +1236,181 @@ export function updateWorkspaceIdentityBinding(
   )
 
   return getWorkspaceIdentityBindingById(db, input.id)
+}
+
+export function getWorkspaceThreadById(db: DB, id: number): WorkspaceThreadRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_threads
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as WorkspaceThreadRow | undefined
+
+  return row ?? null
+}
+
+export function listWorkspaceThreads(db: DB, workspaceId: number): WorkspaceThreadRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM workspace_threads
+    WHERE workspace_id = ?
+    ORDER BY datetime(last_activity_at) DESC, id DESC
+  `).all(workspaceId) as WorkspaceThreadRow[]
+}
+
+export function createWorkspaceThread(
+  db: DB,
+  input: {
+    workspaceId: number
+    kind: WorkspaceThreadRow['kind']
+    title: string
+    summary?: string | null
+    owner?: string | null
+    status?: WorkspaceThreadRow['status']
+    workflowType?: string | null
+    linkedIntentNonce?: string | null
+    lastActivityAt?: string
+  },
+): WorkspaceThreadRow {
+  const now = nowIso()
+  const result = db.prepare(`
+    INSERT INTO workspace_threads (
+      workspace_id,
+      kind,
+      title,
+      summary,
+      owner,
+      status,
+      workflow_type,
+      linked_intent_nonce,
+      last_activity_at,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.workspaceId,
+    input.kind,
+    input.title,
+    input.summary ?? null,
+    input.owner ?? null,
+    input.status ?? 'open',
+    input.workflowType ?? null,
+    input.linkedIntentNonce ?? null,
+    input.lastActivityAt ?? now,
+    now,
+    now,
+  )
+
+  const thread = getWorkspaceThreadById(db, Number(result.lastInsertRowid))
+  if (!thread) {
+    throw new Error('Workspace thread insert succeeded but row was not found')
+  }
+
+  return thread
+}
+
+export function listWorkspaceThreadParticipants(db: DB, threadId: number): WorkspaceThreadParticipantRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM workspace_thread_participants
+    WHERE thread_id = ?
+    ORDER BY
+      CASE role
+        WHEN 'owner' THEN 0
+        WHEN 'approver' THEN 1
+        WHEN 'participant' THEN 2
+        ELSE 3
+      END ASC,
+      COALESCE(display_name, principal_id) ASC,
+      id ASC
+  `).all(threadId) as WorkspaceThreadParticipantRow[]
+}
+
+export function createWorkspaceThreadParticipant(
+  db: DB,
+  input: {
+    threadId: number
+    principalId: string
+    principalType: WorkspaceThreadParticipantRow['principal_type']
+    displayName?: string | null
+    beamId?: string | null
+    workspaceBindingId?: number | null
+    role?: WorkspaceThreadParticipantRow['role']
+  },
+): WorkspaceThreadParticipantRow {
+  const now = nowIso()
+  const result = db.prepare(`
+    INSERT INTO workspace_thread_participants (
+      thread_id,
+      principal_id,
+      principal_type,
+      display_name,
+      beam_id,
+      workspace_binding_id,
+      role,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.threadId,
+    input.principalId,
+    input.principalType,
+    input.displayName ?? null,
+    input.beamId ?? null,
+    input.workspaceBindingId ?? null,
+    input.role ?? 'participant',
+    now,
+    now,
+  )
+
+  return db.prepare(`
+    SELECT *
+    FROM workspace_thread_participants
+    WHERE id = ?
+  `).get(Number(result.lastInsertRowid)) as WorkspaceThreadParticipantRow
+}
+
+export function getWorkspacePolicyDocument(
+  db: DB,
+  workspaceId: number,
+): { policy: WorkspacePolicy; updatedAt: string | null; updatedBy: string | null } {
+  const row = getWorkspacePolicy(db, workspaceId)
+  return {
+    policy: parseWorkspacePolicy(row?.policy_json),
+    updatedAt: row?.updated_at ?? null,
+    updatedBy: row?.updated_by ?? null,
+  }
+}
+
+export function updateWorkspacePolicyDocument(
+  db: DB,
+  workspaceId: number,
+  patch: Partial<WorkspacePolicy>,
+  updatedBy: string | null,
+): { policy: WorkspacePolicy; updatedAt: string; updatedBy: string | null } {
+  const current = getWorkspacePolicyDocument(db, workspaceId).policy
+  const merged = mergeWorkspacePolicy(current, patch)
+  const updatedAt = nowIso()
+
+  db.prepare(`
+    INSERT INTO workspace_policies (workspace_id, policy_json, updated_at, updated_by)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(workspace_id) DO UPDATE SET
+      policy_json = excluded.policy_json,
+      updated_at = excluded.updated_at,
+      updated_by = excluded.updated_by
+  `).run(
+    workspaceId,
+    JSON.stringify(merged),
+    updatedAt,
+    updatedBy,
+  )
+
+  return {
+    policy: merged,
+    updatedAt,
+    updatedBy,
+  }
 }
 
 export function listOrgAgents(db: DB, orgName: string): Array<OrgAgentRow & Partial<AgentRow>> {

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -4,17 +4,24 @@ import { requireAdminRole } from '../admin-auth.js'
 import {
   createWorkspace,
   createWorkspaceIdentityBinding,
+  createWorkspaceThread,
+  createWorkspaceThreadParticipant,
   getAgent,
+  getIntentLogByNonce,
   getOrg,
   getWorkspaceBySlug,
   getWorkspaceIdentityBindingByBeamId,
   getWorkspaceIdentityBindingById,
-  getWorkspacePolicy,
+  getWorkspacePolicyDocument,
   getWorkspaceSummary,
+  getWorkspaceThreadById,
   listAgentKeys,
   listWorkspaceIdentityBindings,
+  listWorkspaceThreadParticipants,
+  listWorkspaceThreads,
   listWorkspaces,
   logAuditEvent,
+  updateWorkspacePolicyDocument,
   updateWorkspaceIdentityBinding,
 } from '../db.js'
 import type {
@@ -22,15 +29,27 @@ import type {
   WorkspaceIdentityBindingRow,
   WorkspaceIdentityBindingStatus,
   WorkspaceIdentityBindingType,
+  WorkspacePolicy,
+  WorkspacePrincipalType,
   WorkspaceRow,
+  WorkspaceThreadKind,
+  WorkspaceThreadParticipantRole,
   WorkspaceThreadScope,
+  WorkspaceThreadStatus,
+  WorkspaceThreadParticipantRow,
+  WorkspaceThreadRow,
 } from '../types.js'
 import { serializeAgentKeyState } from '../utils/serialize.js'
+import { evaluateWorkspacePolicy } from '../workspace-policy.js'
 
 const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
 const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'handoff'])
 const WORKSPACE_BINDING_TYPE_SET = new Set<WorkspaceIdentityBindingType>(['agent', 'service', 'partner'])
 const WORKSPACE_BINDING_STATUS_SET = new Set<WorkspaceIdentityBindingStatus>(['active', 'paused'])
+const WORKSPACE_THREAD_KIND_SET = new Set<WorkspaceThreadKind>(['internal', 'handoff'])
+const WORKSPACE_THREAD_STATUS_SET = new Set<WorkspaceThreadStatus>(['open', 'blocked', 'closed'])
+const WORKSPACE_THREAD_PARTICIPANT_ROLE_SET = new Set<WorkspaceThreadParticipantRole>(['owner', 'participant', 'observer', 'approver'])
+const WORKSPACE_PRINCIPAL_TYPE_SET = new Set<WorkspacePrincipalType>(['human', 'agent', 'service', 'partner'])
 const WORKSPACE_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
 const WORKSPACE_OVERVIEW_STALE_AFTER_HOURS = 24
 const WORKSPACE_OVERVIEW_RECENT_HANDOFF_LIMIT = 8
@@ -124,6 +143,68 @@ type WorkspaceOverviewHandoff = {
   }
 }
 
+type SerializedWorkspaceThreadParticipant = {
+  id: number
+  threadId: number
+  principalId: string
+  principalType: WorkspacePrincipalType
+  displayName: string | null
+  beamId: string | null
+  workspaceBindingId: number | null
+  role: WorkspaceThreadParticipantRole
+  createdAt: string
+  updatedAt: string
+  identity: {
+    existsLocally: boolean
+    displayName: string | null
+    org: string | null
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+  } | null
+}
+
+type SerializedWorkspaceThread = {
+  id: number
+  workspaceId: number
+  kind: WorkspaceThreadKind
+  title: string
+  summary: string | null
+  owner: string | null
+  status: WorkspaceThreadStatus
+  workflowType: string | null
+  linkedIntentNonce: string | null
+  lastActivityAt: string
+  createdAt: string
+  updatedAt: string
+  participantCount: number
+  trace: {
+    nonce: string
+    status: IntentLogRow['status']
+    intentType: string
+    fromBeamId: string
+    toBeamId: string
+    requestedAt: string
+    completedAt: string | null
+    latencyMs: number | null
+    errorCode: string | null
+    href: string
+  } | null
+}
+
+type SerializedWorkspacePolicyPreview = {
+  beamId: string
+  bindingType: WorkspaceIdentityBindingType
+  policyProfile: string | null
+  externalInitiation: 'allow' | 'deny'
+  allowedPartners: string[]
+  approvalRequired: boolean
+  approvers: string[]
+  matchedBindingRules: number
+  matchedWorkflowRules: number
+  workflowType: string | null
+}
+
 function normalizeOptionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
 }
@@ -172,6 +253,42 @@ function normalizeBindingStatus(value: unknown): WorkspaceIdentityBindingStatus 
 
   const normalized = value.trim().toLowerCase() as WorkspaceIdentityBindingStatus
   return WORKSPACE_BINDING_STATUS_SET.has(normalized) ? normalized : null
+}
+
+function normalizeThreadKind(value: unknown): WorkspaceThreadKind | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceThreadKind
+  return WORKSPACE_THREAD_KIND_SET.has(normalized) ? normalized : null
+}
+
+function normalizeThreadStatus(value: unknown): WorkspaceThreadStatus | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceThreadStatus
+  return WORKSPACE_THREAD_STATUS_SET.has(normalized) ? normalized : null
+}
+
+function normalizePrincipalType(value: unknown): WorkspacePrincipalType | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspacePrincipalType
+  return WORKSPACE_PRINCIPAL_TYPE_SET.has(normalized) ? normalized : null
+}
+
+function normalizeThreadParticipantRole(value: unknown): WorkspaceThreadParticipantRole | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspaceThreadParticipantRole
+  return WORKSPACE_THREAD_PARTICIPANT_ROLE_SET.has(normalized) ? normalized : null
 }
 
 function normalizeBoolean(value: unknown): boolean | null {
@@ -252,7 +369,7 @@ function getDisplayNameForBeamId(
 
 function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspace {
   const summary = getWorkspaceSummary(db, row.id)
-  const policy = getWorkspacePolicy(db, row.id)
+  const { policy } = getWorkspacePolicyDocument(db, row.id)
 
   return {
     id: row.id,
@@ -271,7 +388,7 @@ function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspac
       members: summary.memberCount,
       partnerChannels: summary.partnerChannelCount,
     },
-    policyConfigured: policy !== null,
+    policyConfigured: policy.bindingRules.length > 0 || policy.workflowRules.length > 0 || policy.defaults.allowedPartners.length > 0 || policy.defaults.externalInitiation !== 'binding' || Boolean(policy.metadata.notes),
   }
 }
 
@@ -315,6 +432,119 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
       lastSeen: null,
       capabilities: [],
       keyState,
+    },
+  }
+}
+
+function serializeWorkspaceThreadParticipant(
+  db: Database,
+  row: WorkspaceThreadParticipantRow,
+): SerializedWorkspaceThreadParticipant {
+  const identity = row.beam_id ? getAgent(db, row.beam_id) : null
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    principalId: row.principal_id,
+    principalType: row.principal_type,
+    displayName: row.display_name,
+    beamId: row.beam_id,
+    workspaceBindingId: row.workspace_binding_id,
+    role: row.role,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    identity: identity ? {
+      existsLocally: true,
+      displayName: identity.display_name,
+      org: identity.org,
+      verificationTier: identity.verification_tier,
+      trustScore: identity.trust_score,
+      lastSeen: identity.last_seen,
+    } : row.beam_id ? {
+      existsLocally: false,
+      displayName: row.display_name,
+      org: null,
+      verificationTier: null,
+      trustScore: null,
+      lastSeen: null,
+    } : null,
+  }
+}
+
+function serializeWorkspaceThread(
+  db: Database,
+  row: WorkspaceThreadRow,
+  participants: WorkspaceThreadParticipantRow[],
+): SerializedWorkspaceThread {
+  const intent = row.linked_intent_nonce ? getIntentLogByNonce(db, row.linked_intent_nonce) : null
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    kind: row.kind,
+    title: row.title,
+    summary: row.summary,
+    owner: row.owner,
+    status: row.status,
+    workflowType: row.workflow_type,
+    linkedIntentNonce: row.linked_intent_nonce,
+    lastActivityAt: row.last_activity_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    participantCount: participants.length,
+    trace: intent ? {
+      nonce: intent.nonce,
+      status: intent.status,
+      intentType: intent.intent_type,
+      fromBeamId: intent.from_beam_id,
+      toBeamId: intent.to_beam_id,
+      requestedAt: intent.requested_at,
+      completedAt: intent.completed_at,
+      latencyMs: intent.round_trip_latency_ms,
+      errorCode: intent.error_code,
+      href: `/intents/${encodeURIComponent(intent.nonce)}`,
+    } : null,
+  }
+}
+
+function buildWorkspacePolicyPreview(
+  policy: WorkspacePolicy,
+  binding: WorkspaceIdentityBindingRow,
+  workflowType: string | null = null,
+): SerializedWorkspacePolicyPreview {
+  const evaluation = evaluateWorkspacePolicy(policy, binding, {
+    workflowType,
+  })
+
+  return {
+    beamId: evaluation.beamId,
+    bindingType: evaluation.bindingType,
+    policyProfile: evaluation.policyProfile,
+    externalInitiation: evaluation.externalInitiation,
+    allowedPartners: evaluation.allowedPartners,
+    approvalRequired: evaluation.approvalRequired,
+    approvers: evaluation.approvers,
+    matchedBindingRules: evaluation.matchedBindingRules,
+    matchedWorkflowRules: evaluation.matchedWorkflowRules,
+    workflowType,
+  }
+}
+
+function buildWorkspacePolicyEnvelope(db: Database, workspace: WorkspaceRow) {
+  const bindings = listWorkspaceIdentityBindings(db, workspace.id)
+  const locals = bindings.filter(isLocalWorkspaceBinding)
+  const { policy, updatedAt, updatedBy } = getWorkspacePolicyDocument(db, workspace.id)
+  const workflows = [...new Set(policy.workflowRules.map((rule) => rule.workflowType))]
+
+  return {
+    workspace: serializeWorkspace(db, workspace),
+    policy,
+    updatedAt,
+    updatedBy,
+    previews: {
+      bindings: locals.map((binding) => buildWorkspacePolicyPreview(policy, binding)),
+      workflows: workflows.map((workflowType) => ({
+        workflowType,
+        bindings: locals.map((binding) => buildWorkspacePolicyPreview(policy, binding, workflowType)),
+      })),
     },
   }
 }
@@ -651,6 +881,270 @@ export function workspacesRouter(db: Database): Hono {
     return c.json({
       workspace: serializeWorkspace(db, workspace),
       ...buildWorkspaceOverview(db, workspace),
+    })
+  })
+
+  router.get('/:slug/threads', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const rows = listWorkspaceThreads(db, workspace.id)
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      threads: rows.map((row) => serializeWorkspaceThread(db, row, listWorkspaceThreadParticipants(db, row.id))),
+      total: rows.length,
+    })
+  })
+
+  router.get('/:slug/threads/:id', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const threadId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(threadId) || threadId <= 0) {
+      return c.json({ error: 'Invalid thread id', errorCode: 'INVALID_THREAD_ID' }, 400)
+    }
+
+    const thread = getWorkspaceThreadById(db, threadId)
+    if (!thread || thread.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace thread not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const participants = listWorkspaceThreadParticipants(db, thread.id)
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      thread: serializeWorkspaceThread(db, thread, participants),
+      participants: participants.map((row) => serializeWorkspaceThreadParticipant(db, row)),
+    })
+  })
+
+  router.post('/:slug/threads', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const kind = normalizeThreadKind(raw.kind)
+    if (!kind) {
+      return c.json({ error: 'Invalid thread kind', errorCode: 'INVALID_THREAD_KIND' }, 400)
+    }
+
+    const title = normalizeOptionalString(raw.title)
+    if (!title) {
+      return c.json({ error: 'title is required', errorCode: 'INVALID_THREAD_TITLE' }, 400)
+    }
+
+    const summary = normalizeOptionalString(raw.summary)
+    const owner = normalizeOptionalString(raw.owner)
+    const status = 'status' in raw ? normalizeThreadStatus(raw.status) : 'open'
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid thread status', errorCode: 'INVALID_THREAD_STATUS' }, 400)
+    }
+
+    const workflowType = normalizeOptionalString(raw.workflowType)
+    const linkedIntentNonce = normalizeOptionalString(raw.linkedIntentNonce)
+    if (kind === 'handoff' && !linkedIntentNonce) {
+      return c.json({ error: 'linkedIntentNonce is required for handoff threads', errorCode: 'MISSING_THREAD_NONCE' }, 400)
+    }
+    if (kind === 'internal' && linkedIntentNonce) {
+      return c.json({ error: 'Internal threads cannot link directly to a Beam trace', errorCode: 'INTERNAL_THREAD_CANNOT_LINK_TRACE' }, 400)
+    }
+
+    const linkedIntent = linkedIntentNonce ? getIntentLogByNonce(db, linkedIntentNonce) : null
+    if (linkedIntentNonce && !linkedIntent) {
+      return c.json({ error: 'linkedIntentNonce was not found', errorCode: 'INTENT_NOT_FOUND' }, 404)
+    }
+
+    const rawParticipants = Array.isArray(raw.participants) ? raw.participants : []
+    const participantInputs = rawParticipants.map((entry, index) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new Error(`participants[${index}] must be an object`)
+      }
+
+      const participant = entry as Record<string, unknown>
+      const principalId = normalizeOptionalString(participant.principalId)
+      if (!principalId) {
+        throw new Error(`participants[${index}].principalId is required`)
+      }
+
+      const principalType = normalizePrincipalType(participant.principalType)
+      if (!principalType) {
+        throw new Error(`participants[${index}].principalType is invalid`)
+      }
+
+      const role = 'role' in participant ? normalizeThreadParticipantRole(participant.role) : 'participant'
+      if ('role' in participant && !role) {
+        throw new Error(`participants[${index}].role is invalid`)
+      }
+
+      const bindingId = participant.workspaceBindingId == null ? null : Number.parseInt(String(participant.workspaceBindingId), 10)
+      if (participant.workspaceBindingId != null && (!Number.isFinite(bindingId) || (bindingId ?? 0) <= 0)) {
+        throw new Error(`participants[${index}].workspaceBindingId is invalid`)
+      }
+
+      const binding = bindingId ? getWorkspaceIdentityBindingById(db, bindingId) : null
+      if (binding && binding.workspace_id !== workspace.id) {
+        throw new Error(`participants[${index}].workspaceBindingId does not belong to this workspace`)
+      }
+
+      const beamId = normalizeOptionalString(participant.beamId) ?? binding?.beam_id ?? null
+      const displayName = normalizeOptionalString(participant.displayName)
+
+      return {
+        principalId,
+        principalType,
+        role: role ?? 'participant',
+        workspaceBindingId: binding?.id ?? null,
+        beamId,
+        displayName,
+      }
+    })
+
+    let thread: WorkspaceThreadRow
+    try {
+      thread = createWorkspaceThread(db, {
+        workspaceId: workspace.id,
+        kind,
+        title,
+        summary,
+        owner,
+        status: status ?? 'open',
+        workflowType,
+        linkedIntentNonce,
+        lastActivityAt: linkedIntent?.requested_at,
+      })
+
+      for (const participant of participantInputs) {
+        createWorkspaceThreadParticipant(db, {
+          threadId: thread.id,
+          principalId: participant.principalId,
+          principalType: participant.principalType,
+          displayName: participant.displayName,
+          beamId: participant.beamId,
+          workspaceBindingId: participant.workspaceBindingId,
+          role: participant.role,
+        })
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create workspace thread'
+      if (message.includes('participants[')) {
+        return c.json({ error: message, errorCode: 'INVALID_THREAD_PARTICIPANT' }, 400)
+      }
+
+      console.error('Workspace thread create error:', err)
+      return c.json({ error: 'Failed to create workspace thread', errorCode: 'DB_ERROR' }, 500)
+    }
+
+    const participants = listWorkspaceThreadParticipants(db, thread.id)
+    logAuditEvent(db, {
+      action: 'admin.workspace_thread.created',
+      actor: auth.session.email,
+      target: `${workspace.slug}:${thread.id}`,
+      details: {
+        role: auth.session.role,
+        kind: thread.kind,
+        workflowType: thread.workflow_type,
+        linkedIntentNonce: thread.linked_intent_nonce,
+        participants: participants.length,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      thread: serializeWorkspaceThread(db, thread, participants),
+      participants: participants.map((row) => serializeWorkspaceThreadParticipant(db, row)),
+    }, 201)
+  })
+
+  router.get('/:slug/policy', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json(buildWorkspacePolicyEnvelope(db, workspace))
+  })
+
+  router.patch('/:slug/policy', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const patch = body as Partial<WorkspacePolicy>
+    const result = updateWorkspacePolicyDocument(db, workspace.id, patch, auth.session.email)
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_policy.updated',
+      actor: auth.session.email,
+      target: workspace.slug,
+      details: {
+        role: auth.session.role,
+        defaultExternalInitiation: result.policy.defaults.externalInitiation,
+        bindingRules: result.policy.bindingRules.length,
+        workflowRules: result.policy.workflowRules.length,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ...buildWorkspacePolicyEnvelope(db, workspace),
+      updated: true,
     })
   })
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -166,6 +166,11 @@ export type WorkspacePrincipalType = 'human' | 'agent' | 'service' | 'partner'
 export type WorkspaceIdentityBindingType = 'agent' | 'service' | 'partner'
 export type WorkspaceIdentityBindingStatus = 'active' | 'paused'
 export type WorkspacePartnerChannelStatus = 'active' | 'trial' | 'blocked'
+export type WorkspaceThreadKind = 'internal' | 'handoff'
+export type WorkspaceThreadStatus = 'open' | 'blocked' | 'closed'
+export type WorkspaceThreadParticipantRole = 'owner' | 'participant' | 'observer' | 'approver'
+export type WorkspacePolicyDefaultExternalInitiation = 'deny' | 'binding'
+export type WorkspacePolicyRuleExternalInitiation = 'inherit' | 'allow' | 'deny'
 
 export interface WorkspaceRow {
   id: number
@@ -221,11 +226,69 @@ export interface WorkspacePartnerChannelRow {
   updated_at: string
 }
 
+export interface WorkspaceThreadRow {
+  id: number
+  workspace_id: number
+  kind: WorkspaceThreadKind
+  title: string
+  summary: string | null
+  owner: string | null
+  status: WorkspaceThreadStatus
+  workflow_type: string | null
+  linked_intent_nonce: string | null
+  last_activity_at: string
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkspaceThreadParticipantRow {
+  id: number
+  thread_id: number
+  principal_id: string
+  principal_type: WorkspacePrincipalType
+  display_name: string | null
+  beam_id: string | null
+  workspace_binding_id: number | null
+  role: WorkspaceThreadParticipantRole
+  created_at: string
+  updated_at: string
+}
+
 export interface WorkspacePolicyRow {
   workspace_id: number
   policy_json: string
   updated_at: string
   updated_by: string | null
+}
+
+export interface WorkspacePolicyBindingRule {
+  beamId: string | null
+  bindingType: WorkspaceIdentityBindingType | null
+  policyProfile: string | null
+  externalInitiation: WorkspacePolicyRuleExternalInitiation
+  allowedPartners: string[]
+}
+
+export interface WorkspacePolicyWorkflowRule {
+  workflowType: string
+  requireApproval: boolean
+  allowedPartners: string[]
+  approvers: string[]
+}
+
+export interface WorkspacePolicyMetadata {
+  notes: string | null
+}
+
+export interface WorkspacePolicy {
+  version: 1
+  defaults: {
+    externalInitiation: WorkspacePolicyDefaultExternalInitiation
+    allowedPartners: string[]
+  }
+  bindingRules: WorkspacePolicyBindingRule[]
+  workflowRules: WorkspacePolicyWorkflowRule[]
+  metadata: WorkspacePolicyMetadata
 }
 
 export type FunnelEventCategory = 'page_view' | 'cta_click' | 'request' | 'demo_milestone'

--- a/packages/directory/src/workspace-policy.ts
+++ b/packages/directory/src/workspace-policy.ts
@@ -1,0 +1,228 @@
+import type {
+  WorkspaceIdentityBindingRow,
+  WorkspacePolicy,
+  WorkspacePolicyBindingRule,
+  WorkspacePolicyDefaultExternalInitiation,
+  WorkspacePolicyRuleExternalInitiation,
+  WorkspacePolicyWorkflowRule,
+} from './types.js'
+import { matchesBeamPattern } from './shield/policies.js'
+
+export const DEFAULT_WORKSPACE_POLICY: WorkspacePolicy = {
+  version: 1,
+  defaults: {
+    externalInitiation: 'binding',
+    allowedPartners: [],
+  },
+  bindingRules: [],
+  workflowRules: [],
+  metadata: {
+    notes: null,
+  },
+}
+
+function sanitizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return [...new Set(
+    value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  )]
+}
+
+function sanitizeNullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function sanitizeDefaultExternalInitiation(value: unknown): WorkspacePolicyDefaultExternalInitiation {
+  return value === 'deny' ? 'deny' : 'binding'
+}
+
+function sanitizeRuleExternalInitiation(value: unknown): WorkspacePolicyRuleExternalInitiation {
+  if (value === 'allow' || value === 'deny') {
+    return value
+  }
+
+  return 'inherit'
+}
+
+function parseBindingRule(raw: unknown): WorkspacePolicyBindingRule | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+
+  const input = raw as Record<string, unknown>
+  const beamId = sanitizeNullableString(input.beamId)
+  const bindingType = input.bindingType === 'agent' || input.bindingType === 'service' || input.bindingType === 'partner'
+    ? input.bindingType
+    : null
+  const policyProfile = sanitizeNullableString(input.policyProfile)?.toLowerCase() ?? null
+
+  if (!beamId && !bindingType && !policyProfile) {
+    return null
+  }
+
+  return {
+    beamId,
+    bindingType,
+    policyProfile,
+    externalInitiation: sanitizeRuleExternalInitiation(input.externalInitiation),
+    allowedPartners: sanitizeStringList(input.allowedPartners),
+  }
+}
+
+function parseWorkflowRule(raw: unknown): WorkspacePolicyWorkflowRule | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+
+  const input = raw as Record<string, unknown>
+  const workflowType = sanitizeNullableString(input.workflowType)
+  if (!workflowType) {
+    return null
+  }
+
+  return {
+    workflowType,
+    requireApproval: input.requireApproval === true,
+    allowedPartners: sanitizeStringList(input.allowedPartners),
+    approvers: sanitizeStringList(input.approvers),
+  }
+}
+
+export function parseWorkspacePolicy(raw: string | null | undefined): WorkspacePolicy {
+  if (!raw) {
+    return structuredClone(DEFAULT_WORKSPACE_POLICY)
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<WorkspacePolicy>
+    return {
+      version: 1,
+      defaults: {
+        externalInitiation: sanitizeDefaultExternalInitiation(parsed.defaults?.externalInitiation),
+        allowedPartners: sanitizeStringList(parsed.defaults?.allowedPartners),
+      },
+      bindingRules: Array.isArray(parsed.bindingRules)
+        ? parsed.bindingRules.map(parseBindingRule).filter((rule): rule is WorkspacePolicyBindingRule => Boolean(rule))
+        : [],
+      workflowRules: Array.isArray(parsed.workflowRules)
+        ? parsed.workflowRules.map(parseWorkflowRule).filter((rule): rule is WorkspacePolicyWorkflowRule => Boolean(rule))
+        : [],
+      metadata: {
+        notes: sanitizeNullableString(parsed.metadata?.notes),
+      },
+    }
+  } catch {
+    return structuredClone(DEFAULT_WORKSPACE_POLICY)
+  }
+}
+
+export function mergeWorkspacePolicy(current: WorkspacePolicy, patch: Partial<WorkspacePolicy>): WorkspacePolicy {
+  return parseWorkspacePolicy(JSON.stringify({
+    ...current,
+    ...patch,
+    defaults: {
+      ...current.defaults,
+      ...patch.defaults,
+    },
+    metadata: {
+      ...current.metadata,
+      ...patch.metadata,
+    },
+    bindingRules: patch.bindingRules ?? current.bindingRules,
+    workflowRules: patch.workflowRules ?? current.workflowRules,
+  }))
+}
+
+function matchesBindingRule(rule: WorkspacePolicyBindingRule, binding: WorkspaceIdentityBindingRow): boolean {
+  if (rule.beamId && rule.beamId !== binding.beam_id) {
+    return false
+  }
+
+  if (rule.bindingType && rule.bindingType !== binding.binding_type) {
+    return false
+  }
+
+  if (rule.policyProfile && rule.policyProfile !== (binding.policy_profile?.trim().toLowerCase() ?? null)) {
+    return false
+  }
+
+  return true
+}
+
+function mergeAllowedPartners(...sets: string[][]): string[] {
+  return [...new Set(sets.flat().filter(Boolean))]
+}
+
+export interface WorkspacePolicyEvaluation {
+  beamId: string
+  bindingType: WorkspaceIdentityBindingRow['binding_type']
+  policyProfile: string | null
+  externalInitiation: 'allow' | 'deny'
+  allowedPartners: string[]
+  approvalRequired: boolean
+  approvers: string[]
+  matchedBindingRules: number
+  matchedWorkflowRules: number
+}
+
+export function evaluateWorkspacePolicy(
+  policy: WorkspacePolicy,
+  binding: WorkspaceIdentityBindingRow,
+  options: {
+    workflowType?: string | null
+    partnerBeamId?: string | null
+  } = {},
+): WorkspacePolicyEvaluation {
+  const matchedBindingRules = policy.bindingRules.filter((rule) => matchesBindingRule(rule, binding))
+  const matchedWorkflowRules = (options.workflowType
+    ? policy.workflowRules.filter((rule) => rule.workflowType === options.workflowType)
+    : [])
+
+  let externalInitiation: 'allow' | 'deny'
+  if (policy.defaults.externalInitiation === 'deny') {
+    externalInitiation = 'deny'
+  } else {
+    externalInitiation = binding.can_initiate_external === 1 ? 'allow' : 'deny'
+  }
+
+  let allowedPartners = [...policy.defaults.allowedPartners]
+
+  for (const rule of matchedBindingRules) {
+    if (rule.externalInitiation === 'allow') {
+      externalInitiation = 'allow'
+    } else if (rule.externalInitiation === 'deny') {
+      externalInitiation = 'deny'
+    }
+    allowedPartners = mergeAllowedPartners(allowedPartners, rule.allowedPartners)
+  }
+
+  let approvalRequired = false
+  let approvers: string[] = []
+  for (const rule of matchedWorkflowRules) {
+    approvalRequired = approvalRequired || rule.requireApproval
+    approvers = mergeAllowedPartners(approvers, rule.approvers)
+    allowedPartners = mergeAllowedPartners(allowedPartners, rule.allowedPartners)
+  }
+
+  if (options.partnerBeamId && allowedPartners.length > 0 && !matchesBeamPattern(options.partnerBeamId, allowedPartners)) {
+    externalInitiation = 'deny'
+  }
+
+  return {
+    beamId: binding.beam_id,
+    bindingType: binding.binding_type,
+    policyProfile: binding.policy_profile,
+    externalInitiation,
+    allowedPartners,
+    approvalRequired,
+    approvers,
+    matchedBindingRules: matchedBindingRules.length,
+    matchedWorkflowRules: matchedWorkflowRules.length,
+  }
+}

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -68,7 +68,7 @@ test('admins can create and inspect beam workspaces through the admin API', asyn
     assert.equal(createdBody.workspace.name, 'Acme Ops Workspace')
     assert.match(createdBody.workspace.description ?? '', /Control plane/i)
     assert.equal(createdBody.workspace.externalHandoffsEnabled, true)
-    assert.equal(createdBody.workspace.policyConfigured, true)
+    assert.equal(createdBody.workspace.policyConfigured, false)
     assert.equal(createdBody.workspace.summary.identities, 0)
     assert.equal(createdBody.workspace.summary.partnerChannels, 0)
 
@@ -418,6 +418,316 @@ test('workspace overview surfaces stale identities, blocked external motion, and
     assert.equal(overviewBody.recentExternalHandoffs[1]?.direction, 'inbound')
     assert.equal(overviewBody.recentExternalHandoffs[1]?.counterparty.beamId, 'seller-bot@outside.beam.directory')
     assert.equal(overviewBody.recentExternalHandoffs[1]?.counterparty.inWorkspace, false)
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace threads model internal discussion and external handoffs in one timeline', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['triage', 'handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAyG5JwL7aQh7o4V6o8cz+Rmj4S7LnhwF4r2bp7L1fR8Q=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Northwind Ops',
+        slug: 'northwind-ops',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    const localBindingResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex',
+        policyProfile: 'ops-default',
+        canInitiateExternal: true,
+      }),
+    }))
+    const localBinding = await localBindingResponse.json() as { binding: { id: number } }
+
+    const partnerBindingResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'finance@northwind.beam.directory',
+        bindingType: 'partner',
+        owner: 'northwind@example.com',
+        policyProfile: 'partner-finance',
+      }),
+    }))
+    const partnerBinding = await partnerBindingResponse.json() as { binding: { id: number } }
+
+    logIntentStart(db, {
+      v: '1',
+      nonce: 'nonce-thread-handoff',
+      from: 'ops-bot@beam.directory',
+      to: 'finance@northwind.beam.directory',
+      intent: 'quote.approval',
+      payload: { quoteId: 'Q-77' },
+      timestamp: '2026-03-31T10:00:00.000Z',
+      signature: 'sig-thread',
+    })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-thread-handoff', status: 'validated' })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-thread-handoff', status: 'dispatched' })
+    setIntentLifecycleStatus(db, { nonce: 'nonce-thread-handoff', status: 'delivered' })
+    finalizeIntentLog(db, {
+      nonce: 'nonce-thread-handoff',
+      fromBeamId: 'ops-bot@beam.directory',
+      toBeamId: 'finance@northwind.beam.directory',
+      status: 'acked',
+      latencyMs: 510,
+      resultJson: JSON.stringify({ approved: true }),
+    })
+
+    const internalThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/threads', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'internal',
+        title: 'Prepare approval handoff',
+        summary: 'Align buyer owner and evidence before external send.',
+        owner: 'ops@example.com',
+        participants: [
+          {
+            principalId: 'ops@example.com',
+            principalType: 'human',
+            displayName: 'Ops Owner',
+            role: 'owner',
+          },
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: localBinding.binding.id,
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(internalThreadResponse.status, 201)
+    const internalThreadBody = await internalThreadResponse.json() as { thread: { id: number; kind: string; trace: null } }
+    assert.equal(internalThreadBody.thread.kind, 'internal')
+    assert.equal(internalThreadBody.thread.trace, null)
+
+    const handoffThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/threads', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Quote approval handoff',
+        summary: 'External finance approval with async proof.',
+        owner: 'ops@example.com',
+        workflowType: 'quote.approval',
+        linkedIntentNonce: 'nonce-thread-handoff',
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: localBinding.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'finance@northwind.beam.directory',
+            principalType: 'partner',
+            beamId: 'finance@northwind.beam.directory',
+            workspaceBindingId: partnerBinding.binding.id,
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(handoffThreadResponse.status, 201)
+    const handoffThreadBody = await handoffThreadResponse.json() as {
+      thread: { id: number; kind: string; trace: { nonce: string; status: string; href: string } | null }
+      participants: Array<{ beamId: string | null }>
+    }
+    assert.equal(handoffThreadBody.thread.kind, 'handoff')
+    assert.equal(handoffThreadBody.thread.trace?.nonce, 'nonce-thread-handoff')
+    assert.equal(handoffThreadBody.thread.trace?.status, 'acked')
+    assert.equal(handoffThreadBody.thread.trace?.href, '/intents/nonce-thread-handoff')
+    assert.equal(handoffThreadBody.participants.length, 2)
+
+    const listResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/threads', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listResponse.status, 200)
+    const listBody = await listResponse.json() as {
+      total: number
+      threads: Array<{ kind: string; linkedIntentNonce: string | null; participantCount: number }>
+    }
+    assert.equal(listBody.total, 2)
+    const listedHandoffThread = listBody.threads.find((entry) => entry.kind === 'handoff')
+    const listedInternalThread = listBody.threads.find((entry) => entry.kind === 'internal')
+    assert.equal(listedHandoffThread?.linkedIntentNonce, 'nonce-thread-handoff')
+    assert.equal(listedHandoffThread?.participantCount, 2)
+    assert.equal(listedInternalThread?.kind, 'internal')
+
+    const detailResponse = await app.request(new Request(`http://localhost/admin/workspaces/northwind-ops/threads/${handoffThreadBody.thread.id}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(detailResponse.status, 200)
+    const detailBody = await detailResponse.json() as {
+      thread: { kind: string; trace: { intentType: string; fromBeamId: string; toBeamId: string } | null }
+      participants: Array<{ principalType: string; role: string }>
+    }
+    assert.equal(detailBody.thread.kind, 'handoff')
+    assert.equal(detailBody.thread.trace?.intentType, 'quote.approval')
+    assert.equal(detailBody.thread.trace?.fromBeamId, 'ops-bot@beam.directory')
+    assert.equal(detailBody.thread.trace?.toBeamId, 'finance@northwind.beam.directory')
+    assert.deepEqual(detailBody.participants.map((entry) => entry.principalType).sort(), ['agent', 'partner'])
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace policy routes expose normalized policy and enforcement-ready binding previews', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAw2QJY0YH7e1L2+2VQ1bH4TqL6wCnC8n9v8m8z4vPsxM=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Acme Finance',
+        slug: 'acme-finance',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces/acme-finance/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex',
+        policyProfile: 'finance-outbound',
+        canInitiateExternal: false,
+      }),
+    }))
+
+    const initialPolicyResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/policy', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(initialPolicyResponse.status, 200)
+    const initialPolicy = await initialPolicyResponse.json() as {
+      policy: {
+        defaults: { externalInitiation: string }
+        bindingRules: unknown[]
+        workflowRules: unknown[]
+      }
+      previews: {
+        bindings: Array<{ beamId: string; externalInitiation: string }>
+      }
+    }
+    assert.equal(initialPolicy.policy.defaults.externalInitiation, 'binding')
+    assert.equal(initialPolicy.policy.bindingRules.length, 0)
+    assert.equal(initialPolicy.previews.bindings[0]?.externalInitiation, 'deny')
+
+    const patchResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/policy', {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        defaults: {
+          externalInitiation: 'deny',
+          allowedPartners: ['*@northwind.beam.directory'],
+        },
+        bindingRules: [
+          {
+            policyProfile: 'finance-outbound',
+            externalInitiation: 'allow',
+            allowedPartners: ['finance@northwind.beam.directory'],
+          },
+        ],
+        workflowRules: [
+          {
+            workflowType: 'quote.approval',
+            requireApproval: true,
+            allowedPartners: ['finance@northwind.beam.directory'],
+            approvers: ['ops@example.com', 'approvals@example.com'],
+          },
+        ],
+        metadata: {
+          notes: 'Finance outbound handoffs need named approvers.',
+        },
+      }),
+    }))
+    assert.equal(patchResponse.status, 200)
+    const patchBody = await patchResponse.json() as {
+      updated: boolean
+      updatedBy: string | null
+      policy: {
+        defaults: { externalInitiation: string; allowedPartners: string[] }
+        bindingRules: Array<{ policyProfile: string | null; externalInitiation: string; allowedPartners: string[] }>
+        workflowRules: Array<{ workflowType: string; requireApproval: boolean; approvers: string[] }>
+        metadata: { notes: string | null }
+      }
+      previews: {
+        bindings: Array<{ beamId: string; externalInitiation: string; allowedPartners: string[] }>
+        workflows: Array<{
+          workflowType: string
+          bindings: Array<{ beamId: string; externalInitiation: string; approvalRequired: boolean; approvers: string[] }>
+        }>
+      }
+    }
+    assert.equal(patchBody.updated, true)
+    assert.equal(patchBody.updatedBy, 'ops@example.com')
+    assert.equal(patchBody.policy.defaults.externalInitiation, 'deny')
+    assert.deepEqual(patchBody.policy.defaults.allowedPartners, ['*@northwind.beam.directory'])
+    assert.equal(patchBody.policy.bindingRules[0]?.policyProfile, 'finance-outbound')
+    assert.equal(patchBody.policy.bindingRules[0]?.externalInitiation, 'allow')
+    assert.deepEqual(patchBody.policy.bindingRules[0]?.allowedPartners, ['finance@northwind.beam.directory'])
+    assert.equal(patchBody.policy.workflowRules[0]?.workflowType, 'quote.approval')
+    assert.equal(patchBody.policy.workflowRules[0]?.requireApproval, true)
+    assert.deepEqual(patchBody.policy.workflowRules[0]?.approvers, ['ops@example.com', 'approvals@example.com'])
+    assert.match(patchBody.policy.metadata.notes ?? '', /named approvers/i)
+    assert.equal(patchBody.previews.bindings[0]?.beamId, 'ops-bot@beam.directory')
+    assert.equal(patchBody.previews.bindings[0]?.externalInitiation, 'allow')
+    assert.deepEqual(patchBody.previews.bindings[0]?.allowedPartners, ['*@northwind.beam.directory', 'finance@northwind.beam.directory'])
+    assert.equal(patchBody.previews.workflows[0]?.workflowType, 'quote.approval')
+    assert.equal(patchBody.previews.workflows[0]?.bindings[0]?.approvalRequired, true)
+    assert.deepEqual(patchBody.previews.workflows[0]?.bindings[0]?.approvers, ['ops@example.com', 'approvals@example.com'])
   } finally {
     db.close()
   }


### PR DESCRIPTION
## Summary
- add workspace thread + participant modeling and admin API routes for thread timeline and policy documents
- add workspace policy parsing/evaluation helpers plus migration and surface tests
- extend the dashboard workspace page with thread detail, trace linkage, and policy previews, and update workspace docs

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/packages/directory run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e

Closes #115
Closes #116