### PR TITLE
Plan post-1.0.0 workspace control plane

### DIFF
--- a/reports/1.1.0-workspace-control-plane-plan.md
+++ b/reports/1.1.0-workspace-control-plane-plan.md
@@ -1,0 +1,303 @@
+# Beam 1.1.0 Workspace Control Plane Plan
+
+## Goal
+
+Beam `1.1.0` should turn the new Workspace foundation into the operator-grade home for identities, approvals, partner channels, and cross-company control.
+
+The milestone goal is:
+
+**make Beam Workspace the place where a team can see who an agent is, what it may do, which partner channels it may use, and what happened when work crossed an org boundary**
+
+At the end of `1.1.0`, Beam Workspace should feel less like a schema and dashboard shell and more like a real control plane for internal coordination plus external Beam handoffs.
+
+## Target Outcome
+
+By **July 15, 2026**, the team should be able to do this cleanly:
+
+1. a workspace operator can see every bound identity with owner, runtime, key state, and health,
+2. policy and approval rules can be changed from the dashboard instead of only being previewed,
+3. partner channels are visible with trust, health, owner, and recent failure context,
+4. operators can start internal threads and outbound Beam handoffs from the same workspace surface,
+5. workspace decisions can be reconstructed from an audit timeline rather than chat memory,
+6. recurring approval and escalation work is procedural through digest and reminder loops,
+7. buyer-like and operator-like dry runs pass on the release candidate,
+8. `1.1.0` is cut only from explicit evidence and go/no-go gates.
+
+## North Star
+
+Beam `1.1.0` succeeds if one team can use Beam Workspace as:
+
+`home of identities -> policy surface -> partner control -> thread and handoff surface -> audit and recurring operator loop`
+
+without spreadsheet glue, manual shell work, or hidden operator knowledge.
+
+## Non-Goals
+
+`1.1.0` is not for:
+
+- building a general-purpose chat workspace or Slack replacement,
+- adding a shared browser or shared file system as headline work,
+- introducing a Beam-hosted runtime launcher as a major new product pillar,
+- broadening the protocol surface as the main milestone story,
+- self-serve enterprise billing, seat packaging, or procurement tooling,
+- parallelizing many unrelated product experiments next to the workspace track.
+
+## Current Position After 1.0.0
+
+Beam already has strong production credibility:
+
+- the first production-partner workflow is documented and released,
+- partner health, digests, proof export, and recovery drills exist,
+- release automation, release smoke, and public-site deployment are in place,
+- Workspace foundation already exists in the repo:
+  - schema and migrations,
+  - identity bindings,
+  - overview API,
+  - thread model,
+  - policy parser and preview surface.
+
+What is still missing is the actual control-plane experience:
+
+- workspace policy is still mostly read-only or indirect,
+- partner channels are not yet a first-class operator object,
+- workspace roster needs richer lifecycle and runtime-backed identity state,
+- thread creation and outbound handoff initiation are not yet one coherent operator flow,
+- workspace history is not yet a full decision timeline,
+- recurring workspace approval work is not yet boring and procedural.
+
+## Product Thesis For 1.1.0
+
+The key product bet for `1.1.0` is this:
+
+**Beam becomes the home of agent identity and cross-company control when Workspace turns policy, partner access, and handoff history into explicit operator actions.**
+
+That means the milestone should optimize for:
+
+- operator actionability over more dashboard breadth,
+- identity clarity over more agent marketing,
+- partner control over generic collaboration features,
+- auditability over convenience shortcuts,
+- repeatable review loops over heroic operator memory.
+
+## Operating Rule
+
+`1.0.1` remains a hotfix and hygiene lane only.
+
+All material product work after `1.0.0` should land under the `1.1.0 Workspace Control Plane` track. If a live regression appears, fix it directly as a narrow hotfix without changing the `1.1.0` scope.
+
+## Success Criteria
+
+`1.1.0` is done when all of the following are true:
+
+- workspace approval and policy mutations are executable from the dashboard,
+- partner channels show owner, trust, health, and recent failure context,
+- workspace roster shows owner, runtime type, last seen, key state, and binding health,
+- operators can create internal threads and outbound Beam handoffs from the workspace surface,
+- every important workspace decision is reconstructable from a timeline,
+- recurring digest and escalation loops exist for pending approvals and blocked partner motion,
+- one buyer-like and one operator-like dry run are documented under `reports/`,
+- the final release decision is made from a repo-visible checklist and explicit go/no-go criteria.
+
+## Workstreams
+
+### 1. Approval And Policy Actions
+
+Goal: turn policy from preview into action.
+
+Primary issue:
+
+- [#121](https://github.com/Beam-directory/beam-protocol/issues/121) Make workspace approvals and policy actions executable from the dashboard
+
+Scope:
+
+- mutate approval rules from UI,
+- allow, block, or require review per workflow or partner,
+- audit mutations,
+- document operator paths and failure cases.
+
+### 2. Partner Channels
+
+Goal: make partner connectivity a first-class workspace surface.
+
+Primary issue:
+
+- [#122](https://github.com/Beam-directory/beam-protocol/issues/122) Add partner channels and trust/health surfaces to Beam Workspaces
+
+Scope:
+
+- partner-channel object with owner, status, trust, and recent failure state,
+- blocked/degraded visibility in overview,
+- one-step jump to traces and incidents,
+- test coverage for API and dashboard.
+
+### 3. Identity Lifecycle
+
+Goal: show whether a workspace identity is safe and usable.
+
+Primary issue:
+
+- [#123](https://github.com/Beam-directory/beam-protocol/issues/123) Expose runtime-backed identity lifecycle and owner state in workspace roster
+
+Scope:
+
+- owner and runtime metadata,
+- last seen, key state, and binding health,
+- stale, revoked, or unbound markers,
+- docs for identity state and operator actions.
+
+### 4. Thread Composer
+
+Goal: let operators start work from the workspace instead of jumping between tools.
+
+Primary issue:
+
+- [#124](https://github.com/Beam-directory/beam-protocol/issues/124) Add a workspace thread composer for internal threads and outbound Beam handoffs
+
+Scope:
+
+- create internal thread from workspace UI,
+- start outbound handoff from same surface,
+- make internal vs external state explicit,
+- keep trace linkage into Beam observability.
+
+### 5. Audit Timeline
+
+Goal: reconstruct what happened without guesswork.
+
+Primary issue:
+
+- [#125](https://github.com/Beam-directory/beam-protocol/issues/125) Add workspace audit timeline and decision history
+
+Scope:
+
+- auditable timeline of approvals, policy changes, thread actions, and partner-channel events,
+- links to traces, alerts, and proof artifacts,
+- filtering by event type,
+- persistence and restart safety.
+
+### 6. Recurring Operator Loop
+
+Goal: make workspace follow-through procedural.
+
+Primary issue:
+
+- [#126](https://github.com/Beam-directory/beam-protocol/issues/126) Add recurring workspace approval digest and escalation loop
+
+Scope:
+
+- digest for pending approvals, stale identities, blocked channels, and overdue actions,
+- explicit escalation path,
+- reproducible operator-visible output,
+- docs for the routine.
+
+### 7. Final Dry Runs
+
+Goal: make the release candidate earn the release.
+
+Primary issue:
+
+- [#127](https://github.com/Beam-directory/beam-protocol/issues/127) Run 1.1.0 workspace buyer and operator dry runs
+
+Scope:
+
+- one buyer-like pass from landing to workspace value,
+- one operator-like pass through approvals, partner channels, and threads,
+- new blockers filed as GitHub issues,
+- reports committed under `reports/`.
+
+### 8. Cut Control
+
+Goal: keep the first workspace release boring.
+
+Primary issue:
+
+- [#128](https://github.com/Beam-directory/beam-protocol/issues/128) Prepare the 1.1.0 cut checklist, release notes, and go-no-go gates
+
+Scope:
+
+- repo-visible cut checklist,
+- draft release notes,
+- explicit go/no-go gates,
+- final release only after smoke and dry-run evidence.
+
+## Sequence
+
+### Phase 1: Policy And Partner Control
+
+**April 1, 2026 to April 21, 2026**
+
+- make policy and approval rules actionable,
+- add partner-channel health and trust surface,
+- ensure workspace overview points directly to the blocked or risky objects.
+
+Primary issues:
+
+- [#121](https://github.com/Beam-directory/beam-protocol/issues/121)
+- [#122](https://github.com/Beam-directory/beam-protocol/issues/122)
+
+### Phase 2: Identity Lifecycle
+
+**April 22, 2026 to May 12, 2026**
+
+- enrich the workspace roster with owner, runtime, and key-state truth,
+- make unsafe identities obvious,
+- define the operator actions for stale, revoked, or unbound identities.
+
+Primary issue:
+
+- [#123](https://github.com/Beam-directory/beam-protocol/issues/123)
+
+### Phase 3: Threads And Auditability
+
+**May 13, 2026 to June 2, 2026**
+
+- add the workspace thread composer,
+- connect outbound handoffs to existing Beam traces,
+- add audit timeline and decision history.
+
+Primary issues:
+
+- [#124](https://github.com/Beam-directory/beam-protocol/issues/124)
+- [#125](https://github.com/Beam-directory/beam-protocol/issues/125)
+
+### Phase 4: Recurring Operator Loop
+
+**June 3, 2026 to June 23, 2026**
+
+- make recurring approval and escalation work procedural,
+- define the digest cadence and escalation path,
+- ensure the workflow survives staff memory gaps.
+
+Primary issue:
+
+- [#126](https://github.com/Beam-directory/beam-protocol/issues/126)
+
+### Phase 5: Dry Runs And Cut Control
+
+**June 24, 2026 to July 15, 2026**
+
+- run the final buyer-like and operator-like workspace passes,
+- file any discovered blockers explicitly,
+- prepare the cut checklist, release notes, and go/no-go gates,
+- release only from boring evidence.
+
+Primary issues:
+
+- [#127](https://github.com/Beam-directory/beam-protocol/issues/127)
+- [#128](https://github.com/Beam-directory/beam-protocol/issues/128)
+
+## Release Gates
+
+`1.1.0` should not ship unless all of the following are true:
+
+1. workspace policy mutations are executable and audited,
+2. partner-channel health is visible and linkable to trace evidence,
+3. workspace roster exposes owner/runtime/key-state truth,
+4. internal threads and outbound handoffs can be initiated from the workspace surface,
+5. audit timeline and recurring digest paths are documented and exercised,
+6. buyer-like and operator-like dry runs pass on the candidate,
+7. release notes, checklist, and go/no-go gates are committed in `reports/`.
+
+## Immediate Next Step
+
+Start with `#121` and `#122` together. They define whether Workspace is a real control plane or still just a reporting shell.


### PR DESCRIPTION
## Summary
- add the detailed post-1.0.0 workspace control plane plan under reports/
- close the 1.0.0 milestone and retitle the existing workspace milestone to 1.1.0 Workspace Control Plane
- create issues #121 through #128 for the new 1.1.0 phases and cut-control work

## Testing
- not run (planning and GitHub project management only)