### PR TITLE
Complete 1.1.0 workspace control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v1.1.0 (draft)
+
+### Workspace Control Plane
+- expose workspace partner channels with health states and partner-channel ownership controls
+- show identity lifecycle status, ownership state, and outbound permission toggles in the workspace roster
+- add the thread composer for internal prep work, blocked handoff drafts, and linked handoff threads with trace links
+- add timeline and digest endpoints plus digest delivery to the operator mailbox
+- make policy and approval actions executable from the dashboard-backed workspace surface
+- create workspace dry-run scripts and reports for buyer, operator digest, and operator incident scenarios
+- publish RC checklist and release notes before cutting the `v1.1.0` release
+
 ## v1.0.0 (2026-04-01)
 
 ### First Production Partner

--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -28,7 +28,7 @@ The workspace foundation now adds these records to the directory:
 - `workspace_policies`
   - the policy document for external initiation and approval rules
 
-The current operator-facing surface now covers workspace creation, identity bindings, overview metrics, thread timelines, and policy previews.
+The current operator-facing surface now covers workspace creation, identity bindings, lifecycle state, partner channels, thread composition, timeline history, digest delivery, and policy previews.
 
 ## Why Beam Needs This
 
@@ -44,7 +44,7 @@ Beam Workspaces close that gap.
 
 ## Current Admin API
 
-The first routes are all admin-authenticated:
+The first routes are all admin-authenticated and now include the controls required for partner channels, timelines, digests, and digest delivery.
 
 - `GET /admin/workspaces`
 - `POST /admin/workspaces`
@@ -58,6 +58,12 @@ The first routes are all admin-authenticated:
 - `POST /admin/workspaces/:slug/threads`
 - `GET /admin/workspaces/:slug/policy`
 - `PATCH /admin/workspaces/:slug/policy`
+- `GET /admin/workspaces/:slug/partner-channels`
+- `POST /admin/workspaces/:slug/partner-channels`
+- `PATCH /admin/workspaces/:slug/partner-channels/:id`
+- `GET /admin/workspaces/:slug/timeline`
+- `GET /admin/workspaces/:slug/digest`
+- `POST /admin/workspaces/:slug/digest/deliver`
 
 ### Create a workspace
 
@@ -141,6 +147,49 @@ The first routes are all admin-authenticated:
 }
 ```
 
+### Create a blocked handoff draft
+
+Blocked handoff drafts are valid without a `linkedIntentNonce`. This is the control-plane representation of "the operator has staged the outbound motion, but policy or approval is still stopping it."
+
+```json
+{
+  "kind": "handoff",
+  "title": "Quote approval draft",
+  "summary": "Blocked until the named approver confirms the partner route.",
+  "owner": "ops@example.com",
+  "status": "blocked",
+  "workflowType": "quote.approval",
+  "participants": [
+    {
+      "principalId": "ops-bot@beam.directory",
+      "principalType": "agent",
+      "beamId": "ops-bot@beam.directory",
+      "workspaceBindingId": 12,
+      "role": "owner"
+    },
+    {
+      "principalId": "finance@northwind.beam.directory",
+      "principalType": "partner",
+      "beamId": "finance@northwind.beam.directory",
+      "workspaceBindingId": 13,
+      "role": "participant"
+    }
+  ]
+}
+```
+
+### Create a partner channel
+
+```json
+{
+  "partnerBeamId": "finance@northwind.beam.directory",
+  "label": "Northwind Finance",
+  "owner": "ops@example.com",
+  "status": "trial",
+  "notes": "Primary finance route for invoice approvals."
+}
+```
+
 ### Patch a workspace policy
 
 ```json
@@ -170,6 +219,23 @@ The first routes are all admin-authenticated:
 }
 ```
 
+### Deliver a workspace digest
+
+```json
+{
+  "days": 7,
+  "email": "ops@example.com"
+}
+```
+
+The digest summarizes:
+
+- blocked external motion
+- stale or unowned identities
+- degraded or blocked partner channels
+- blocked or ownerless threads
+- recent timeline entries that explain what changed
+
 ## Design Boundary
 
 Beam Workspaces are intentionally narrower than products like OpenAgents Workspace.
@@ -189,8 +255,11 @@ That is why Workspaces start as a control-plane surface first.
 
 The dashboard now surfaces:
 
-1. workspace overview metrics for stale identities, manual review, and blocked outbound motion
-2. internal and external workspace threads on one page, with direct trace links for handoff threads
-3. policy previews showing which bindings can initiate external motion and which workflows require approvals
+1. workspace overview metrics for stale identities, manual review, blocked outbound motion, and the digest queue with overdue action items
+2. internal and external workspace threads on one page, covering blocked handoff drafts, linked handoff threads with trace links, and policy-driven workflows
+3. partner channel health plus partner-channel ownership controls that can trial, unblock, or escalate a partner relationship
+4. identity lifecycle cards showing `lastSeenAgeHours`, ownership state, and controls for pausing or toggling outbound permission
+5. the timeline drawer that collapses partner, policy, identity, thread, and digest events so the operator sees a unified audit trail
+6. the digest delivery panel that bottles action items, escalations, and summary stats and can deliver markdown to the operator mailbox
 
-This keeps Beam Workspace focused on identity ownership, policy, and cross-company control instead of drifting into a generic collaboration product.
+This keeps Beam Workspace focused on identity ownership, policy, partner health, and cross-company control instead of drifting into a generic collaboration product.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "release:smoke": "node scripts/release/release-smoke.mjs",
     "test": "npm run test --workspaces --if-present",
     "test:e2e": "node scripts/e2e/run.mjs",
+    "workspace:buyer-dry-run": "node scripts/workspace/buyer-dry-run.mjs",
+    "workspace:digest": "node scripts/workspace/operator-digest.mjs",
+    "workspace:operator-dry-run": "node scripts/workspace/operator-dry-run.mjs",
     "dev:directory": "npm run dev --workspace=packages/directory",
     "typecheck": "npm run typecheck:workspaces",
     "typecheck:workspaces": "npm run typecheck --if-present --workspace=packages/sdk-typescript --workspace=packages/cli --workspace=packages/echo-agent --workspace=packages/create-beam-agent --workspace=packages/dashboard --workspace=packages/directory --workspace=packages/message-bus"

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -15,10 +15,14 @@ export type WorkspaceStatus = 'active' | 'paused' | 'archived'
 export type WorkspaceThreadScope = 'internal' | 'handoff'
 export type WorkspaceBindingType = 'agent' | 'service' | 'partner'
 export type WorkspaceBindingStatus = 'active' | 'paused'
+export type WorkspaceIdentityLifecycleStatus = 'healthy' | 'stale' | 'paused' | 'missing' | 'revoked' | 'unowned'
 export type WorkspacePrincipalType = 'human' | 'agent' | 'service' | 'partner'
 export type WorkspaceThreadKind = 'internal' | 'handoff'
 export type WorkspaceThreadStatus = 'open' | 'blocked' | 'closed'
 export type WorkspaceThreadParticipantRole = 'owner' | 'participant' | 'observer' | 'approver'
+export type WorkspacePartnerChannelStatus = 'active' | 'trial' | 'blocked'
+export type WorkspacePartnerChannelHealth = 'healthy' | 'watch' | 'critical'
+export type WorkspaceTimelineEventKind = 'workspace' | 'policy' | 'identity' | 'partner_channel' | 'thread' | 'digest'
 export type WorkspacePolicyDefaultExternalInitiation = 'binding' | 'deny'
 export type WorkspacePolicyRuleExternalInitiation = 'inherit' | 'allow' | 'deny'
 export type WorkspaceOverviewAttentionCode =
@@ -137,6 +141,14 @@ export interface WorkspaceIdentityBinding {
   notes: string | null
   createdAt: string
   updatedAt: string
+  lastSeenAgeHours: number | null
+  ownershipState: 'owned' | 'unowned'
+  lifecycleStatus: WorkspaceIdentityLifecycleStatus
+  runtime: {
+    mode: 'runtime-backed' | 'service' | 'partner' | 'manual'
+    connector: string | null
+    label: string | null
+  }
   identity: {
     existsLocally: boolean
     beamId: string
@@ -149,6 +161,105 @@ export interface WorkspaceIdentityBinding {
     capabilities: string[]
     keyState: object | null
   }
+}
+
+export interface WorkspaceIdentitiesResponse {
+  workspace: WorkspaceRecord
+  bindings: WorkspaceIdentityBinding[]
+  total: number
+}
+
+export interface WorkspacePartnerChannel {
+  id: number
+  workspaceId: number
+  partnerBeamId: string
+  label: string | null
+  owner: string | null
+  status: WorkspacePartnerChannelStatus
+  healthStatus: WorkspacePartnerChannelHealth
+  notes: string | null
+  lastSuccessAt: string | null
+  lastFailureAt: string | null
+  lastIntentNonce: string | null
+  createdAt: string
+  updatedAt: string
+  stats: {
+    recentSuccesses: number
+    recentFailures: number
+    totalObserved: number
+  }
+  partner: {
+    existsLocally: boolean
+    displayName: string | null
+    org: string | null
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+  }
+  trace: {
+    nonce: string
+    status: IntentLifecycleStatus
+    intentType: string
+    requestedAt: string
+    completedAt: string | null
+    errorCode: string | null
+    href: string
+  } | null
+}
+
+export interface WorkspacePartnerChannelsResponse {
+  workspace: WorkspaceRecord
+  channels: WorkspacePartnerChannel[]
+  total: number
+}
+
+export interface WorkspaceTimelineEntry {
+  id: number
+  kind: WorkspaceTimelineEventKind
+  action: string
+  actor: string
+  target: string
+  timestamp: string
+  summary: string
+  details: Record<string, unknown> | null
+  href: string | null
+  traceHref: string | null
+}
+
+export interface WorkspaceTimelineResponse {
+  workspace: WorkspaceRecord
+  entries: WorkspaceTimelineEntry[]
+  total: number
+}
+
+export interface WorkspaceDigestActionItem {
+  id: string
+  category: 'approval' | 'identity' | 'partner_channel' | 'thread'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
+}
+
+export interface WorkspaceDigestResponse {
+  workspace: WorkspaceRecord
+  generatedAt: string
+  days: number
+  summary: {
+    actionItems: number
+    escalations: number
+    partnerChannels: number
+    openThreads: number
+    staleIdentities: number
+    blockedExternalMotion: number
+  }
+  actionItems: WorkspaceDigestActionItem[]
+  escalations: WorkspaceDigestActionItem[]
+  partnerChannels: WorkspacePartnerChannel[]
+  timeline: WorkspaceTimelineEntry[]
+  markdown: string
 }
 
 export interface WorkspaceOverviewAttentionItem {
@@ -323,6 +434,54 @@ export interface WorkspacePolicyResponse {
 }
 
 export type WorkspacePolicyPatchInput = Partial<WorkspacePolicyDocument>
+
+export interface WorkspaceIdentityPatchInput {
+  owner?: string | null
+  runtimeType?: string | null
+  policyProfile?: string | null
+  defaultThreadScope?: WorkspaceThreadScope
+  canInitiateExternal?: boolean
+  status?: WorkspaceBindingStatus
+  notes?: string | null
+}
+
+export interface WorkspacePartnerChannelCreateInput {
+  partnerBeamId: string
+  label?: string | null
+  owner?: string | null
+  status?: WorkspacePartnerChannelStatus
+  notes?: string | null
+}
+
+export interface WorkspacePartnerChannelPatchInput {
+  label?: string | null
+  owner?: string | null
+  status?: WorkspacePartnerChannelStatus
+  notes?: string | null
+  lastSuccessAt?: string | null
+  lastFailureAt?: string | null
+  lastIntentNonce?: string | null
+}
+
+export interface WorkspaceThreadParticipantInput {
+  principalId: string
+  principalType: WorkspacePrincipalType
+  displayName?: string | null
+  beamId?: string | null
+  workspaceBindingId?: number | null
+  role?: WorkspaceThreadParticipantRole
+}
+
+export interface WorkspaceThreadCreateInput {
+  kind: WorkspaceThreadKind
+  title: string
+  summary?: string | null
+  owner?: string | null
+  status?: WorkspaceThreadStatus
+  workflowType?: string | null
+  linkedIntentNonce?: string | null
+  participants?: WorkspaceThreadParticipantInput[]
+}
 
 export interface BusHealth {
   status: string
@@ -1588,12 +1747,36 @@ export const directoryApi = {
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
   listWorkspaces: () => request<WorkspaceListResponse>('/admin/workspaces', undefined, { admin: true }),
   getWorkspaceOverview: (slug: string) => request<WorkspaceOverviewResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/overview`, undefined, { admin: true }),
+  listWorkspaceIdentities: (slug: string) => request<WorkspaceIdentitiesResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/identities`, undefined, { admin: true }),
+  updateWorkspaceIdentity: (slug: string, id: number, input: WorkspaceIdentityPatchInput) => request<{ binding: WorkspaceIdentityBinding }>(`/admin/workspaces/${encodeURIComponent(slug)}/identities/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  listWorkspacePartnerChannels: (slug: string) => request<WorkspacePartnerChannelsResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/partner-channels`, undefined, { admin: true }),
+  createWorkspacePartnerChannel: (slug: string, input: WorkspacePartnerChannelCreateInput) => request<{ channel: WorkspacePartnerChannel }>(`/admin/workspaces/${encodeURIComponent(slug)}/partner-channels`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  updateWorkspacePartnerChannel: (slug: string, id: number, input: WorkspacePartnerChannelPatchInput) => request<{ channel: WorkspacePartnerChannel }>(`/admin/workspaces/${encodeURIComponent(slug)}/partner-channels/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   listWorkspaceThreads: (slug: string) => request<WorkspaceThreadsResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads`, undefined, { admin: true }),
+  createWorkspaceThread: (slug: string, input: WorkspaceThreadCreateInput) => request<WorkspaceThreadDetailResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   getWorkspaceThread: (slug: string, id: number) => request<WorkspaceThreadDetailResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads/${id}`, undefined, { admin: true }),
   getWorkspacePolicy: (slug: string) => request<WorkspacePolicyResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, undefined, { admin: true }),
   updateWorkspacePolicy: (slug: string, input: WorkspacePolicyPatchInput) => request<WorkspacePolicyResponse & { updated: boolean }>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, {
     method: 'PATCH',
     body: JSON.stringify(input),
+  }, { admin: true }),
+  getWorkspaceTimeline: (slug: string, limit = 100) => request<WorkspaceTimelineResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/timeline${buildQuery({ limit })}`, undefined, { admin: true }),
+  getWorkspaceDigest: (slug: string, params?: { days?: number }) => request<WorkspaceDigestResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/digest${buildQuery({ days: params?.days })}`, undefined, { admin: true }),
+  deliverWorkspaceDigest: (slug: string, input?: { days?: number; email?: string | null }) => request<{ ok: boolean; email: string; deliveredAt: string }>(`/admin/workspaces/${encodeURIComponent(slug)}/digest/deliver`, {
+    method: 'POST',
+    body: JSON.stringify(input ?? {}),
   }, { admin: true }),
   heartbeat: (beamId: string) => request<DirectoryAgent>(`/agents/${encodeURIComponent(beamId)}/heartbeat`, { method: 'POST' }),
   registerAgent: (input: RegisterAgentInput) => request<DirectoryAgent>('/agents/register', {

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -1,20 +1,30 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
 import {
   ApiError,
   directoryApi,
   type IntentLifecycleStatus,
+  type WorkspaceBindingStatus,
+  type WorkspaceDigestActionItem,
+  type WorkspaceDigestResponse,
+  type WorkspaceIdentityBinding,
+  type WorkspaceIdentityLifecycleStatus,
   type WorkspaceOverviewAttentionCode,
   type WorkspaceOverviewAttentionItem,
   type WorkspaceOverviewResponse,
-  type WorkspacePolicyPreview,
+  type WorkspacePartnerChannel,
+  type WorkspacePartnerChannelHealth,
+  type WorkspacePartnerChannelStatus,
   type WorkspacePolicyResponse,
   type WorkspaceRecord,
   type WorkspaceStatus,
   type WorkspaceThread,
   type WorkspaceThreadDetailResponse,
+  type WorkspaceThreadKind,
   type WorkspaceThreadStatus,
+  type WorkspaceTimelineEntry,
+  type WorkspaceTimelineEventKind,
 } from '../lib/api'
 import { formatDateTime, formatLatency, formatNumber, formatRelativeTime } from '../lib/utils'
 
@@ -24,6 +34,48 @@ function workspaceStatusTone(status: WorkspaceStatus): 'default' | 'success' | '
       return 'success'
     case 'paused':
       return 'warning'
+    default:
+      return 'default'
+  }
+}
+
+function lifecycleTone(status: WorkspaceIdentityLifecycleStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'healthy':
+      return 'success'
+    case 'stale':
+    case 'paused':
+    case 'unowned':
+      return 'warning'
+    case 'missing':
+    case 'revoked':
+      return 'critical'
+    default:
+      return 'default'
+  }
+}
+
+function partnerHealthTone(status: WorkspacePartnerChannelHealth): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'healthy':
+      return 'success'
+    case 'watch':
+      return 'warning'
+    case 'critical':
+      return 'critical'
+    default:
+      return 'default'
+  }
+}
+
+function partnerStatusTone(status: WorkspacePartnerChannelStatus): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'active':
+      return 'success'
+    case 'trial':
+      return 'warning'
+    case 'blocked':
+      return 'critical'
     default:
       return 'default'
   }
@@ -88,8 +140,28 @@ function threadStatusTone(status: WorkspaceThreadStatus): 'default' | 'success' 
   }
 }
 
+function digestSeverityTone(severity: WorkspaceDigestActionItem['severity']): 'default' | 'warning' | 'critical' {
+  return severity === 'critical' ? 'critical' : 'warning'
+}
+
+function timelineTone(kind: WorkspaceTimelineEventKind): 'default' | 'success' | 'warning' {
+  switch (kind) {
+    case 'policy':
+      return 'warning'
+    case 'thread':
+    case 'digest':
+      return 'success'
+    default:
+      return 'default'
+  }
+}
+
 function displayName(label: string | null, beamId: string): string {
   return label || beamId
+}
+
+function parseCsvList(value: string): string[] {
+  return [...new Set(value.split(',').map((entry) => entry.trim()).filter(Boolean))]
 }
 
 function summarizeList(values: string[], fallback: string): string {
@@ -109,40 +181,76 @@ function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
   return parts.join(' · ')
 }
 
-function renderPolicyMeta(preview: WorkspacePolicyPreview): string {
-  const parts = [
-    preview.policyProfile ? `Profile ${preview.policyProfile}` : 'No policy profile',
-    preview.matchedBindingRules > 0 ? `${preview.matchedBindingRules} binding rule${preview.matchedBindingRules === 1 ? '' : 's'}` : 'Binding defaults only',
-  ]
-
-  if (preview.matchedWorkflowRules > 0) {
-    parts.push(`${preview.matchedWorkflowRules} workflow rule${preview.matchedWorkflowRules === 1 ? '' : 's'}`)
+function renderBindingRuntime(binding: WorkspaceIdentityBinding): string {
+  if (binding.runtime.label) {
+    return binding.runtime.connector ? `${binding.runtime.connector} · ${binding.runtime.label}` : binding.runtime.label
   }
+  return binding.runtime.mode
+}
 
-  return parts.join(' · ')
+function renderChannelMeta(channel: WorkspacePartnerChannel): string {
+  return [
+    channel.owner ? `Owner ${channel.owner}` : 'No owner',
+    channel.lastSuccessAt ? `Last success ${formatRelativeTime(channel.lastSuccessAt)}` : 'No successful handoff yet',
+    channel.lastFailureAt ? `Last failure ${formatRelativeTime(channel.lastFailureAt)}` : 'No recent failures',
+  ].join(' · ')
+}
+
+function buildPolicyDefaultsState(policy: WorkspacePolicyResponse | null) {
+  return {
+    externalInitiation: policy?.policy.defaults.externalInitiation ?? 'binding',
+    allowedPartners: policy?.policy.defaults.allowedPartners.join(', ') ?? '',
+    notes: policy?.policy.metadata.notes ?? '',
+  }
 }
 
 export default function WorkspacesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [workspaces, setWorkspaces] = useState<WorkspaceRecord[]>([])
   const [overview, setOverview] = useState<WorkspaceOverviewResponse | null>(null)
+  const [bindings, setBindings] = useState<WorkspaceIdentityBinding[]>([])
+  const [channels, setChannels] = useState<WorkspacePartnerChannel[]>([])
   const [threads, setThreads] = useState<WorkspaceThread[]>([])
   const [threadDetail, setThreadDetail] = useState<WorkspaceThreadDetailResponse | null>(null)
   const [policy, setPolicy] = useState<WorkspacePolicyResponse | null>(null)
+  const [timeline, setTimeline] = useState<WorkspaceTimelineEntry[]>([])
+  const [digest, setDigest] = useState<WorkspaceDigestResponse | null>(null)
   const [loading, setLoading] = useState(true)
-  const [overviewLoading, setOverviewLoading] = useState(false)
-  const [threadsLoading, setThreadsLoading] = useState(false)
+  const [surfaceLoading, setSurfaceLoading] = useState(false)
   const [threadDetailLoading, setThreadDetailLoading] = useState(false)
-  const [policyLoading, setPolicyLoading] = useState(false)
+  const [actionBusy, setActionBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
+
+  const [policyDefaults, setPolicyDefaults] = useState(buildPolicyDefaultsState(null))
+  const [workflowForm, setWorkflowForm] = useState({
+    workflowType: '',
+    requireApproval: true,
+    allowedPartners: '',
+    approvers: '',
+  })
+  const [partnerForm, setPartnerForm] = useState({
+    partnerBeamId: '',
+    label: '',
+    owner: '',
+    status: 'trial' as WorkspacePartnerChannelStatus,
+    notes: '',
+  })
+  const [threadForm, setThreadForm] = useState({
+    kind: 'internal' as WorkspaceThreadKind,
+    title: '',
+    summary: '',
+    owner: '',
+    workflowType: '',
+    localBindingId: '',
+    partnerChannelId: '',
+    linkedIntentNonce: '',
+  })
 
   const selectedSlug = searchParams.get('workspace') ?? ''
   const selectedThreadId = useMemo(() => {
     const raw = searchParams.get('thread')
-    if (!raw) {
-      return null
-    }
-
+    if (!raw) return null
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null
   }, [searchParams])
@@ -151,86 +259,99 @@ export default function WorkspacesPage() {
     () => workspaces.find((entry) => entry.slug === selectedSlug) ?? workspaces[0] ?? null,
     [selectedSlug, workspaces],
   )
-
   const selectedThread = useMemo(
     () => threads.find((entry) => entry.id === selectedThreadId) ?? threads[0] ?? null,
     [selectedThreadId, threads],
   )
+  const localBindings = useMemo(
+    () => bindings.filter((binding) => binding.bindingType !== 'partner'),
+    [bindings],
+  )
 
   async function loadWorkspaces() {
+    const response = await directoryApi.listWorkspaces()
+    setWorkspaces(response.workspaces)
+  }
+
+  async function loadWorkspaceSurface(slug: string) {
+    const [
+      overviewResponse,
+      identitiesResponse,
+      partnerChannelsResponse,
+      threadsResponse,
+      policyResponse,
+      timelineResponse,
+      digestResponse,
+    ] = await Promise.all([
+      directoryApi.getWorkspaceOverview(slug),
+      directoryApi.listWorkspaceIdentities(slug),
+      directoryApi.listWorkspacePartnerChannels(slug),
+      directoryApi.listWorkspaceThreads(slug),
+      directoryApi.getWorkspacePolicy(slug),
+      directoryApi.getWorkspaceTimeline(slug, 60),
+      directoryApi.getWorkspaceDigest(slug, { days: 7 }),
+    ])
+
+    setOverview(overviewResponse)
+    setBindings(identitiesResponse.bindings)
+    setChannels(partnerChannelsResponse.channels)
+    setThreads(threadsResponse.threads)
+    setPolicy(policyResponse)
+    setTimeline(timelineResponse.entries)
+    setDigest(digestResponse)
+    setPolicyDefaults(buildPolicyDefaultsState(policyResponse))
+  }
+
+  async function loadThreadDetail(slug: string, threadId: number) {
+    const response = await directoryApi.getWorkspaceThread(slug, threadId)
+    setThreadDetail(response)
+  }
+
+  async function refreshAll(targetWorkspaceSlug?: string, targetThreadId?: number | null) {
     try {
-      setLoading(true)
-      const response = await directoryApi.listWorkspaces()
-      setWorkspaces(response.workspaces)
+      setSurfaceLoading(true)
       setError(null)
+      const slug = targetWorkspaceSlug ?? selectedWorkspace?.slug ?? null
+      await loadWorkspaces()
+      if (slug) {
+        await loadWorkspaceSurface(slug)
+        const effectiveThreadId = targetThreadId ?? selectedThread?.id ?? null
+        if (effectiveThreadId) {
+          await loadThreadDetail(slug, effectiveThreadId)
+        } else {
+          setThreadDetail(null)
+        }
+      }
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Failed to load Beam workspaces')
+      setError(err instanceof ApiError ? err.message : 'Failed to load workspace control plane')
     } finally {
+      setSurfaceLoading(false)
       setLoading(false)
     }
   }
 
-  async function loadOverview(slug: string) {
+  async function runAction(actionKey: string, fn: () => Promise<void>, successMessage: string) {
     try {
-      setOverviewLoading(true)
-      const response = await directoryApi.getWorkspaceOverview(slug)
-      setOverview(response)
+      setActionBusy(actionKey)
+      setNotice(null)
       setError(null)
+      await fn()
+      setNotice(successMessage)
     } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Failed to load workspace overview')
+      setError(err instanceof ApiError ? err.message : 'Workspace action failed')
     } finally {
-      setOverviewLoading(false)
-    }
-  }
-
-  async function loadThreads(slug: string) {
-    try {
-      setThreadsLoading(true)
-      const response = await directoryApi.listWorkspaceThreads(slug)
-      setThreads(response.threads)
-      setError(null)
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Failed to load workspace threads')
-    } finally {
-      setThreadsLoading(false)
-    }
-  }
-
-  async function loadThreadDetail(slug: string, threadId: number) {
-    try {
-      setThreadDetailLoading(true)
-      const response = await directoryApi.getWorkspaceThread(slug, threadId)
-      setThreadDetail(response)
-      setError(null)
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Failed to load workspace thread detail')
-    } finally {
-      setThreadDetailLoading(false)
-    }
-  }
-
-  async function loadPolicy(slug: string) {
-    try {
-      setPolicyLoading(true)
-      const response = await directoryApi.getWorkspacePolicy(slug)
-      setPolicy(response)
-      setError(null)
-    } catch (err) {
-      setError(err instanceof ApiError ? err.message : 'Failed to load workspace policy')
-    } finally {
-      setPolicyLoading(false)
+      setActionBusy(null)
     }
   }
 
   useEffect(() => {
-    void loadWorkspaces()
+    void refreshAll()
   }, [])
 
   useEffect(() => {
     if (!selectedWorkspace) {
       return
     }
-
     if (selectedWorkspace.slug !== selectedSlug) {
       const next = new URLSearchParams(searchParams)
       next.set('workspace', selectedWorkspace.slug)
@@ -241,15 +362,27 @@ export default function WorkspacesPage() {
   useEffect(() => {
     if (!selectedWorkspace) {
       setOverview(null)
+      setBindings([])
+      setChannels([])
       setThreads([])
       setThreadDetail(null)
       setPolicy(null)
+      setTimeline([])
+      setDigest(null)
       return
     }
 
-    void loadOverview(selectedWorkspace.slug)
-    void loadThreads(selectedWorkspace.slug)
-    void loadPolicy(selectedWorkspace.slug)
+    void (async () => {
+      try {
+        setSurfaceLoading(true)
+        setError(null)
+        await loadWorkspaceSurface(selectedWorkspace.slug)
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to load workspace surface')
+      } finally {
+        setSurfaceLoading(false)
+      }
+    })()
   }, [selectedWorkspace?.slug])
 
   useEffect(() => {
@@ -279,14 +412,221 @@ export default function WorkspacesPage() {
       return
     }
 
-    void loadThreadDetail(selectedWorkspace.slug, selectedThread.id)
+    void (async () => {
+      try {
+        setThreadDetailLoading(true)
+        setError(null)
+        await loadThreadDetail(selectedWorkspace.slug, selectedThread.id)
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to load workspace thread detail')
+      } finally {
+        setThreadDetailLoading(false)
+      }
+    })()
   }, [selectedWorkspace?.slug, selectedThread?.id])
+
+  async function handlePolicyDefaultsSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!selectedWorkspace) return
+
+    await runAction('policy-defaults', async () => {
+      const response = await directoryApi.updateWorkspacePolicy(selectedWorkspace.slug, {
+        defaults: {
+          externalInitiation: policyDefaults.externalInitiation,
+          allowedPartners: parseCsvList(policyDefaults.allowedPartners),
+        },
+        metadata: {
+          notes: policyDefaults.notes.trim() || null,
+        },
+      })
+      setPolicy(response)
+      setPolicyDefaults(buildPolicyDefaultsState(response))
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, 'Workspace policy defaults updated.')
+  }
+
+  async function handleWorkflowRuleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!selectedWorkspace || !policy || !workflowForm.workflowType.trim()) return
+
+    const nextRule = {
+      workflowType: workflowForm.workflowType.trim(),
+      requireApproval: workflowForm.requireApproval,
+      allowedPartners: parseCsvList(workflowForm.allowedPartners),
+      approvers: parseCsvList(workflowForm.approvers),
+    }
+
+    await runAction(`workflow-${nextRule.workflowType}`, async () => {
+      const response = await directoryApi.updateWorkspacePolicy(selectedWorkspace.slug, {
+        workflowRules: [
+          ...policy.policy.workflowRules.filter((rule) => rule.workflowType !== nextRule.workflowType),
+          nextRule,
+        ],
+      })
+      setPolicy(response)
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      setWorkflowForm({
+        workflowType: '',
+        requireApproval: true,
+        allowedPartners: '',
+        approvers: '',
+      })
+    }, `Workflow rule ${nextRule.workflowType} updated.`)
+  }
+
+  async function handleWorkflowRuleDelete(workflowType: string) {
+    if (!selectedWorkspace || !policy) return
+
+    await runAction(`workflow-delete-${workflowType}`, async () => {
+      const response = await directoryApi.updateWorkspacePolicy(selectedWorkspace.slug, {
+        workflowRules: policy.policy.workflowRules.filter((rule) => rule.workflowType !== workflowType),
+      })
+      setPolicy(response)
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, `Workflow rule ${workflowType} removed.`)
+  }
+
+  async function handleBindingToggle(binding: WorkspaceIdentityBinding, patch: Partial<Pick<WorkspaceIdentityBinding, 'status' | 'canInitiateExternal'>>) {
+    if (!selectedWorkspace) return
+    await runAction(`binding-${binding.id}`, async () => {
+      await directoryApi.updateWorkspaceIdentity(selectedWorkspace.slug, binding.id, patch)
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, `${binding.beamId} updated.`)
+  }
+
+  async function handlePartnerChannelSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!selectedWorkspace || !partnerForm.partnerBeamId.trim()) return
+
+    await runAction('partner-channel-create', async () => {
+      await directoryApi.createWorkspacePartnerChannel(selectedWorkspace.slug, {
+        partnerBeamId: partnerForm.partnerBeamId.trim(),
+        label: partnerForm.label.trim() || null,
+        owner: partnerForm.owner.trim() || null,
+        status: partnerForm.status,
+        notes: partnerForm.notes.trim() || null,
+      })
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      setPartnerForm({
+        partnerBeamId: '',
+        label: '',
+        owner: '',
+        status: 'trial',
+        notes: '',
+      })
+    }, `Partner channel ${partnerForm.partnerBeamId.trim()} created.`)
+  }
+
+  async function handlePartnerChannelAction(channel: WorkspacePartnerChannel, status: WorkspacePartnerChannelStatus) {
+    if (!selectedWorkspace) return
+    await runAction(`partner-channel-${channel.id}`, async () => {
+      await directoryApi.updateWorkspacePartnerChannel(selectedWorkspace.slug, channel.id, { status })
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, `${channel.label || channel.partnerBeamId} moved to ${status}.`)
+  }
+
+  async function handleThreadComposerSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!selectedWorkspace || !threadForm.title.trim()) return
+
+    const localBinding = localBindings.find((binding) => binding.id === Number.parseInt(threadForm.localBindingId, 10))
+    const partnerChannel = channels.find((channel) => channel.id === Number.parseInt(threadForm.partnerChannelId, 10))
+    const partnerBinding = bindings.find((binding) => binding.beamId === partnerChannel?.partnerBeamId)
+    const participants: Array<{
+      principalId: string
+      principalType: 'human' | 'agent' | 'service' | 'partner'
+      displayName?: string | null
+      beamId?: string | null
+      workspaceBindingId?: number | null
+      role?: 'owner' | 'participant' | 'observer' | 'approver'
+    }> = []
+
+    if (threadForm.owner.trim()) {
+      participants.push({
+        principalId: threadForm.owner.trim(),
+        principalType: 'human',
+        displayName: threadForm.owner.trim(),
+        role: 'owner',
+      })
+    }
+
+    if (localBinding) {
+      participants.push({
+        principalId: localBinding.beamId,
+        principalType: localBinding.bindingType === 'service' ? 'service' : 'agent',
+        beamId: localBinding.beamId,
+        workspaceBindingId: localBinding.id,
+        displayName: localBinding.identity.displayName,
+        role: threadForm.kind === 'handoff' ? 'owner' : 'participant',
+      })
+    }
+
+    if (threadForm.kind === 'handoff' && partnerChannel) {
+      participants.push({
+        principalId: partnerChannel.partnerBeamId,
+        principalType: 'partner',
+        beamId: partnerChannel.partnerBeamId,
+        workspaceBindingId: partnerBinding?.id ?? null,
+        displayName: partnerChannel.label || partnerChannel.partner.displayName,
+        role: 'participant',
+      })
+    }
+
+    await runAction('thread-composer', async () => {
+      const response = await directoryApi.createWorkspaceThread(selectedWorkspace.slug, {
+        kind: threadForm.kind,
+        title: threadForm.title.trim(),
+        summary: threadForm.summary.trim() || null,
+        owner: threadForm.owner.trim() || null,
+        workflowType: threadForm.workflowType.trim() || null,
+        linkedIntentNonce: threadForm.linkedIntentNonce.trim() || null,
+        status: threadForm.kind === 'handoff' && !threadForm.linkedIntentNonce.trim() ? 'blocked' : 'open',
+        participants,
+      })
+
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      setThreadForm({
+        kind: 'internal',
+        title: '',
+        summary: '',
+        owner: '',
+        workflowType: '',
+        localBindingId: '',
+        partnerChannelId: '',
+        linkedIntentNonce: '',
+      })
+
+      const next = new URLSearchParams(searchParams)
+      next.set('workspace', selectedWorkspace.slug)
+      next.set('thread', String(response.thread.id))
+      setSearchParams(next, { replace: true })
+    }, 'Workspace thread created.')
+  }
+
+  async function handleDeliverDigest() {
+    if (!selectedWorkspace) return
+
+    await runAction('workspace-digest-deliver', async () => {
+      await directoryApi.deliverWorkspaceDigest(selectedWorkspace.slug, { days: 7 })
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, 'Workspace digest delivered to your operator mailbox.')
+  }
+
+  async function handleCopyDigest() {
+    if (!digest) return
+    try {
+      await navigator.clipboard.writeText(digest.markdown)
+      setNotice('Workspace digest copied to the clipboard.')
+    } catch {
+      setError('Clipboard access is not available in this browser context.')
+    }
+  }
 
   return (
     <div className="space-y-6">
       <PageHeader
         title="Workspaces"
-        description="Identity home, external handoff controls, thread timelines, and operator policy previews for Beam workspaces."
+        description="Identity home, policy control, outbound approvals, partner channels, thread drafts, and audit proof for Beam workspaces."
         actions={(
           <div className="flex flex-wrap items-center gap-2">
             {workspaces.length > 0 ? (
@@ -307,25 +647,18 @@ export default function WorkspacesPage() {
                 ))}
               </select>
             ) : null}
-            <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to="/beta-requests">
-              Beta requests
+            <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to="/partner-ops">
+              Partner ops
             </Link>
             <button
-              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
               type="button"
+              disabled={surfaceLoading}
               onClick={() => {
-                void loadWorkspaces()
-                if (selectedWorkspace) {
-                  void loadOverview(selectedWorkspace.slug)
-                  void loadThreads(selectedWorkspace.slug)
-                  void loadPolicy(selectedWorkspace.slug)
-                  if (selectedThread) {
-                    void loadThreadDetail(selectedWorkspace.slug, selectedThread.id)
-                  }
-                }
+                void refreshAll(selectedWorkspace?.slug, selectedThread?.id ?? null)
               }}
             >
-              Refresh
+              {surfaceLoading ? 'Refreshing…' : 'Refresh'}
             </button>
           </div>
         )}
@@ -337,66 +670,68 @@ export default function WorkspacesPage() {
         </div>
       ) : null}
 
+      {notice ? (
+        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+          {notice}
+        </div>
+      ) : null}
+
       {!loading && workspaces.length === 0 ? (
-        <EmptyPanel label="No Beam workspaces exist yet. Create one from the admin API first, then this surface will show identity health, threads, and partner policy previews." />
+        <EmptyPanel label="No Beam workspaces exist yet. Create one from the admin API first, then this surface will show control-plane state." />
       ) : null}
 
       {selectedWorkspace ? (
         <>
           <section className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
-            <MetricCard label="Active identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.activeIdentities)} hint={`${overview ? formatNumber(overview.summary.totalIdentities) : '—'} total bound identities`} />
-            <MetricCard label="External ready" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.externalReadyIdentities)} tone={(overview?.summary.externalReadyIdentities ?? 0) > 0 ? 'success' : 'default'} />
-            <MetricCard label="Stale identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.staleIdentities)} tone={(overview?.summary.staleIdentities ?? 0) > 0 ? 'warning' : 'default'} />
-            <MetricCard label="Manual review" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.pendingApprovals)} tone={(overview?.summary.pendingApprovals ?? 0) > 0 ? 'warning' : 'default'} />
-            <MetricCard label="Blocked motion" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.blockedExternalMotion)} tone={(overview?.summary.blockedExternalMotion ?? 0) > 0 ? 'critical' : 'default'} />
-            <MetricCard label="Recent external handoffs" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.recentExternalHandoffs)} hint={`Stale after ${overview?.staleAfterHours ?? 24}h`} />
+            <MetricCard label="Active identities" value={!overview ? '—' : formatNumber(overview.summary.activeIdentities)} hint={`${overview ? formatNumber(overview.summary.totalIdentities) : '—'} total`} />
+            <MetricCard label="External ready" value={!overview ? '—' : formatNumber(overview.summary.externalReadyIdentities)} tone={(overview?.summary.externalReadyIdentities ?? 0) > 0 ? 'success' : 'default'} />
+            <MetricCard label="Stale identities" value={!overview ? '—' : formatNumber(overview.summary.staleIdentities)} tone={(overview?.summary.staleIdentities ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Manual review" value={!overview ? '—' : formatNumber(overview.summary.pendingApprovals)} tone={(overview?.summary.pendingApprovals ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Partner channels" value={formatNumber(channels.length)} tone={channels.some((channel) => channel.healthStatus === 'critical') ? 'critical' : channels.some((channel) => channel.healthStatus === 'watch') ? 'warning' : 'success'} />
+            <MetricCard label="Digest escalations" value={!digest ? '—' : formatNumber(digest.summary.escalations)} tone={(digest?.summary.escalations ?? 0) > 0 ? 'critical' : 'default'} />
           </section>
 
-          <section className="grid gap-6 xl:grid-cols-[0.78fr,1.22fr]">
+          <section className="grid gap-6 xl:grid-cols-[0.74fr,1.26fr]">
             <div className="panel">
               <div className="panel-title">Workspace roster</div>
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                Choose the workspace whose identity surface, thread timeline, and outbound readiness you want to inspect.
+                Pick the workspace whose control plane you want to inspect.
               </p>
               <div className="mt-4 space-y-3">
-                {loading ? (
-                  <EmptyPanel label="Loading workspaces…" />
-                ) : (
-                  workspaces.map((workspace) => {
-                    const selected = workspace.slug === selectedWorkspace.slug
-                    return (
-                      <button
-                        key={workspace.slug}
-                        type="button"
-                        className={`w-full rounded-2xl border px-4 py-3 text-left transition ${
-                          selected
-                            ? 'border-orange-300 bg-orange-50/80 dark:border-orange-500/40 dark:bg-orange-500/10'
-                            : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-900'
-                        }`}
-                        onClick={() => {
-                          const next = new URLSearchParams(searchParams)
-                          next.set('workspace', workspace.slug)
-                          next.delete('thread')
-                          setSearchParams(next, { replace: true })
-                        }}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium">{workspace.name}</div>
-                            <div className="truncate text-xs text-slate-500 dark:text-slate-400">{workspace.slug}</div>
-                          </div>
-                          <StatusPill label={workspace.status} tone={workspaceStatusTone(workspace.status)} />
+                {workspaces.map((workspace) => {
+                  const selected = workspace.slug === selectedWorkspace.slug
+                  return (
+                    <button
+                      key={workspace.slug}
+                      type="button"
+                      className={`w-full rounded-2xl border px-4 py-3 text-left transition ${
+                        selected
+                          ? 'border-orange-300 bg-orange-50/80 dark:border-orange-500/40 dark:bg-orange-500/10'
+                          : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:hover:border-slate-700 dark:hover:bg-slate-900'
+                      }`}
+                      onClick={() => {
+                        const next = new URLSearchParams(searchParams)
+                        next.set('workspace', workspace.slug)
+                        next.delete('thread')
+                        setSearchParams(next, { replace: true })
+                      }}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium">{workspace.name}</div>
+                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{workspace.slug}</div>
                         </div>
-                        <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-500 dark:text-slate-400">
-                          <div>{formatNumber(workspace.summary.identities)} identities</div>
-                          <div>{formatNumber(workspace.summary.externalInitiators)} initiators</div>
-                          <div>{formatNumber(workspace.summary.partnerChannels)} partner channels</div>
-                          <div>{workspace.externalHandoffsEnabled ? 'External on' : 'External off'}</div>
-                        </div>
-                      </button>
-                    )
-                  })
-                )}
+                        <StatusPill label={workspace.status} tone={workspaceStatusTone(workspace.status)} />
+                      </div>
+                      <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-500 dark:text-slate-400">
+                        <div>{formatNumber(workspace.summary.identities)} identities</div>
+                        <div>{formatNumber(workspace.summary.partnerChannels)} partner channels</div>
+                        <div>{formatNumber(workspace.summary.externalInitiators)} initiators</div>
+                        <div>{workspace.externalHandoffsEnabled ? 'External on' : 'External off'}</div>
+                      </div>
+                    </button>
+                  )
+                })}
               </div>
             </div>
 
@@ -405,7 +740,7 @@ export default function WorkspacesPage() {
                 <div>
                   <div className="panel-title">{selectedWorkspace.name}</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    {selectedWorkspace.description || 'Beam Workspace control plane for identities, internal work, and partner-facing motion.'}
+                    {selectedWorkspace.description || 'Beam Workspace control plane for identities, approvals, and partner-facing motion.'}
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
@@ -419,18 +754,17 @@ export default function WorkspacesPage() {
               </div>
 
               <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                <MetricCard label="Local identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.localIdentities)} />
-                <MetricCard label="Partner identities" value={overviewLoading || !overview ? '—' : formatNumber(overview.summary.partnerIdentities)} />
+                <MetricCard label="Local identities" value={!overview ? '—' : formatNumber(overview.summary.localIdentities)} />
+                <MetricCard label="Partner identities" value={!overview ? '—' : formatNumber(overview.summary.partnerIdentities)} />
                 <MetricCard label="Workspace members" value={formatNumber(selectedWorkspace.summary.members)} />
                 <MetricCard label="Updated" value={formatRelativeTime(selectedWorkspace.updatedAt)} hint={formatDateTime(selectedWorkspace.updatedAt)} />
               </div>
 
               <div className="mt-5 rounded-2xl border border-slate-200 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
-                <div className="font-medium text-slate-900 dark:text-slate-100">What this page is telling you</div>
+                <div className="font-medium text-slate-900 dark:text-slate-100">What changed in this control plane</div>
                 <div className="mt-1">
-                  Beam marks a workspace as risky when identities stop checking in, when outbound motion is paused or still manual,
-                  or when recent partner-facing traces are failing. Threads below distinguish internal prep from cross-company motion, and the policy
-                  preview shows which bindings can move outward and which workflows still need explicit approval.
+                  Operators can now execute approval-path decisions directly from one surface: resume or pause bindings, grant or remove outbound rights, manage partner channels,
+                  create internal or blocked handoff threads, review workspace policy, inspect the audit timeline, and ship a digest when a workspace needs human attention.
                 </div>
               </div>
             </div>
@@ -440,41 +774,78 @@ export default function WorkspacesPage() {
             <div className="panel">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="panel-title">Stale identities</div>
+                  <div className="panel-title">Identity lifecycle</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Local identities that are missing or have not checked in within {overview?.staleAfterHours ?? 24} hours.
+                    Runtime-backed identities, owners, key-state drift, and outbound controls for this workspace.
                   </p>
                 </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">{formatNumber(bindings.length)} bindings</div>
               </div>
+
               <div className="mt-4 space-y-3">
-                {overviewLoading || !overview ? (
-                  <EmptyPanel label="Loading stale identity signals…" />
-                ) : overview.staleBindings.length === 0 ? (
-                  <EmptyPanel label="No stale workspace identities right now." />
+                {bindings.length === 0 ? (
+                  <EmptyPanel label="No workspace bindings exist yet." />
                 ) : (
-                  overview.staleBindings.map((item) => (
-                    <div key={`${item.binding.id}-${item.reasonCode}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
-                      <div className="flex items-start justify-between gap-3">
+                  bindings.map((binding) => (
+                    <div key={binding.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="min-w-0">
-                          <div className="truncate text-sm font-medium">
-                            {displayName(item.binding.identity.displayName, item.binding.beamId)}
+                          <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                            {displayName(binding.identity.displayName, binding.beamId)}
                           </div>
-                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{item.binding.beamId}</div>
+                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{binding.beamId}</div>
                         </div>
-                        <div className="flex flex-wrap items-center justify-end gap-2">
-                          <StatusPill label={attentionLabel(item.reasonCode)} tone={attentionTone(item.reasonCode)} />
-                          <StatusPill label={item.binding.bindingType} />
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={binding.bindingType} />
+                          <StatusPill label={binding.lifecycleStatus} tone={lifecycleTone(binding.lifecycleStatus)} />
+                          <StatusPill label={binding.status} tone={binding.status === 'paused' ? 'warning' : 'default'} />
                         </div>
                       </div>
-                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.reason}</div>
-                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{renderAttentionMeta(item)}</div>
-                      {item.binding.identity.existsLocally ? (
-                        <div className="mt-3">
-                          <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/agents/${encodeURIComponent(item.binding.beamId)}`}>
-                            Open agent profile
-                          </Link>
-                        </div>
+
+                      <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                        <div>{binding.owner ? `Owner ${binding.owner}` : 'No owner assigned'}</div>
+                        <div>{renderBindingRuntime(binding)}</div>
+                        <div>{binding.identity.lastSeen ? `Last seen ${formatRelativeTime(binding.identity.lastSeen)}` : 'No heartbeat recorded'}</div>
+                        <div>{binding.canInitiateExternal ? 'Can initiate external' : 'Manual review required'}</div>
+                      </div>
+
+                      {binding.notes ? (
+                        <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{binding.notes}</div>
                       ) : null}
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {binding.bindingType !== 'partner' ? (
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `binding-${binding.id}`}
+                            onClick={() => {
+                              void handleBindingToggle(binding, {
+                                canInitiateExternal: !binding.canInitiateExternal,
+                              })
+                            }}
+                          >
+                            {binding.canInitiateExternal ? 'Require manual review' : 'Allow external'}
+                          </button>
+                        ) : null}
+                        <button
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          type="button"
+                          disabled={actionBusy === `binding-${binding.id}`}
+                          onClick={() => {
+                            void handleBindingToggle(binding, {
+                              status: binding.status === 'paused' ? 'active' : 'paused',
+                            })
+                          }}
+                        >
+                          {binding.status === 'paused' ? 'Resume binding' : 'Pause binding'}
+                        </button>
+                        {binding.identity.existsLocally ? (
+                          <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-orange-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-orange-300 dark:hover:bg-slate-800" to={`/agents/${encodeURIComponent(binding.beamId)}`}>
+                            Open agent
+                          </Link>
+                        ) : null}
+                      </div>
                     </div>
                   ))
                 )}
@@ -484,37 +855,97 @@ export default function WorkspacesPage() {
             <div className="panel">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="panel-title">Blocked external motion</div>
+                  <div className="panel-title">Partner channels</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Identities that cannot currently start partner-facing work from this workspace.
+                    Trial, active, or blocked partner lanes with owner, trust context, and last known trace.
                   </p>
                 </div>
-                <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/beta-requests">
-                  Open beta requests
-                </Link>
+                <div className="text-xs text-slate-500 dark:text-slate-400">{formatNumber(channels.length)} channels</div>
               </div>
+
+              <form className="mt-4 grid gap-3 rounded-2xl border border-slate-200 p-4 dark:border-slate-800 md:grid-cols-2" onSubmit={(event) => { void handlePartnerChannelSubmit(event) }}>
+                <input className="input-field" placeholder="partner@northwind.beam.directory" value={partnerForm.partnerBeamId} onChange={(event) => setPartnerForm((current) => ({ ...current, partnerBeamId: event.target.value }))} />
+                <input className="input-field" placeholder="Human label" value={partnerForm.label} onChange={(event) => setPartnerForm((current) => ({ ...current, label: event.target.value }))} />
+                <input className="input-field" placeholder="Owner email" value={partnerForm.owner} onChange={(event) => setPartnerForm((current) => ({ ...current, owner: event.target.value }))} />
+                <select className="input-field" value={partnerForm.status} onChange={(event) => setPartnerForm((current) => ({ ...current, status: event.target.value as WorkspacePartnerChannelStatus }))}>
+                  <option value="trial">trial</option>
+                  <option value="active">active</option>
+                  <option value="blocked">blocked</option>
+                </select>
+                <textarea className="input-field md:col-span-2 min-h-24" placeholder="Operator notes" value={partnerForm.notes} onChange={(event) => setPartnerForm((current) => ({ ...current, notes: event.target.value }))} />
+                <div className="md:col-span-2">
+                  <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white" type="submit" disabled={actionBusy === 'partner-channel-create'}>
+                    {actionBusy === 'partner-channel-create' ? 'Creating…' : 'Add partner channel'}
+                  </button>
+                </div>
+              </form>
+
               <div className="mt-4 space-y-3">
-                {overviewLoading || !overview ? (
-                  <EmptyPanel label="Loading blocked motion…" />
-                ) : overview.blockedExternalMotion.length === 0 ? (
-                  <EmptyPanel label="No outbound blockers are registered for this workspace." />
+                {channels.length === 0 ? (
+                  <EmptyPanel label="No partner channels are configured for this workspace yet." />
                 ) : (
-                  overview.blockedExternalMotion.map((item) => (
-                    <div key={`${item.binding.id}-${item.reasonCode}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
-                      <div className="flex items-start justify-between gap-3">
+                  channels.map((channel) => (
+                    <div key={channel.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
                         <div className="min-w-0">
-                          <div className="truncate text-sm font-medium">
-                            {displayName(item.binding.identity.displayName, item.binding.beamId)}
+                          <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                            {channel.label || displayName(channel.partner.displayName, channel.partnerBeamId)}
                           </div>
-                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{item.binding.beamId}</div>
+                          <div className="truncate text-xs text-slate-500 dark:text-slate-400">{channel.partnerBeamId}</div>
                         </div>
-                        <div className="flex flex-wrap items-center justify-end gap-2">
-                          <StatusPill label={attentionLabel(item.reasonCode)} tone={attentionTone(item.reasonCode)} />
-                          <StatusPill label={item.binding.status} tone={item.binding.status === 'paused' ? 'warning' : 'default'} />
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={channel.status} tone={partnerStatusTone(channel.status)} />
+                          <StatusPill label={channel.healthStatus} tone={partnerHealthTone(channel.healthStatus)} />
                         </div>
                       </div>
-                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.reason}</div>
-                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">{renderAttentionMeta(item)}</div>
+
+                      <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">{renderChannelMeta(channel)}</div>
+                      <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-3">
+                        <div>{formatNumber(channel.stats.totalObserved)} observed</div>
+                        <div>{formatNumber(channel.stats.recentSuccesses)} recent successes</div>
+                        <div>{formatNumber(channel.stats.recentFailures)} recent failures</div>
+                      </div>
+
+                      {channel.notes ? (
+                        <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{channel.notes}</div>
+                      ) : null}
+
+                      <div className="mt-4 flex flex-wrap gap-2">
+                        {channel.status !== 'active' ? (
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `partner-channel-${channel.id}`}
+                            onClick={() => { void handlePartnerChannelAction(channel, 'active') }}
+                          >
+                            Promote active
+                          </button>
+                        ) : null}
+                        {channel.status !== 'blocked' ? (
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `partner-channel-${channel.id}`}
+                            onClick={() => { void handlePartnerChannelAction(channel, 'blocked') }}
+                          >
+                            Block channel
+                          </button>
+                        ) : (
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `partner-channel-${channel.id}`}
+                            onClick={() => { void handlePartnerChannelAction(channel, 'trial') }}
+                          >
+                            Reopen as trial
+                          </button>
+                        )}
+                        {channel.trace ? (
+                          <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-orange-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-orange-300 dark:hover:bg-slate-800" to={channel.trace.href}>
+                            Open last trace
+                          </Link>
+                        ) : null}
+                      </div>
                     </div>
                   ))
                 )}
@@ -526,19 +957,56 @@ export default function WorkspacesPage() {
             <div className="panel">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="panel-title">Workspace threads</div>
+                  <div className="panel-title">Thread composer</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Internal prep stays separate from external Beam handoffs, but both live on one operator timeline.
+                    Draft internal coordination threads or blocked handoff threads before a runtime sends the real Beam message.
                   </p>
                 </div>
-                <div className="text-xs text-slate-500 dark:text-slate-400">
-                  {threadsLoading ? 'Loading…' : `${formatNumber(threads.length)} threads`}
-                </div>
+                <StatusPill label={threadForm.kind === 'handoff' ? 'Handoff draft' : 'Internal thread'} tone={threadForm.kind === 'handoff' ? 'warning' : 'default'} />
               </div>
-              <div className="mt-4 space-y-3">
-                {threadsLoading ? (
-                  <EmptyPanel label="Loading workspace threads…" />
-                ) : threads.length === 0 ? (
+
+              <form className="mt-4 grid gap-3 md:grid-cols-2" onSubmit={(event) => { void handleThreadComposerSubmit(event) }}>
+                <select className="input-field" value={threadForm.kind} onChange={(event) => setThreadForm((current) => ({ ...current, kind: event.target.value as WorkspaceThreadKind }))}>
+                  <option value="internal">internal</option>
+                  <option value="handoff">handoff</option>
+                </select>
+                <input className="input-field" placeholder="Owner email" value={threadForm.owner} onChange={(event) => setThreadForm((current) => ({ ...current, owner: event.target.value }))} />
+                <input className="input-field md:col-span-2" placeholder="Thread title" value={threadForm.title} onChange={(event) => setThreadForm((current) => ({ ...current, title: event.target.value }))} />
+                <textarea className="input-field md:col-span-2 min-h-24" placeholder="Summary or operator brief" value={threadForm.summary} onChange={(event) => setThreadForm((current) => ({ ...current, summary: event.target.value }))} />
+                <select className="input-field" value={threadForm.localBindingId} onChange={(event) => setThreadForm((current) => ({ ...current, localBindingId: event.target.value }))}>
+                  <option value="">Select local identity</option>
+                  {localBindings.map((binding) => (
+                    <option key={binding.id} value={binding.id}>
+                      {binding.identity.displayName || binding.beamId}
+                    </option>
+                  ))}
+                </select>
+                <input className="input-field" placeholder="Workflow type (optional)" value={threadForm.workflowType} onChange={(event) => setThreadForm((current) => ({ ...current, workflowType: event.target.value }))} />
+                {threadForm.kind === 'handoff' ? (
+                  <>
+                    <select className="input-field" value={threadForm.partnerChannelId} onChange={(event) => setThreadForm((current) => ({ ...current, partnerChannelId: event.target.value }))}>
+                      <option value="">Select partner channel</option>
+                      {channels.map((channel) => (
+                        <option key={channel.id} value={channel.id}>
+                          {channel.label || channel.partnerBeamId}
+                        </option>
+                      ))}
+                    </select>
+                    <input className="input-field" placeholder="Linked intent nonce (optional if still blocked)" value={threadForm.linkedIntentNonce} onChange={(event) => setThreadForm((current) => ({ ...current, linkedIntentNonce: event.target.value }))} />
+                  </>
+                ) : null}
+                <div className="md:col-span-2 flex flex-wrap gap-2">
+                  <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white" type="submit" disabled={actionBusy === 'thread-composer'}>
+                    {actionBusy === 'thread-composer' ? 'Creating…' : 'Create thread'}
+                  </button>
+                  <div className="text-xs text-slate-500 dark:text-slate-400">
+                    Handoff drafts without a linked nonce are created as blocked threads until a runtime sends the real outbound message.
+                  </div>
+                </div>
+              </form>
+
+              <div className="mt-6 space-y-3">
+                {threads.length === 0 ? (
                   <EmptyPanel label="No workspace threads were recorded yet." />
                 ) : (
                   threads.map((thread) => {
@@ -566,17 +1034,16 @@ export default function WorkspacesPage() {
                               {thread.summary || 'No thread summary yet.'}
                             </div>
                           </div>
-                          <div className="flex flex-wrap justify-end gap-2">
-                            <StatusPill label={thread.kind} tone={thread.kind === 'handoff' ? 'success' : 'default'} />
+                          <div className="flex flex-wrap gap-2">
+                            <StatusPill label={thread.kind} tone={thread.kind === 'handoff' ? 'warning' : 'default'} />
                             <StatusPill label={thread.status} tone={threadStatusTone(thread.status)} />
                             {thread.trace ? <StatusPill label={thread.trace.status} tone={handoffStatusTone(thread.trace.status)} /> : null}
                           </div>
                         </div>
-
                         <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
-                          <div>{thread.workflowType ? `Workflow ${thread.workflowType}` : 'Internal-only thread'}</div>
-                          <div>{formatNumber(thread.participantCount)} participants</div>
+                          <div>{thread.workflowType ? `Workflow ${thread.workflowType}` : 'Internal coordination'}</div>
                           <div>{thread.owner ? `Owner ${thread.owner}` : 'No owner assigned'}</div>
+                          <div>{formatNumber(thread.participantCount)} participants</div>
                           <div>Last active {formatRelativeTime(thread.lastActivityAt)}</div>
                         </div>
                       </button>
@@ -587,40 +1054,30 @@ export default function WorkspacesPage() {
             </div>
 
             <div className="panel">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="panel-title">Thread detail</div>
-                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Read the participant set, linked Beam trace, and the exact workflow mode for the selected thread.
-                  </p>
-                </div>
-                {selectedThread ? (
-                  <StatusPill label={selectedThread.kind === 'handoff' ? 'Cross-company motion' : 'Internal prep'} tone={selectedThread.kind === 'handoff' ? 'success' : 'default'} />
-                ) : null}
-              </div>
+              <div className="panel-title">Thread detail</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Participant list, linked Beam trace, and exact workflow mode for the selected thread.
+              </p>
 
               <div className="mt-4">
                 {threadDetailLoading ? (
                   <EmptyPanel label="Loading thread detail…" />
                 ) : !threadDetail ? (
-                  <EmptyPanel label="Select a workspace thread to inspect participants, trace linkage, and workflow state." />
+                  <EmptyPanel label="Select a thread to inspect participants and linked trace state." />
                 ) : (
                   <div className="space-y-4">
                     <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
                           <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{threadDetail.thread.title}</div>
-                          <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">
-                            {threadDetail.thread.summary || 'No thread summary is attached yet.'}
-                          </div>
+                          <div className="mt-1 text-sm text-slate-600 dark:text-slate-300">{threadDetail.thread.summary || 'No thread summary attached yet.'}</div>
                         </div>
                         <div className="flex flex-wrap gap-2">
-                          <StatusPill label={threadDetail.thread.kind} tone={threadDetail.thread.kind === 'handoff' ? 'success' : 'default'} />
+                          <StatusPill label={threadDetail.thread.kind} tone={threadDetail.thread.kind === 'handoff' ? 'warning' : 'default'} />
                           <StatusPill label={threadDetail.thread.status} tone={threadStatusTone(threadDetail.thread.status)} />
                           {threadDetail.thread.trace ? <StatusPill label={threadDetail.thread.trace.status} tone={handoffStatusTone(threadDetail.thread.trace.status)} /> : null}
                         </div>
                       </div>
-
                       <div className="mt-4 grid gap-3 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
                         <div>
                           <div className="text-xs uppercase tracking-wide text-slate-400">Workflow</div>
@@ -642,10 +1099,7 @@ export default function WorkspacesPage() {
                     </div>
 
                     <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
-                      <div className="flex items-center justify-between gap-3">
-                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Participants</div>
-                        <div className="text-xs text-slate-500 dark:text-slate-400">{formatNumber(threadDetail.participants.length)} total</div>
-                      </div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Participants</div>
                       <div className="mt-3 space-y-3">
                         {threadDetail.participants.map((participant) => (
                           <div key={participant.id} className="rounded-2xl border border-slate-200 p-3 dark:border-slate-800">
@@ -703,15 +1157,10 @@ export default function WorkspacesPage() {
                             <div className="text-xs uppercase tracking-wide text-slate-400">Latency</div>
                             <div>{formatLatency(threadDetail.thread.trace.latencyMs)}</div>
                           </div>
-                          {threadDetail.thread.trace.errorCode ? (
-                            <div className="md:col-span-2 xl:col-span-4 text-red-600 dark:text-red-300">
-                              {threadDetail.thread.trace.errorCode}
-                            </div>
-                          ) : null}
                         </div>
                       ) : (
                         <div className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-                          Internal threads do not need a linked Beam nonce. Use them to organize prep, approvals, and operator work before external motion starts.
+                          This thread is still internal or blocked. Once a runtime sends the real outbound Beam handoff, attach the nonce here and the full trace will appear.
                         </div>
                       )}
                     </div>
@@ -721,69 +1170,13 @@ export default function WorkspacesPage() {
             </div>
           </section>
 
-          <section className="grid gap-6 xl:grid-cols-[0.95fr,1.05fr]">
+          <section className="grid gap-6 xl:grid-cols-2">
             <div className="panel">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="panel-title">Policy surface</div>
+                  <div className="panel-title">Policy actions</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    These previews show which workspace bindings can initiate external motion and what partner scope they inherit.
-                  </p>
-                </div>
-                <div className="text-xs text-slate-500 dark:text-slate-400">
-                  {policyLoading ? 'Loading…' : policy?.updatedAt ? `Updated ${formatRelativeTime(policy.updatedAt)}` : 'Default policy'}
-                </div>
-              </div>
-
-              <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                <MetricCard label="Default external initiation" value={policyLoading || !policy ? '—' : policy.policy.defaults.externalInitiation} tone={policy?.policy.defaults.externalInitiation === 'deny' ? 'warning' : 'default'} />
-                <MetricCard label="Default partner allowlist" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.defaults.allowedPartners.length)} />
-                <MetricCard label="Binding rules" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.bindingRules.length)} />
-                <MetricCard label="Workflow rules" value={policyLoading || !policy ? '—' : formatNumber(policy.policy.workflowRules.length)} hint={policy?.updatedBy ? `Updated by ${policy.updatedBy}` : 'No explicit updater yet'} />
-              </div>
-
-              <div className="mt-4 rounded-2xl border border-slate-200 px-4 py-4 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
-                <div className="font-medium text-slate-900 dark:text-slate-100">Operator note</div>
-                <div className="mt-1">
-                  {policyLoading || !policy
-                    ? 'Loading workspace policy notes…'
-                    : policy.policy.metadata.notes || 'No workspace-specific note is attached yet. The workspace is using its default policy envelope.'}
-                </div>
-              </div>
-
-              <div className="mt-4 space-y-3">
-                {policyLoading || !policy ? (
-                  <EmptyPanel label="Loading binding previews…" />
-                ) : policy.previews.bindings.length === 0 ? (
-                  <EmptyPanel label="No local bindings are available for policy preview yet." />
-                ) : (
-                  policy.previews.bindings.map((preview) => (
-                    <div key={preview.beamId} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{preview.beamId}</div>
-                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{renderPolicyMeta(preview)}</div>
-                        </div>
-                        <div className="flex flex-wrap gap-2">
-                          <StatusPill label={preview.bindingType} />
-                          <StatusPill label={preview.externalInitiation} tone={preview.externalInitiation === 'allow' ? 'success' : 'warning'} />
-                        </div>
-                      </div>
-                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">
-                        {summarizeList(preview.allowedPartners, 'No explicit partner allowlist. The binding relies on workspace defaults or downstream approval rules.')}
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            </div>
-
-            <div className="panel">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="panel-title">Workflow approvals</div>
-                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Workflow-level previews show when a handoff can leave the workspace immediately and when Beam should stop for named approvers.
+                    Update default outbound policy and attach workflow-specific approval rules without leaving the dashboard.
                   </p>
                 </div>
                 <a
@@ -796,10 +1189,48 @@ export default function WorkspacesPage() {
                 </a>
               </div>
 
+              <form className="mt-4 grid gap-3 rounded-2xl border border-slate-200 p-4 dark:border-slate-800" onSubmit={(event) => { void handlePolicyDefaultsSubmit(event) }}>
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-400">Default external initiation</label>
+                <select className="input-field" value={policyDefaults.externalInitiation} onChange={(event) => setPolicyDefaults((current) => ({ ...current, externalInitiation: event.target.value as 'binding' | 'deny' }))}>
+                  <option value="binding">binding</option>
+                  <option value="deny">deny</option>
+                </select>
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-400">Default allowed partners</label>
+                <input className="input-field" placeholder="partner-a.*, partner-b@northwind.beam.directory" value={policyDefaults.allowedPartners} onChange={(event) => setPolicyDefaults((current) => ({ ...current, allowedPartners: event.target.value }))} />
+                <label className="text-xs font-medium uppercase tracking-wide text-slate-400">Operator note</label>
+                <textarea className="input-field min-h-24" placeholder="Why this workspace is configured this way" value={policyDefaults.notes} onChange={(event) => setPolicyDefaults((current) => ({ ...current, notes: event.target.value }))} />
+                <div>
+                  <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white" type="submit" disabled={actionBusy === 'policy-defaults'}>
+                    {actionBusy === 'policy-defaults' ? 'Saving…' : 'Save defaults'}
+                  </button>
+                </div>
+              </form>
+
+              <form className="mt-4 grid gap-3 rounded-2xl border border-slate-200 p-4 dark:border-slate-800" onSubmit={(event) => { void handleWorkflowRuleSubmit(event) }}>
+                <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Workflow rule</div>
+                <input className="input-field" placeholder="invoice.review" value={workflowForm.workflowType} onChange={(event) => setWorkflowForm((current) => ({ ...current, workflowType: event.target.value }))} />
+                <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                  <input checked={workflowForm.requireApproval} onChange={(event) => setWorkflowForm((current) => ({ ...current, requireApproval: event.target.checked }))} type="checkbox" />
+                  Require approval before outbound motion
+                </label>
+                <input className="input-field" placeholder="Allowed partners (comma separated)" value={workflowForm.allowedPartners} onChange={(event) => setWorkflowForm((current) => ({ ...current, allowedPartners: event.target.value }))} />
+                <input className="input-field" placeholder="Approvers (comma separated)" value={workflowForm.approvers} onChange={(event) => setWorkflowForm((current) => ({ ...current, approvers: event.target.value }))} />
+                <div>
+                  <button className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" type="submit" disabled={actionBusy?.startsWith('workflow-')}>
+                    Save workflow rule
+                  </button>
+                </div>
+              </form>
+            </div>
+
+            <div className="panel">
+              <div className="panel-title">Workflow approvals</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Current workflow rules and the live binding previews they produce.
+              </p>
+
               <div className="mt-4 space-y-4">
-                {policyLoading || !policy ? (
-                  <EmptyPanel label="Loading workflow previews…" />
-                ) : policy.previews.workflows.length === 0 ? (
+                {!policy || policy.previews.workflows.length === 0 ? (
                   <EmptyPanel label="No workflow-specific approval rules are configured for this workspace yet." />
                 ) : (
                   policy.previews.workflows.map((workflow) => (
@@ -807,14 +1238,22 @@ export default function WorkspacesPage() {
                       <div className="flex items-center justify-between gap-3">
                         <div>
                           <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{workflow.workflowType}</div>
-                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                            {formatNumber(workflow.bindings.length)} binding previews
-                          </div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{formatNumber(workflow.bindings.length)} binding previews</div>
                         </div>
-                        <StatusPill
-                          label={workflow.bindings.some((binding) => binding.approvalRequired) ? 'Approval path present' : 'Direct path only'}
-                          tone={workflow.bindings.some((binding) => binding.approvalRequired) ? 'warning' : 'success'}
-                        />
+                        <div className="flex gap-2">
+                          <StatusPill
+                            label={workflow.bindings.some((binding) => binding.approvalRequired) ? 'Approval path present' : 'Direct path only'}
+                            tone={workflow.bindings.some((binding) => binding.approvalRequired) ? 'warning' : 'success'}
+                          />
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `workflow-delete-${workflow.workflowType}`}
+                            onClick={() => { void handleWorkflowRuleDelete(workflow.workflowType) }}
+                          >
+                            Remove
+                          </button>
+                        </div>
                       </div>
 
                       <div className="mt-3 space-y-3">
@@ -823,7 +1262,9 @@ export default function WorkspacesPage() {
                             <div className="flex flex-wrap items-start justify-between gap-3">
                               <div className="min-w-0">
                                 <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{binding.beamId}</div>
-                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{renderPolicyMeta(binding)}</div>
+                                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                  {binding.policyProfile ? `Profile ${binding.policyProfile}` : 'No policy profile'} · {binding.matchedBindingRules} binding rule matches
+                                </div>
                               </div>
                               <div className="flex flex-wrap gap-2">
                                 <StatusPill label={binding.externalInitiation} tone={binding.externalInitiation === 'allow' ? 'success' : 'warning'} />
@@ -833,9 +1274,7 @@ export default function WorkspacesPage() {
                             <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">
                               <div>{summarizeList(binding.allowedPartners, 'No additional workflow-scoped partner allowlist.')}</div>
                               {binding.approvalRequired ? (
-                                <div className="mt-2">
-                                  Approvers: {summarizeList(binding.approvers, 'No approvers listed')}
-                                </div>
+                                <div className="mt-2">Approvers: {summarizeList(binding.approvers, 'No approvers listed')}</div>
                               ) : null}
                             </div>
                           </div>
@@ -848,22 +1287,132 @@ export default function WorkspacesPage() {
             </div>
           </section>
 
+          <section className="grid gap-6 xl:grid-cols-[1.05fr,0.95fr]">
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Workspace timeline</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Audit proof across policy changes, binding updates, partner-channel decisions, thread creation, and digest delivery.
+                  </p>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">{formatNumber(timeline.length)} entries</div>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                {timeline.length === 0 ? (
+                  <EmptyPanel label="No workspace audit entries were recorded yet." />
+                ) : (
+                  timeline.map((entry) => (
+                    <div key={entry.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{entry.summary}</div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{entry.actor} · {formatRelativeTime(entry.timestamp)}</div>
+                        </div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={entry.kind} tone={timelineTone(entry.kind)} />
+                          <StatusPill label={entry.action} />
+                        </div>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-4 text-sm">
+                        {entry.href ? (
+                          <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={entry.href}>
+                            Open workspace surface
+                          </Link>
+                        ) : null}
+                        {entry.traceHref ? (
+                          <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={entry.traceHref}>
+                            Open trace
+                          </Link>
+                        ) : null}
+                        <span className="text-slate-500 dark:text-slate-400">{formatDateTime(entry.timestamp)}</span>
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+
+            <div className="panel">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <div className="panel-title">Workspace digest</div>
+                  <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                    Recurring operator digest and escalation loop for this workspace.
+                  </p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    type="button"
+                    disabled={actionBusy === 'workspace-digest-deliver'}
+                    onClick={() => { void handleDeliverDigest() }}
+                  >
+                    {actionBusy === 'workspace-digest-deliver' ? 'Delivering…' : 'Deliver digest'}
+                  </button>
+                  <button
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    type="button"
+                    disabled={!digest}
+                    onClick={() => { void handleCopyDigest() }}
+                  >
+                    Copy markdown
+                  </button>
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-4 md:grid-cols-2">
+                <MetricCard label="Action items" value={!digest ? '—' : formatNumber(digest.summary.actionItems)} tone={(digest?.summary.actionItems ?? 0) > 0 ? 'warning' : 'default'} />
+                <MetricCard label="Escalations" value={!digest ? '—' : formatNumber(digest.summary.escalations)} tone={(digest?.summary.escalations ?? 0) > 0 ? 'critical' : 'default'} />
+                <MetricCard label="Open threads" value={!digest ? '—' : formatNumber(digest.summary.openThreads)} />
+                <MetricCard label="Blocked motion" value={!digest ? '—' : formatNumber(digest.summary.blockedExternalMotion)} tone={(digest?.summary.blockedExternalMotion ?? 0) > 0 ? 'critical' : 'default'} />
+              </div>
+
+              <div className="mt-4 space-y-3">
+                {!digest || digest.actionItems.length === 0 ? (
+                  <EmptyPanel label="No workspace action items are in the digest right now." />
+                ) : (
+                  digest.actionItems.slice(0, 8).map((item) => (
+                    <div key={item.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.category} · {item.owner ? `Owner ${item.owner}` : 'No owner'}</div>
+                        </div>
+                        <StatusPill label={item.severity} tone={digestSeverityTone(item.severity)} />
+                      </div>
+                      <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.detail}</div>
+                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">Next action: {item.nextAction}</div>
+                      {item.href ? (
+                        <div className="mt-3">
+                          <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={item.href}>
+                            Open surface
+                          </Link>
+                        </div>
+                      ) : null}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          </section>
+
           <section className="panel">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="panel-title">Recent external handoffs</div>
                 <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                  The latest partner-facing or outside-in traces touching this workspace. Use these links to jump straight into the intent feed.
+                  Latest partner-facing or outside-in traces touching this workspace.
                 </p>
               </div>
               <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to="/intents">
                 Open intent feed
               </Link>
             </div>
+
             <div className="mt-4 space-y-3">
-              {overviewLoading || !overview ? (
-                <EmptyPanel label="Loading external handoffs…" />
-              ) : overview.recentExternalHandoffs.length === 0 ? (
+              {!overview || overview.recentExternalHandoffs.length === 0 ? (
                 <EmptyPanel label="No external handoffs were recorded for this workspace yet." />
               ) : (
                 overview.recentExternalHandoffs.map((handoff) => (

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -26,6 +26,7 @@ import type {
   TrustScoreRow,
   VerificationTier,
   WorkspaceIdentityBindingRow,
+  WorkspacePartnerChannelRow,
   WorkspacePolicy,
   WorkspacePolicyRow,
   WorkspaceRow,
@@ -1142,6 +1143,145 @@ export function listWorkspaceIdentityBindings(db: DB, workspaceId: number): Work
       COALESCE(owner, '') ASC,
       beam_id ASC
   `).all(workspaceId) as WorkspaceIdentityBindingRow[]
+}
+
+export function getWorkspacePartnerChannelById(db: DB, id: number): WorkspacePartnerChannelRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_partner_channels
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as WorkspacePartnerChannelRow | undefined
+
+  return row ?? null
+}
+
+export function getWorkspacePartnerChannelByBeamId(
+  db: DB,
+  workspaceId: number,
+  partnerBeamId: string,
+): WorkspacePartnerChannelRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_partner_channels
+    WHERE workspace_id = ? AND partner_beam_id = ?
+    LIMIT 1
+  `).get(workspaceId, partnerBeamId) as WorkspacePartnerChannelRow | undefined
+
+  return row ?? null
+}
+
+export function listWorkspacePartnerChannels(db: DB, workspaceId: number): WorkspacePartnerChannelRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM workspace_partner_channels
+    WHERE workspace_id = ?
+    ORDER BY
+      CASE status
+        WHEN 'blocked' THEN 0
+        WHEN 'trial' THEN 1
+        ELSE 2
+      END ASC,
+      COALESCE(owner, '') ASC,
+      COALESCE(label, partner_beam_id) ASC,
+      id ASC
+  `).all(workspaceId) as WorkspacePartnerChannelRow[]
+}
+
+export function createWorkspacePartnerChannel(
+  db: DB,
+  input: {
+    workspaceId: number
+    partnerBeamId: string
+    label?: string | null
+    owner?: string | null
+    status?: WorkspacePartnerChannelRow['status']
+    notes?: string | null
+    lastSuccessAt?: string | null
+    lastFailureAt?: string | null
+    lastIntentNonce?: string | null
+  },
+): WorkspacePartnerChannelRow {
+  const now = nowIso()
+  const result = db.prepare(`
+    INSERT INTO workspace_partner_channels (
+      workspace_id,
+      partner_beam_id,
+      label,
+      owner,
+      status,
+      notes,
+      last_success_at,
+      last_failure_at,
+      last_intent_nonce,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.workspaceId,
+    input.partnerBeamId,
+    input.label ?? null,
+    input.owner ?? null,
+    input.status ?? 'trial',
+    input.notes ?? null,
+    input.lastSuccessAt ?? null,
+    input.lastFailureAt ?? null,
+    input.lastIntentNonce ?? null,
+    now,
+    now,
+  )
+
+  const channel = getWorkspacePartnerChannelById(db, Number(result.lastInsertRowid))
+  if (!channel) {
+    throw new Error('Workspace partner channel insert succeeded but row was not found')
+  }
+
+  return channel
+}
+
+export function updateWorkspacePartnerChannel(
+  db: DB,
+  input: {
+    id: number
+    label: string | null
+    owner: string | null
+    status: WorkspacePartnerChannelRow['status']
+    notes: string | null
+    lastSuccessAt?: string | null
+    lastFailureAt?: string | null
+    lastIntentNonce?: string | null
+  },
+): WorkspacePartnerChannelRow | null {
+  const existing = getWorkspacePartnerChannelById(db, input.id)
+  if (!existing) {
+    return null
+  }
+
+  const updatedAt = nowIso()
+  db.prepare(`
+    UPDATE workspace_partner_channels
+    SET label = ?,
+        owner = ?,
+        status = ?,
+        notes = ?,
+        last_success_at = ?,
+        last_failure_at = ?,
+        last_intent_nonce = ?,
+        updated_at = ?
+    WHERE id = ?
+  `).run(
+    input.label,
+    input.owner,
+    input.status,
+    input.notes,
+    input.lastSuccessAt === undefined ? existing.last_success_at : input.lastSuccessAt,
+    input.lastFailureAt === undefined ? existing.last_failure_at : input.lastFailureAt,
+    input.lastIntentNonce === undefined ? existing.last_intent_nonce : input.lastIntentNonce,
+    updatedAt,
+    input.id,
+  )
+
+  return getWorkspacePartnerChannelById(db, input.id)
 }
 
 export function createWorkspaceIdentityBinding(

--- a/packages/directory/src/partner-ops.test.ts
+++ b/packages/directory/src/partner-ops.test.ts
@@ -79,6 +79,10 @@ function registerProofAgents(db: ReturnType<typeof createDatabase>) {
   })
 }
 
+function minutesAgoIso(minutesAgo: number): string {
+  return new Date(Date.now() - minutesAgo * 60_000).toISOString()
+}
+
 function seedFailedIntent(
   db: ReturnType<typeof createDatabase>,
   nonce: string,
@@ -215,7 +219,7 @@ test('partner health and alerts attribute incidents back to the affected partner
     const created = await createHostedBetaRequest(app, 'buyer@example.com', 'Northwind Systems')
 
     for (let index = 0; index < 10; index += 1) {
-      seedFailedIntent(db, `partner-proof-${index}`, `2026-03-31T09:${String(index).padStart(2, '0')}:00.000Z`)
+      seedFailedIntent(db, `partner-proof-${index}`, minutesAgoIso(30 + index))
     }
 
     const patchResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
@@ -230,7 +234,7 @@ test('partner health and alerts attribute incidents back to the affected partner
         nextAction: 'Escalate the failing partner approval route before go-live.',
         lastContactAt: '2026-03-30T08:30:00.000Z',
         reminderAt: '2026-03-31T08:00:00.000Z',
-        proofIntentNonce: 'partner-proof-9',
+        proofIntentNonce: 'partner-proof-0',
       }),
     }))
     assert.equal(patchResponse.status, 200)

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -4,6 +4,7 @@ import { requireAdminRole } from '../admin-auth.js'
 import {
   createWorkspace,
   createWorkspaceIdentityBinding,
+  createWorkspacePartnerChannel,
   createWorkspaceThread,
   createWorkspaceThreadParticipant,
   getAgent,
@@ -12,26 +13,36 @@ import {
   getWorkspaceBySlug,
   getWorkspaceIdentityBindingByBeamId,
   getWorkspaceIdentityBindingById,
+  getWorkspacePartnerChannelByBeamId,
+  getWorkspacePartnerChannelById,
   getWorkspacePolicyDocument,
   getWorkspaceSummary,
   getWorkspaceThreadById,
   listAgentKeys,
   listWorkspaceIdentityBindings,
+  listWorkspacePartnerChannels,
   listWorkspaceThreadParticipants,
   listWorkspaceThreads,
   listWorkspaces,
   logAuditEvent,
+  updateWorkspacePartnerChannel,
   updateWorkspacePolicyDocument,
   updateWorkspaceIdentityBinding,
 } from '../db.js'
 import type {
+  AuditLogRow,
   IntentLogRow,
   WorkspaceIdentityBindingRow,
   WorkspaceIdentityBindingStatus,
   WorkspaceIdentityBindingType,
+  WorkspaceIdentityLifecycleStatus,
+  WorkspacePartnerChannelHealth,
+  WorkspacePartnerChannelRow,
+  WorkspacePartnerChannelStatus,
   WorkspacePolicy,
   WorkspacePrincipalType,
   WorkspaceRow,
+  WorkspaceTimelineEventKind,
   WorkspaceThreadKind,
   WorkspaceThreadParticipantRole,
   WorkspaceThreadScope,
@@ -41,6 +52,7 @@ import type {
 } from '../types.js'
 import { serializeAgentKeyState } from '../utils/serialize.js'
 import { evaluateWorkspacePolicy } from '../workspace-policy.js'
+import { sendOperatorDigestEmail } from '../email.js'
 
 const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
 const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'handoff'])
@@ -50,10 +62,14 @@ const WORKSPACE_THREAD_KIND_SET = new Set<WorkspaceThreadKind>(['internal', 'han
 const WORKSPACE_THREAD_STATUS_SET = new Set<WorkspaceThreadStatus>(['open', 'blocked', 'closed'])
 const WORKSPACE_THREAD_PARTICIPANT_ROLE_SET = new Set<WorkspaceThreadParticipantRole>(['owner', 'participant', 'observer', 'approver'])
 const WORKSPACE_PRINCIPAL_TYPE_SET = new Set<WorkspacePrincipalType>(['human', 'agent', 'service', 'partner'])
+const WORKSPACE_PARTNER_CHANNEL_STATUS_SET = new Set<WorkspacePartnerChannelStatus>(['active', 'trial', 'blocked'])
 const WORKSPACE_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
 const WORKSPACE_OVERVIEW_STALE_AFTER_HOURS = 24
 const WORKSPACE_OVERVIEW_RECENT_HANDOFF_LIMIT = 8
 const WORKSPACE_OVERVIEW_INTENT_SCAN_LIMIT = 96
+const WORKSPACE_TIMELINE_LIMIT_DEFAULT = 100
+const WORKSPACE_TIMELINE_LIMIT_MAX = 250
+const WORKSPACE_DIGEST_DEFAULT_DAYS = 7
 
 type SerializedWorkspace = {
   id: number
@@ -89,6 +105,14 @@ type SerializedWorkspaceIdentityBinding = {
   notes: string | null
   createdAt: string
   updatedAt: string
+  lastSeenAgeHours: number | null
+  ownershipState: 'owned' | 'unowned'
+  lifecycleStatus: WorkspaceIdentityLifecycleStatus
+  runtime: {
+    mode: 'runtime-backed' | 'service' | 'partner' | 'manual'
+    connector: string | null
+    label: string | null
+  }
   identity: {
     existsLocally: boolean
     beamId: string
@@ -101,6 +125,68 @@ type SerializedWorkspaceIdentityBinding = {
     capabilities: string[]
     keyState: object | null
   }
+}
+
+type SerializedWorkspacePartnerChannel = {
+  id: number
+  workspaceId: number
+  partnerBeamId: string
+  label: string | null
+  owner: string | null
+  status: WorkspacePartnerChannelStatus
+  healthStatus: WorkspacePartnerChannelHealth
+  notes: string | null
+  lastSuccessAt: string | null
+  lastFailureAt: string | null
+  lastIntentNonce: string | null
+  createdAt: string
+  updatedAt: string
+  stats: {
+    recentSuccesses: number
+    recentFailures: number
+    totalObserved: number
+  }
+  partner: {
+    existsLocally: boolean
+    displayName: string | null
+    org: string | null
+    verificationTier: string | null
+    trustScore: number | null
+    lastSeen: string | null
+  }
+  trace: {
+    nonce: string
+    status: IntentLogRow['status']
+    intentType: string
+    requestedAt: string
+    completedAt: string | null
+    errorCode: string | null
+    href: string
+  } | null
+}
+
+type WorkspaceTimelineEntry = {
+  id: number
+  kind: WorkspaceTimelineEventKind
+  action: string
+  actor: string
+  target: string
+  timestamp: string
+  summary: string
+  details: Record<string, unknown> | null
+  href: string | null
+  traceHref: string | null
+}
+
+type WorkspaceDigestActionItem = {
+  id: string
+  category: 'approval' | 'identity' | 'partner_channel' | 'thread'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
 }
 
 type WorkspaceOverviewAttentionCode =
@@ -255,6 +341,15 @@ function normalizeBindingStatus(value: unknown): WorkspaceIdentityBindingStatus 
   return WORKSPACE_BINDING_STATUS_SET.has(normalized) ? normalized : null
 }
 
+function normalizePartnerChannelStatus(value: unknown): WorkspacePartnerChannelStatus | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase() as WorkspacePartnerChannelStatus
+  return WORKSPACE_PARTNER_CHANNEL_STATUS_SET.has(normalized) ? normalized : null
+}
+
 function normalizeThreadKind(value: unknown): WorkspaceThreadKind | null {
   if (typeof value !== 'string') {
     return null
@@ -367,6 +462,155 @@ function getDisplayNameForBeamId(
   return null
 }
 
+function parseRuntimeMetadata(
+  bindingType: WorkspaceIdentityBindingType,
+  runtimeType: string | null,
+): SerializedWorkspaceIdentityBinding['runtime'] {
+  if (bindingType === 'partner') {
+    return {
+      mode: 'partner',
+      connector: null,
+      label: runtimeType,
+    }
+  }
+
+  if (bindingType === 'service') {
+    const [connector, ...rest] = runtimeType?.split(':').map((entry) => entry.trim()).filter(Boolean) ?? []
+    return {
+      mode: 'service',
+      connector: connector ?? null,
+      label: rest.join(' · ') || runtimeType,
+    }
+  }
+
+  if (runtimeType) {
+    const [connector, ...rest] = runtimeType.split(':').map((entry) => entry.trim()).filter(Boolean)
+    return {
+      mode: 'runtime-backed',
+      connector: connector ?? null,
+      label: rest.join(' · ') || runtimeType,
+    }
+  }
+
+  return {
+    mode: 'manual',
+    connector: null,
+    label: null,
+  }
+}
+
+function classifyWorkspaceIdentityLifecycle(
+  binding: WorkspaceIdentityBindingRow,
+  options: {
+    existsLocally: boolean
+    lastSeenAgeHours: number | null
+    keyState: object | null
+    owner: string | null
+  },
+): WorkspaceIdentityLifecycleStatus {
+  if (!options.owner) {
+    return 'unowned'
+  }
+
+  if (binding.status !== 'active') {
+    return 'paused'
+  }
+
+  if (!options.existsLocally && binding.binding_type !== 'partner') {
+    return 'missing'
+  }
+
+  const keyState = options.keyState as {
+    active?: object | null
+    revoked?: object[]
+  } | null
+
+  if (options.existsLocally && keyState && !keyState.active && Array.isArray(keyState.revoked) && keyState.revoked.length > 0) {
+    return 'revoked'
+  }
+
+  if (options.lastSeenAgeHours !== null && options.lastSeenAgeHours >= WORKSPACE_OVERVIEW_STALE_AFTER_HOURS) {
+    return 'stale'
+  }
+
+  return 'healthy'
+}
+
+function timelineKindFromAction(action: string): WorkspaceTimelineEventKind {
+  if (action.startsWith('admin.workspace_policy')) {
+    return 'policy'
+  }
+  if (action.startsWith('admin.workspace_identity')) {
+    return 'identity'
+  }
+  if (action.startsWith('admin.workspace_partner_channel')) {
+    return 'partner_channel'
+  }
+  if (action.startsWith('admin.workspace_thread')) {
+    return 'thread'
+  }
+  if (action.startsWith('admin.workspace_digest')) {
+    return 'digest'
+  }
+  return 'workspace'
+}
+
+function parseAuditDetails(value: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function extractTraceHref(details: Record<string, unknown> | null): string | null {
+  const nonceCandidates = [
+    details?.['linkedIntentNonce'],
+    details?.['lastIntentNonce'],
+    details?.['proofIntentNonce'],
+    details?.['nonce'],
+  ]
+
+  for (const value of nonceCandidates) {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return `/intents/${encodeURIComponent(value)}`
+    }
+  }
+
+  return null
+}
+
+function summarizeWorkspaceAuditAction(action: string, details: Record<string, unknown> | null): string {
+  switch (action) {
+    case 'admin.workspace.created':
+      return 'Workspace created.'
+    case 'admin.workspace_policy.updated':
+      return 'Workspace policy updated.'
+    case 'admin.workspace_identity.created':
+      return 'Workspace identity binding added.'
+    case 'admin.workspace_identity.updated':
+      return 'Workspace identity binding updated.'
+    case 'admin.workspace_thread.created':
+      return 'Workspace thread created.'
+    case 'admin.workspace_partner_channel.created':
+      return 'Partner channel added.'
+    case 'admin.workspace_partner_channel.updated':
+      return 'Partner channel updated.'
+    case 'admin.workspace_digest.delivered':
+      return 'Workspace digest delivered.'
+    default:
+      if (typeof details?.['workflowType'] === 'string') {
+        return `Workspace action for ${details['workflowType']}.`
+      }
+      return action
+    }
+}
+
 function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspace {
   const summary = getWorkspaceSummary(db, row.id)
   const { policy } = getWorkspacePolicyDocument(db, row.id)
@@ -395,6 +639,14 @@ function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspac
 function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityBindingRow): SerializedWorkspaceIdentityBinding {
   const agent = getAgent(db, row.beam_id)
   const keyState = agent ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) : null
+  const lastSeenAgeHours = hoursSince(agent?.last_seen ?? null)
+  const runtime = parseRuntimeMetadata(row.binding_type, row.runtime_type)
+  const lifecycleStatus = classifyWorkspaceIdentityLifecycle(row, {
+    existsLocally: Boolean(agent),
+    lastSeenAgeHours,
+    keyState,
+    owner: row.owner,
+  })
 
   return {
     id: row.id,
@@ -410,6 +662,10 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
     notes: row.notes,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    lastSeenAgeHours,
+    ownershipState: row.owner ? 'owned' : 'unowned',
+    lifecycleStatus,
+    runtime,
     identity: agent ? {
       existsLocally: true,
       beamId: agent.beam_id,
@@ -433,6 +689,319 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
       capabilities: [],
       keyState,
     },
+  }
+}
+
+function countWorkspacePartnerTraffic(
+  db: Database,
+  localBeamIds: string[],
+  partnerBeamId: string,
+): {
+  recentSuccesses: number
+  recentFailures: number
+  totalObserved: number
+} {
+  if (localBeamIds.length === 0) {
+    return {
+      recentSuccesses: 0,
+      recentFailures: 0,
+      totalObserved: 0,
+    }
+  }
+
+  const placeholders = localBeamIds.map(() => '?').join(', ')
+  const cutoff = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString()
+  const row = db.prepare(`
+    SELECT
+      COUNT(*) AS totalObserved,
+      SUM(CASE WHEN status = 'acked' AND requested_at >= ? THEN 1 ELSE 0 END) AS recentSuccesses,
+      SUM(CASE WHEN status IN ('failed', 'dead_letter') AND requested_at >= ? THEN 1 ELSE 0 END) AS recentFailures
+    FROM intent_log
+    WHERE (
+      (from_beam_id IN (${placeholders}) AND to_beam_id = ?)
+      OR
+      (to_beam_id IN (${placeholders}) AND from_beam_id = ?)
+    )
+  `).get(
+    cutoff,
+    cutoff,
+    ...localBeamIds,
+    partnerBeamId,
+    ...localBeamIds,
+    partnerBeamId,
+  ) as {
+    totalObserved: number | null
+    recentSuccesses: number | null
+    recentFailures: number | null
+  } | undefined
+
+  return {
+    recentSuccesses: row?.recentSuccesses ?? 0,
+    recentFailures: row?.recentFailures ?? 0,
+    totalObserved: row?.totalObserved ?? 0,
+  }
+}
+
+function classifyWorkspacePartnerChannelHealth(
+  row: WorkspacePartnerChannelRow,
+  stats: {
+    recentSuccesses: number
+    recentFailures: number
+    totalObserved: number
+  },
+): WorkspacePartnerChannelHealth {
+  if (row.status === 'blocked') {
+    return 'critical'
+  }
+
+  if (row.last_failure_at && (!row.last_success_at || row.last_failure_at > row.last_success_at)) {
+    return stats.recentFailures > 0 ? 'critical' : 'watch'
+  }
+
+  if (stats.recentFailures > 0) {
+    return 'watch'
+  }
+
+  if (row.status === 'trial' || stats.totalObserved === 0) {
+    return 'watch'
+  }
+
+  return 'healthy'
+}
+
+function serializeWorkspacePartnerChannel(
+  db: Database,
+  row: WorkspacePartnerChannelRow,
+  localBeamIds: string[],
+): SerializedWorkspacePartnerChannel {
+  const partner = getAgent(db, row.partner_beam_id)
+  const stats = countWorkspacePartnerTraffic(db, localBeamIds, row.partner_beam_id)
+  const healthStatus = classifyWorkspacePartnerChannelHealth(row, stats)
+  const trace = row.last_intent_nonce ? getIntentLogByNonce(db, row.last_intent_nonce) : null
+
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    partnerBeamId: row.partner_beam_id,
+    label: row.label,
+    owner: row.owner,
+    status: row.status,
+    healthStatus,
+    notes: row.notes,
+    lastSuccessAt: row.last_success_at,
+    lastFailureAt: row.last_failure_at,
+    lastIntentNonce: row.last_intent_nonce,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    stats,
+    partner: {
+      existsLocally: Boolean(partner),
+      displayName: partner?.display_name ?? null,
+      org: partner?.org ?? null,
+      verificationTier: partner?.verification_tier ?? null,
+      trustScore: partner?.trust_score ?? null,
+      lastSeen: partner?.last_seen ?? null,
+    },
+    trace: trace ? {
+      nonce: trace.nonce,
+      status: trace.status,
+      intentType: trace.intent_type,
+      requestedAt: trace.requested_at,
+      completedAt: trace.completed_at,
+      errorCode: trace.error_code,
+      href: `/intents/${encodeURIComponent(trace.nonce)}`,
+    } : null,
+  }
+}
+
+function listWorkspaceTimelineEntries(
+  db: Database,
+  workspace: WorkspaceRow,
+  limit = WORKSPACE_TIMELINE_LIMIT_DEFAULT,
+): WorkspaceTimelineEntry[] {
+  const boundedLimit = Math.max(1, Math.min(WORKSPACE_TIMELINE_LIMIT_MAX, Math.trunc(limit)))
+  const rows = db.prepare(`
+    SELECT *
+    FROM audit_log
+    WHERE target = ? OR target LIKE ?
+    ORDER BY timestamp DESC, id DESC
+    LIMIT ?
+  `).all(
+    workspace.slug,
+    `${workspace.slug}:%`,
+    boundedLimit,
+  ) as AuditLogRow[]
+
+  return rows.map((row) => {
+    const details = parseAuditDetails(row.details)
+    const kind = timelineKindFromAction(row.action)
+    const traceHref = extractTraceHref(details)
+    let href: string | null = `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`
+    if (kind === 'thread') {
+      const threadId = row.target.slice(`${workspace.slug}:`.length)
+      if (/^\d+$/.test(threadId)) {
+        href = `/workspaces?workspace=${encodeURIComponent(workspace.slug)}&thread=${encodeURIComponent(threadId)}`
+      }
+    }
+
+    return {
+      id: row.id,
+      kind,
+      action: row.action,
+      actor: row.actor,
+      target: row.target,
+      timestamp: row.timestamp,
+      summary: summarizeWorkspaceAuditAction(row.action, details),
+      details,
+      href,
+      traceHref,
+    }
+  })
+}
+
+function buildWorkspaceDigestPayload(db: Database, workspace: WorkspaceRow, days = WORKSPACE_DIGEST_DEFAULT_DAYS) {
+  const generatedAt = new Date().toISOString()
+  const overview = buildWorkspaceOverview(db, workspace)
+  const bindings = listWorkspaceIdentityBindings(db, workspace.id)
+  const localBeamIds = bindings
+    .filter((binding) => binding.binding_type !== 'partner')
+    .map((binding) => binding.beam_id)
+  const partnerChannels = listWorkspacePartnerChannels(db, workspace.id).map((row) => serializeWorkspacePartnerChannel(db, row, localBeamIds))
+  const threads = listWorkspaceThreads(db, workspace.id).map((row) => serializeWorkspaceThread(db, row, listWorkspaceThreadParticipants(db, row.id)))
+  const timeline = listWorkspaceTimelineEntries(db, workspace, 12)
+
+  const actionItems: WorkspaceDigestActionItem[] = []
+
+  for (const item of overview.blockedExternalMotion) {
+    actionItems.push({
+      id: `approval-${item.binding.id}-${item.reasonCode}`,
+      category: 'approval',
+      severity: item.reasonCode === 'workspace_handoffs_disabled' ? 'critical' : 'warning',
+      title: `${item.binding.beamId} cannot initiate external motion`,
+      detail: item.reason,
+      owner: item.binding.owner,
+      href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`,
+      nextAction: item.reasonCode === 'manual_review_required'
+        ? 'Approve external initiation or add a matching workflow rule.'
+        : 'Resume the binding or re-enable workspace external handoffs.',
+    })
+  }
+
+  for (const item of overview.staleBindings) {
+    actionItems.push({
+      id: `identity-${item.binding.id}-${item.reasonCode}`,
+      category: 'identity',
+      severity: item.reasonCode === 'identity_missing' ? 'critical' : 'warning',
+      title: `${item.binding.beamId} needs identity attention`,
+      detail: item.reason,
+      owner: item.binding.owner,
+      href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`,
+      nextAction: item.reasonCode === 'identity_missing'
+        ? 'Re-register the runtime or remove the stale binding.'
+        : 'Check the runtime heartbeat and confirm the owner is still current.',
+    })
+  }
+
+  for (const channel of partnerChannels) {
+    if (channel.healthStatus === 'healthy' && channel.owner) {
+      continue
+    }
+
+    actionItems.push({
+      id: `partner-${channel.id}`,
+      category: 'partner_channel',
+      severity: channel.healthStatus === 'critical' ? 'critical' : 'warning',
+      title: `${channel.label || channel.partnerBeamId} partner channel needs follow-up`,
+      detail: channel.status === 'blocked'
+        ? 'The channel is blocked and cannot be used for new partner-facing motion.'
+        : channel.owner
+          ? 'The channel is degraded or still in trial and should be reviewed before the next handoff.'
+          : 'The channel has no owner and should be assigned before the next external workflow.',
+      owner: channel.owner,
+      href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`,
+      nextAction: channel.status === 'blocked'
+        ? 'Confirm whether to reopen the partner channel or keep it blocked.'
+        : 'Assign an owner, review recent trace evidence, and confirm the partner allowlist.',
+    })
+  }
+
+  for (const thread of threads) {
+    if (thread.status === 'closed') {
+      continue
+    }
+    if (thread.status === 'blocked' || !thread.owner) {
+      actionItems.push({
+        id: `thread-${thread.id}`,
+        category: 'thread',
+        severity: thread.status === 'blocked' ? 'critical' : 'warning',
+        title: `${thread.title} needs operator follow-up`,
+        detail: thread.status === 'blocked'
+          ? 'This workspace thread is blocked and will not progress until an operator resolves it.'
+          : 'This workspace thread has no owner yet and risks getting dropped.',
+        owner: thread.owner,
+        href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}&thread=${thread.id}`,
+        nextAction: thread.status === 'blocked'
+          ? 'Review the linked policy or partner channel decision and unblock or close the thread.'
+          : 'Assign an owner and confirm the next operator action.',
+      })
+    }
+  }
+
+  const escalations = actionItems.filter((item) => item.severity === 'critical')
+
+  const markdownLines = [
+    `# Beam workspace digest · ${workspace.name}`,
+    '',
+    `Generated: ${generatedAt}`,
+    `Window: last ${days} day${days === 1 ? '' : 's'}`,
+    '',
+    '## Summary',
+    `- Active identities: ${overview.summary.activeIdentities}/${overview.summary.totalIdentities}`,
+    `- External-ready identities: ${overview.summary.externalReadyIdentities}`,
+    `- Stale identities: ${overview.summary.staleIdentities}`,
+    `- Pending approvals: ${overview.summary.pendingApprovals}`,
+    `- Blocked external motion: ${overview.summary.blockedExternalMotion}`,
+    `- Partner channels: ${partnerChannels.length}`,
+    `- Open threads: ${threads.filter((thread) => thread.status !== 'closed').length}`,
+    '',
+    '## Action Items',
+  ]
+
+  if (actionItems.length === 0) {
+    markdownLines.push('- No workspace action items right now.')
+  } else {
+    for (const item of actionItems) {
+      markdownLines.push(`- [${item.severity.toUpperCase()}] ${item.title}: ${item.detail} Next: ${item.nextAction}${item.owner ? ` Owner: ${item.owner}.` : ''}${item.href ? ` Surface: ${item.href}` : ''}`)
+    }
+  }
+
+  markdownLines.push('', '## Recent Timeline')
+
+  if (timeline.length === 0) {
+    markdownLines.push('- No workspace timeline entries yet.')
+  } else {
+    for (const entry of timeline) {
+      markdownLines.push(`- ${entry.timestamp} · ${entry.summary} (${entry.actor})`)
+    }
+  }
+
+  return {
+    workspace: serializeWorkspace(db, workspace),
+    generatedAt,
+    days,
+    summary: {
+      actionItems: actionItems.length,
+      escalations: escalations.length,
+      partnerChannels: partnerChannels.length,
+      openThreads: threads.filter((thread) => thread.status !== 'closed').length,
+      staleIdentities: overview.summary.staleIdentities,
+      blockedExternalMotion: overview.summary.blockedExternalMotion,
+    },
+    actionItems,
+    escalations,
+    partnerChannels,
+    timeline,
+    markdown: markdownLines.join('\n'),
   }
 }
 
@@ -884,6 +1453,186 @@ export function workspacesRouter(db: Database): Hono {
     })
   })
 
+  router.get('/:slug/partner-channels', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const localBeamIds = listWorkspaceIdentityBindings(db, workspace.id)
+      .filter((binding) => binding.binding_type !== 'partner')
+      .map((binding) => binding.beam_id)
+    const channels = listWorkspacePartnerChannels(db, workspace.id).map((row) => serializeWorkspacePartnerChannel(db, row, localBeamIds))
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      channels,
+      total: channels.length,
+    })
+  })
+
+  router.post('/:slug/partner-channels', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const partnerBeamId = normalizeOptionalString(raw.partnerBeamId)
+    if (!partnerBeamId) {
+      return c.json({ error: 'partnerBeamId is required', errorCode: 'INVALID_PARTNER_BEAM_ID' }, 400)
+    }
+
+    const status = 'status' in raw ? normalizePartnerChannelStatus(raw.status) : 'trial'
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid partner channel status', errorCode: 'INVALID_PARTNER_CHANNEL_STATUS' }, 400)
+    }
+
+    if (getWorkspacePartnerChannelByBeamId(db, workspace.id, partnerBeamId)) {
+      return c.json({ error: 'Workspace partner channel already exists', errorCode: 'WORKSPACE_PARTNER_CHANNEL_EXISTS' }, 409)
+    }
+
+    try {
+      const channel = createWorkspacePartnerChannel(db, {
+        workspaceId: workspace.id,
+        partnerBeamId,
+        label: normalizeOptionalString(raw.label),
+        owner: normalizeOptionalString(raw.owner),
+        status: status ?? 'trial',
+        notes: normalizeOptionalString(raw.notes),
+      })
+
+      logAuditEvent(db, {
+        action: 'admin.workspace_partner_channel.created',
+        actor: auth.session.email,
+        target: `${workspace.slug}:${partnerBeamId}`,
+        details: {
+          role: auth.session.role,
+          owner: channel.owner,
+          status: channel.status,
+        },
+      })
+
+      const localBeamIds = listWorkspaceIdentityBindings(db, workspace.id)
+        .filter((binding) => binding.binding_type !== 'partner')
+        .map((binding) => binding.beam_id)
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        channel: serializeWorkspacePartnerChannel(db, channel, localBeamIds),
+      }, 201)
+    } catch (err) {
+      if (isUniqueConstraintError(err, 'workspace_partner_channels.workspace_id, workspace_partner_channels.partner_beam_id')) {
+        return c.json({ error: 'Workspace partner channel already exists', errorCode: 'WORKSPACE_PARTNER_CHANNEL_EXISTS' }, 409)
+      }
+
+      console.error('Workspace partner channel create error:', err)
+      return c.json({ error: 'Failed to create workspace partner channel', errorCode: 'DB_ERROR' }, 500)
+    }
+  })
+
+  router.patch('/:slug/partner-channels/:id', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const channelId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(channelId) || channelId <= 0) {
+      return c.json({ error: 'Invalid partner channel id', errorCode: 'INVALID_PARTNER_CHANNEL_ID' }, 400)
+    }
+
+    const existing = getWorkspacePartnerChannelById(db, channelId)
+    if (!existing || existing.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace partner channel not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const status = 'status' in raw ? normalizePartnerChannelStatus(raw.status) : existing.status
+    if ('status' in raw && !status) {
+      return c.json({ error: 'Invalid partner channel status', errorCode: 'INVALID_PARTNER_CHANNEL_STATUS' }, 400)
+    }
+
+    const lastIntentNonce = 'lastIntentNonce' in raw ? normalizeOptionalString(raw.lastIntentNonce) : existing.last_intent_nonce
+    if (lastIntentNonce && !getIntentLogByNonce(db, lastIntentNonce)) {
+      return c.json({ error: 'lastIntentNonce was not found', errorCode: 'INTENT_NOT_FOUND' }, 404)
+    }
+
+    const updated = updateWorkspacePartnerChannel(db, {
+      id: existing.id,
+      label: 'label' in raw ? normalizeOptionalString(raw.label) : existing.label,
+      owner: 'owner' in raw ? normalizeOptionalString(raw.owner) : existing.owner,
+      status: status ?? existing.status,
+      notes: 'notes' in raw ? normalizeOptionalString(raw.notes) : existing.notes,
+      lastSuccessAt: 'lastSuccessAt' in raw ? normalizeOptionalString(raw.lastSuccessAt) : undefined,
+      lastFailureAt: 'lastFailureAt' in raw ? normalizeOptionalString(raw.lastFailureAt) : undefined,
+      lastIntentNonce: 'lastIntentNonce' in raw ? lastIntentNonce : undefined,
+    })
+
+    if (!updated) {
+      return c.json({ error: 'Workspace partner channel not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_partner_channel.updated',
+      actor: auth.session.email,
+      target: `${workspace.slug}:${existing.partner_beam_id}`,
+      details: {
+        role: auth.session.role,
+        owner: updated.owner,
+        status: updated.status,
+        lastIntentNonce: updated.last_intent_nonce,
+      },
+    })
+
+    const localBeamIds = listWorkspaceIdentityBindings(db, workspace.id)
+      .filter((binding) => binding.binding_type !== 'partner')
+      .map((binding) => binding.beam_id)
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      channel: serializeWorkspacePartnerChannel(db, updated, localBeamIds),
+    })
+  })
+
   router.get('/:slug/threads', (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'viewer')
     if (auth instanceof Response) {
@@ -976,8 +1725,8 @@ export function workspacesRouter(db: Database): Hono {
 
     const workflowType = normalizeOptionalString(raw.workflowType)
     const linkedIntentNonce = normalizeOptionalString(raw.linkedIntentNonce)
-    if (kind === 'handoff' && !linkedIntentNonce) {
-      return c.json({ error: 'linkedIntentNonce is required for handoff threads', errorCode: 'MISSING_THREAD_NONCE' }, 400)
+    if (kind === 'handoff' && !linkedIntentNonce && (status ?? 'open') !== 'blocked') {
+      return c.json({ error: 'linkedIntentNonce is required for non-blocked handoff threads', errorCode: 'MISSING_THREAD_NONCE' }, 400)
     }
     if (kind === 'internal' && linkedIntentNonce) {
       return c.json({ error: 'Internal threads cannot link directly to a Beam trace', errorCode: 'INTERNAL_THREAD_CANNOT_LINK_TRACE' }, 400)
@@ -1145,6 +1894,123 @@ export function workspacesRouter(db: Database): Hono {
     return c.json({
       ...buildWorkspacePolicyEnvelope(db, workspace),
       updated: true,
+    })
+  })
+
+  router.get('/:slug/timeline', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const limit = Math.max(
+      1,
+      Math.min(
+        WORKSPACE_TIMELINE_LIMIT_MAX,
+        Number.parseInt(c.req.query('limit') ?? String(WORKSPACE_TIMELINE_LIMIT_DEFAULT), 10) || WORKSPACE_TIMELINE_LIMIT_DEFAULT,
+      ),
+    )
+    const entries = listWorkspaceTimelineEntries(db, workspace, limit)
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      entries,
+      total: entries.length,
+    })
+  })
+
+  router.get('/:slug/digest', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const days = Math.max(1, Number.parseInt(c.req.query('days') ?? String(WORKSPACE_DIGEST_DEFAULT_DAYS), 10) || WORKSPACE_DIGEST_DEFAULT_DAYS)
+    const format = (c.req.query('format') ?? 'json').trim().toLowerCase()
+    if (format !== 'json' && format !== 'markdown') {
+      return c.json({ error: 'format must be json or markdown', errorCode: 'INVALID_EXPORT_FORMAT' }, 400)
+    }
+
+    const digest = buildWorkspaceDigestPayload(db, workspace, days)
+    c.header('Cache-Control', 'no-store')
+
+    if (format === 'markdown') {
+      const timestamp = new Date().toISOString().replaceAll(':', '-')
+      c.header('Content-Type', 'text/markdown; charset=utf-8')
+      c.header('Content-Disposition', `attachment; filename="beam-workspace-digest-${workspace.slug}-${timestamp}.md"`)
+      return c.body(digest.markdown)
+    }
+
+    return c.json(digest)
+  })
+
+  router.post('/:slug/digest/deliver', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const days = Math.max(1, Number.parseInt(String(body.days ?? WORKSPACE_DIGEST_DEFAULT_DAYS), 10) || WORKSPACE_DIGEST_DEFAULT_DAYS)
+    const requestedEmail = normalizeOptionalString(body.email)
+    const targetEmail = requestedEmail ?? auth.session.email
+
+    if (requestedEmail && auth.session.role !== 'admin' && requestedEmail !== auth.session.email) {
+      return c.json({ error: 'Only admins can deliver digests to a different mailbox', errorCode: 'FORBIDDEN' }, 403)
+    }
+
+    const digest = buildWorkspaceDigestPayload(db, workspace, days)
+    const delivered = await sendOperatorDigestEmail({
+      email: targetEmail,
+      subject: `Beam workspace digest · ${workspace.name} · ${new Date().toISOString().slice(0, 10)}`,
+      markdown: digest.markdown,
+    })
+
+    if (!delivered) {
+      return c.json({ error: 'Operator email delivery is not configured', errorCode: 'EMAIL_DELIVERY_UNAVAILABLE' }, 503)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_digest.delivered',
+      actor: auth.session.email,
+      target: `${workspace.slug}:digest`,
+      details: {
+        role: auth.session.role,
+        workspace: workspace.slug,
+        days,
+        deliveredTo: targetEmail,
+        actionItems: digest.summary.actionItems,
+        escalations: digest.summary.escalations,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ok: true,
+      email: targetEmail,
+      deliveredAt: new Date().toISOString(),
     })
   })
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -166,11 +166,14 @@ export type WorkspacePrincipalType = 'human' | 'agent' | 'service' | 'partner'
 export type WorkspaceIdentityBindingType = 'agent' | 'service' | 'partner'
 export type WorkspaceIdentityBindingStatus = 'active' | 'paused'
 export type WorkspacePartnerChannelStatus = 'active' | 'trial' | 'blocked'
+export type WorkspacePartnerChannelHealth = 'healthy' | 'watch' | 'critical'
 export type WorkspaceThreadKind = 'internal' | 'handoff'
 export type WorkspaceThreadStatus = 'open' | 'blocked' | 'closed'
 export type WorkspaceThreadParticipantRole = 'owner' | 'participant' | 'observer' | 'approver'
 export type WorkspacePolicyDefaultExternalInitiation = 'deny' | 'binding'
 export type WorkspacePolicyRuleExternalInitiation = 'inherit' | 'allow' | 'deny'
+export type WorkspaceIdentityLifecycleStatus = 'healthy' | 'stale' | 'paused' | 'missing' | 'revoked' | 'unowned'
+export type WorkspaceTimelineEventKind = 'workspace' | 'policy' | 'identity' | 'partner_channel' | 'thread' | 'digest'
 
 export interface WorkspaceRow {
   id: number

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -150,6 +150,13 @@ test('workspace identity bindings can be created, listed, and updated through th
         id: number
         owner: string | null
         canInitiateExternal: boolean
+        lifecycleStatus: string
+        ownershipState: string
+        runtime: {
+          mode: string
+          connector: string | null
+        }
+        lastSeenAgeHours: number | null
         identity: {
           existsLocally: boolean
           displayName: string | null
@@ -161,6 +168,11 @@ test('workspace identity bindings can be created, listed, and updated through th
     }
     assert.equal(localBindingBody.binding.owner, 'ops@example.com')
     assert.equal(localBindingBody.binding.canInitiateExternal, true)
+    assert.equal(localBindingBody.binding.lifecycleStatus, 'healthy')
+    assert.equal(localBindingBody.binding.ownershipState, 'owned')
+    assert.equal(localBindingBody.binding.runtime.mode, 'runtime-backed')
+    assert.equal(localBindingBody.binding.runtime.connector, 'codex')
+    assert.equal(typeof localBindingBody.binding.lastSeenAgeHours, 'number')
     assert.equal(localBindingBody.binding.identity.existsLocally, true)
     assert.equal(localBindingBody.binding.identity.displayName, 'Ops Bot')
     assert.equal(localBindingBody.binding.identity.keyState?.active?.beamId, 'ops-bot@beam.directory')
@@ -530,6 +542,43 @@ test('workspace threads model internal discussion and external handoffs in one t
     assert.equal(internalThreadBody.thread.kind, 'internal')
     assert.equal(internalThreadBody.thread.trace, null)
 
+    const blockedHandoffThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/threads', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Await partner approval route',
+        summary: 'Blocked until the runtime sends the real handoff.',
+        owner: 'ops@example.com',
+        workflowType: 'quote.approval',
+        status: 'blocked',
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: localBinding.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'finance@northwind.beam.directory',
+            principalType: 'partner',
+            beamId: 'finance@northwind.beam.directory',
+            workspaceBindingId: partnerBinding.binding.id,
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(blockedHandoffThreadResponse.status, 201)
+    const blockedHandoffThreadBody = await blockedHandoffThreadResponse.json() as {
+      thread: { kind: string; status: string; linkedIntentNonce: string | null; trace: null }
+    }
+    assert.equal(blockedHandoffThreadBody.thread.kind, 'handoff')
+    assert.equal(blockedHandoffThreadBody.thread.status, 'blocked')
+    assert.equal(blockedHandoffThreadBody.thread.linkedIntentNonce, null)
+    assert.equal(blockedHandoffThreadBody.thread.trace, null)
+
     const handoffThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-ops/threads', {
       method: 'POST',
       headers: adminHeaders,
@@ -577,8 +626,8 @@ test('workspace threads model internal discussion and external handoffs in one t
       total: number
       threads: Array<{ kind: string; linkedIntentNonce: string | null; participantCount: number }>
     }
-    assert.equal(listBody.total, 2)
-    const listedHandoffThread = listBody.threads.find((entry) => entry.kind === 'handoff')
+    assert.equal(listBody.total, 3)
+    const listedHandoffThread = listBody.threads.find((entry) => entry.kind === 'handoff' && entry.linkedIntentNonce === 'nonce-thread-handoff')
     const listedInternalThread = listBody.threads.find((entry) => entry.kind === 'internal')
     assert.equal(listedHandoffThread?.linkedIntentNonce, 'nonce-thread-handoff')
     assert.equal(listedHandoffThread?.participantCount, 2)
@@ -597,6 +646,182 @@ test('workspace threads model internal discussion and external handoffs in one t
     assert.equal(detailBody.thread.trace?.fromBeamId, 'ops-bot@beam.directory')
     assert.equal(detailBody.thread.trace?.toBeamId, 'finance@northwind.beam.directory')
     assert.deepEqual(detailBody.participants.map((entry) => entry.principalType).sort(), ['agent', 'partner'])
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace partner channels, timeline, and digest expose operator-ready control-plane state', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAw2QJY0YH7e1L2+2VQ1bH4TqL6wCnC8n9v8m8z4vPsxM=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Acme Finance',
+        slug: 'acme-finance',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    const bindingResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex:operator',
+        policyProfile: 'finance-default',
+        canInitiateExternal: false,
+      }),
+    }))
+    const bindingBody = await bindingResponse.json() as { binding: { id: number } }
+
+    const channelResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/partner-channels', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        partnerBeamId: 'finance@northwind.beam.directory',
+        label: 'Northwind Finance',
+        owner: 'northwind@example.com',
+        status: 'trial',
+        notes: 'Trial until the first approval flow settles.',
+      }),
+    }))
+    assert.equal(channelResponse.status, 201)
+    const channelBody = await channelResponse.json() as {
+      channel: {
+        id: number
+        status: string
+        healthStatus: string
+      }
+    }
+    assert.equal(channelBody.channel.status, 'trial')
+    assert.equal(channelBody.channel.healthStatus, 'watch')
+
+    const channelPatchResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-finance/partner-channels/${channelBody.channel.id}`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        status: 'blocked',
+        notes: 'Blocked until manual approval policy is tightened.',
+      }),
+    }))
+    assert.equal(channelPatchResponse.status, 200)
+
+    const blockedThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/threads', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Invoice approval needs operator review',
+        summary: 'Waiting for approval policy before the runtime sends outward.',
+        owner: 'ops@example.com',
+        status: 'blocked',
+        workflowType: 'invoice.review',
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: bindingBody.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'finance@northwind.beam.directory',
+            principalType: 'partner',
+            beamId: 'finance@northwind.beam.directory',
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(blockedThreadResponse.status, 201)
+
+    const channelsListResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/partner-channels', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(channelsListResponse.status, 200)
+    const channelsListBody = await channelsListResponse.json() as {
+      total: number
+      channels: Array<{
+        status: string
+        healthStatus: string
+      }>
+    }
+    assert.equal(channelsListBody.total, 1)
+    assert.equal(channelsListBody.channels[0]?.status, 'blocked')
+    assert.equal(channelsListBody.channels[0]?.healthStatus, 'critical')
+
+    const timelineResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/timeline?limit=20', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(timelineResponse.status, 200)
+    const timelineBody = await timelineResponse.json() as {
+      total: number
+      entries: Array<{
+        kind: string
+        action: string
+      }>
+    }
+    assert.ok(timelineBody.total >= 4)
+    assert.ok(timelineBody.entries.some((entry) => entry.kind === 'partner_channel'))
+    assert.ok(timelineBody.entries.some((entry) => entry.kind === 'thread'))
+
+    const digestResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/digest', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(digestResponse.status, 200)
+    const digestBody = await digestResponse.json() as {
+      summary: {
+        actionItems: number
+        escalations: number
+      }
+      actionItems: Array<{
+        category: string
+      }>
+      markdown: string
+    }
+    assert.ok(digestBody.summary.actionItems >= 2)
+    assert.ok(digestBody.summary.escalations >= 1)
+    assert.ok(digestBody.actionItems.some((item) => item.category === 'partner_channel'))
+    assert.match(digestBody.markdown, /Beam workspace digest/i)
+
+    const digestDeliveryResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/digest/deliver', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    }))
+    assert.equal(digestDeliveryResponse.status, 503)
   } finally {
     db.close()
   }

--- a/reports/1.1.0-buyer-dry-run.md
+++ b/reports/1.1.0-buyer-dry-run.md
@@ -1,0 +1,35 @@
+# Beam 1.1.0 Buyer Dry Run
+
+## Context
+
+- run date: `2026-04-01`
+- generated at: `2026-04-01T10:34:35.451Z`
+- surface: workspace docs and operator-facing product copy
+
+## Result
+
+`PASS`
+
+## Path
+
+1. The docs home still points operators to Beam Workspaces from the main control-plane narrative.
+2. The Beam Workspaces guide describes the new control-plane model beyond simple identity bindings.
+3. The operator surface vocabulary matches the guide: partner channels, timeline, digest, and thread composer.
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-01",
+  "checks": {
+    "docsHome": true,
+    "workspaceGuide": true,
+    "dashboardSurface": true,
+    "partnerChannels": true,
+    "timeline": true,
+    "digest": true,
+    "threadComposer": true
+  }
+}
+```

--- a/reports/1.1.0-operator-digest.md
+++ b/reports/1.1.0-operator-digest.md
@@ -1,0 +1,61 @@
+# Beam 1.1.0 Operator Digest
+
+## Context
+
+- run date: `2026-04-01`
+- generated at: `2026-04-01T10:34:41.885Z`
+- environment: local workspace harness
+
+## Result
+
+`PASS`
+
+## Digest Summary
+
+- Workspace: `acme-finance`
+- Action items: `3`
+- Escalations: `2`
+- Partner channels: `1`
+- Open threads: `3`
+
+## Escalation Sample
+
+- Title: Northwind Finance partner channel needs follow-up
+- Severity: `critical`
+- Next action: Confirm whether to reopen the partner channel or keep it blocked.
+- Surface: /workspaces?workspace=acme-finance
+
+## Delivery Path
+
+- Status: `delivery_unavailable`
+- Note: Digest delivery is wired end to end, but the local harness intentionally has no SMTP or Resend configuration.
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-01",
+  "workspace": "acme-finance",
+  "actionItems": 3,
+  "escalations": 2,
+  "partnerChannels": 1,
+  "openThreads": 3,
+  "criticalItem": {
+    "id": "partner-1",
+    "category": "partner_channel",
+    "severity": "critical",
+    "title": "Northwind Finance partner channel needs follow-up",
+    "detail": "The channel is blocked and cannot be used for new partner-facing motion.",
+    "owner": "northwind@example.com",
+    "href": "/workspaces?workspace=acme-finance",
+    "nextAction": "Confirm whether to reopen the partner channel or keep it blocked."
+  },
+  "deliveryOutcome": {
+    "status": "delivery_unavailable",
+    "note": "Digest delivery is wired end to end, but the local harness intentionally has no SMTP or Resend configuration."
+  },
+  "timelineEntries": 9,
+  "relatedTimelineId": 11
+}
+```

--- a/reports/1.1.0-operator-dry-run.md
+++ b/reports/1.1.0-operator-dry-run.md
@@ -1,0 +1,84 @@
+# Beam 1.1.0 Operator Dry Run
+
+## Context
+
+- run date: `2026-04-01`
+- generated at: `2026-04-01T10:40:17.109Z`
+- environment: local workspace harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Approve the local runtime binding for external motion.
+2. Assign the blocked partner channel to the current operator.
+3. Create a second blocked handoff draft for the appeal path.
+4. Patch the workspace policy to cover both workflow variants.
+5. Re-open overview, identities, partner channels, thread detail, timeline, and digest.
+
+## Verification
+
+- Local binding external-ready: `true`
+- Partner channel owner: `ops@beam.local`
+- Blocked draft status: `blocked`
+- Linked trace: `/intents/workspace-control-failed`
+- Policy workflows: `2`
+- Timeline entries: `13`
+- Digest action items: `3`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-01",
+  "workspace": "acme-finance",
+  "localBinding": {
+    "id": 1,
+    "canInitiateExternal": true,
+    "lifecycleStatus": "healthy"
+  },
+  "partnerChannel": {
+    "id": 1,
+    "healthStatus": "critical",
+    "owner": "ops@beam.local"
+  },
+  "blockedThread": {
+    "id": 2,
+    "status": "blocked",
+    "traceHref": null
+  },
+  "linkedThread": {
+    "id": 3,
+    "status": "open",
+    "traceHref": "/intents/workspace-control-failed"
+  },
+  "summary": {
+    "totalIdentities": 2,
+    "activeIdentities": 2,
+    "localIdentities": 1,
+    "partnerIdentities": 1,
+    "externalReadyIdentities": 1,
+    "staleIdentities": 0,
+    "pendingApprovals": 0,
+    "blockedExternalMotion": 0,
+    "recentExternalHandoffs": 2
+  },
+  "digestSummary": {
+    "actionItems": 3,
+    "escalations": 3,
+    "partnerChannels": 1,
+    "openThreads": 4,
+    "staleIdentities": 0,
+    "blockedExternalMotion": 0
+  },
+  "policyWorkflows": [
+    "invoice.review",
+    "invoice.review.appeal"
+  ],
+  "threadCount": 4,
+  "timelineEntries": 13
+}
+```

--- a/reports/1.1.0-rc1-checklist.md
+++ b/reports/1.1.0-rc1-checklist.md
@@ -1,0 +1,47 @@
+# Beam 1.1.0 RC1 Checklist
+
+## Context
+
+- target: workspace control-plane release
+- status: `ready_for_cut`
+- branch: `codex/1-1-0-workspace-control-plane`
+- release tag: `v1.1.0` (planned)
+- updated: `2026-04-01`
+
+## Checklist
+
+- [x] buyer dry run passes with the new workspace surface (`reports/1.1.0-buyer-dry-run.md`)
+- [x] operator digest is recorded with the workspace digest and delivery path (`reports/1.1.0-operator-digest.md`)
+- [x] operator dry run exercises approval actions, partner ownership controls, thread composition, and linked traces (`reports/1.1.0-operator-dry-run.md`)
+- [x] recurring digest/escalation loop is repo-visible and reports `delivery_unavailable` when the local harness has no mail transport
+- [x] workspace policy approvals and binding actions are executable from the dashboard-backed API surface
+- [x] full repo verification passes on the branch candidate (`npm run build`, `npm test`, `npm run test:e2e`, `npm -C docs run build`)
+- [x] release notes draft exists (`reports/1.1.0-release-notes-draft.md`)
+- [x] changelog contains a `v1.1.0 (draft)` block
+- [x] go/no-go gates are defined and satisfied before tagging
+
+## Release Gates
+
+1. Full repo `npm run build`, `npm test`, `npm run test:e2e`, `npm -C docs run build`.
+2. Workspace buyer/operator dry runs and workspace digest are checked in under `reports/`.
+3. Binding approval, partner-channel ownership, policy updates, thread composition, timeline, and digest actions are exercised against the real admin API surface.
+4. Release notes and changelog are updated for `v1.1.0`.
+5. Tag-time release smoke remains owned by the existing release automation and is not a pre-tag blocker for this checklist.
+
+## Evidence
+
+- `reports/1.1.0-buyer-dry-run.md`
+- `reports/1.1.0-operator-digest.md`
+- `reports/1.1.0-operator-dry-run.md`
+
+## Go / No-Go
+
+`GO` for the pre-tag `v1.1.0-rc1` cut.
+
+Reasoning:
+
+- the workspace control-plane surface now includes executable approval actions, partner channel management, lifecycle signals, thread composition, timeline history, and digest generation,
+- the buyer, operator digest, and operator dry runs are all green and checked into the repo,
+- the full build/test/e2e/docs verification pass is green on the same branch candidate,
+- no new blockers appeared during the control-plane dry runs,
+- the remaining release smoke belongs to the normal tag/publish path rather than this pre-tag readiness gate.

--- a/reports/1.1.0-release-notes-draft.md
+++ b/reports/1.1.0-release-notes-draft.md
@@ -1,0 +1,33 @@
+# Beam 1.1.0 Release Notes
+
+Status: draft for `v1.1.0` as of `2026-04-01`
+
+## Summary
+
+Beam `1.1.0` turns Beam Workspaces from a foundational roster into an operator-ready control plane. Operators can now approve outbound motion at the binding layer, manage partner channels, compose internal and blocked handoff threads, review a unified timeline, and generate a recurring workspace digest from the same surface.
+
+## Highlights
+
+- the workspace dashboard now lets operators approve outbound motion, pause or resume bindings, review lifecycle status, and reconcile ownerless or stale identities without leaving the workspace view
+- partner channels now carry explicit owner, status, health, and last-trace context so partner-facing workflow risk is visible where the decision is made
+- the thread composer handles internal prep threads, blocked handoff drafts without a nonce, and linked handoff threads with direct Beam trace links
+- timeline and digest endpoints collapse policy updates, identity changes, partner-channel decisions, thread activity, and digest delivery into one control-plane history
+- recurring digest delivery now targets the operator mailbox and makes the local `delivery_unavailable` path explicit when SMTP or Resend is intentionally absent
+- repo-visible buyer, operator digest, and operator dry runs now back the `v1.1.0` cut instead of leaving the workspace story as a purely manual demo
+
+## Evidence
+
+- `reports/1.1.0-rc1-checklist.md`
+- `reports/1.1.0-buyer-dry-run.md`
+- `reports/1.1.0-operator-digest.md`
+- `reports/1.1.0-operator-dry-run.md`
+
+## Operational Notes
+
+- Blocked handoff drafts can now exist without a `linkedIntentNonce`; once a real Beam handoff exists, linked thread detail still points directly at the trace surface.
+- The local workspace digest run intentionally reports `delivery_unavailable` when mail transport is not configured; that is expected in the harness and proves the unhappy-path status is visible.
+- The operator dry run exercises the same admin APIs the dashboard uses for binding approval, partner ownership, policy updates, thread creation, timeline review, and digest inspection.
+
+## Compatibility
+
+No protocol version bump; Beam stays on `beam/1` with this workspace control-plane refinement.

--- a/scripts/workspace/buyer-dry-run.mjs
+++ b/scripts/workspace/buyer-dry-run.mjs
@@ -1,0 +1,73 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { formatDate, formatDateTime, optionalFlag, repoRoot, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+
+const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.1.0-buyer-dry-run.md'))
+
+function assertIncludes(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`)
+  }
+}
+
+async function main() {
+  const docsHome = await readFile(path.join(repoRoot, 'docs/index.md'), 'utf8')
+  const workspaceGuide = await readFile(path.join(repoRoot, 'docs/guide/beam-workspaces.md'), 'utf8')
+  const workspaceUi = await readFile(path.join(repoRoot, 'packages/dashboard/src/pages/WorkspacesPage.tsx'), 'utf8')
+
+  assertIncludes(docsHome, 'Beam Workspaces', 'docs home workspace entry')
+  assertIncludes(workspaceGuide, 'workspace_partner_channels', 'workspace guide partner channel model')
+  assertIncludes(workspaceGuide, '`GET /admin/workspaces/:slug/partner-channels`', 'partner channel route')
+  assertIncludes(workspaceGuide, '`GET /admin/workspaces/:slug/timeline`', 'timeline route')
+  assertIncludes(workspaceGuide, '`GET /admin/workspaces/:slug/digest`', 'digest route')
+  assertIncludes(workspaceGuide, 'blocked handoff draft', 'blocked handoff guidance')
+  assertIncludes(workspaceUi, 'Partner channels', 'workspace UI partner channels section')
+  assertIncludes(workspaceUi, 'Workspace digest', 'workspace UI digest section')
+  assertIncludes(workspaceUi, 'Workspace timeline', 'workspace UI timeline section')
+  assertIncludes(workspaceUi, 'Thread composer', 'workspace UI composer section')
+
+  const result = {
+    ok: true,
+    date: formatDate(),
+    checks: {
+      docsHome: true,
+      workspaceGuide: true,
+      dashboardSurface: true,
+      partnerChannels: true,
+      timeline: true,
+      digest: true,
+      threadComposer: true,
+    },
+  }
+
+  const markdown = `# Beam 1.1.0 Buyer Dry Run
+
+## Context
+
+- run date: \`${formatDate()}\`
+- generated at: \`${formatDateTime()}\`
+- surface: workspace docs and operator-facing product copy
+
+## Result
+
+\`PASS\`
+
+## Path
+
+1. The docs home still points operators to Beam Workspaces from the main control-plane narrative.
+2. The Beam Workspaces guide describes the new control-plane model beyond simple identity bindings.
+3. The operator surface vocabulary matches the guide: partner channels, timeline, digest, and thread composer.
+
+## Evidence
+
+${toJsonBlock(result)}
+`
+
+  await writeMarkdownReport(outputPath, markdown)
+  console.log(JSON.stringify({ ...result, report: outputPath }, null, 2))
+}
+
+main().catch((error) => {
+  console.error('[workspace:buyer-dry-run] failed:', error)
+  process.exitCode = 1
+})

--- a/scripts/workspace/operator-digest.mjs
+++ b/scripts/workspace/operator-digest.mjs
@@ -1,0 +1,129 @@
+import path from 'node:path'
+import { formatDate, formatDateTime, optionalFlag, requestJson, requestText, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { startWorkspaceHarness } from './shared.mjs'
+
+const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.1.0-operator-digest.md'))
+
+async function main() {
+  const { harness, token, workspaceSlug, failedNonce } = await startWorkspaceHarness()
+
+  try {
+    const headers = {
+      Authorization: `Bearer ${token}`,
+    }
+
+    const [digest, markdownExport, timeline] = await Promise.all([
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/digest?days=7`, {
+        headers,
+      }),
+      requestText(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/digest?days=7&format=markdown`, {
+        headers,
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/timeline?limit=20`, {
+        headers,
+      }),
+    ])
+
+    if (digest.summary.actionItems < 3) {
+      throw new Error(`Expected at least 3 workspace action items, found ${digest.summary.actionItems}`)
+    }
+
+    if (digest.summary.escalations < 1) {
+      throw new Error(`Expected at least 1 workspace escalation, found ${digest.summary.escalations}`)
+    }
+
+    if (!markdownExport.text.includes('## Action Items')) {
+      throw new Error('Workspace digest markdown is missing the action item section')
+    }
+
+    let deliveryOutcome = {
+      status: 'delivered',
+      note: `Workspace digest sent to ${harness.adminEmail}.`,
+    }
+    try {
+      await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/digest/deliver`, {
+        method: 'POST',
+        headers: {
+          ...headers,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ days: 7 }),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      deliveryOutcome = message.includes('EMAIL_DELIVERY_UNAVAILABLE')
+        ? {
+            status: 'delivery_unavailable',
+            note: 'Digest delivery is wired end to end, but the local harness intentionally has no SMTP or Resend configuration.',
+          }
+        : {
+            status: 'delivery_failed',
+            note: message,
+          }
+    }
+
+    const criticalItem = digest.escalations[0] ?? digest.actionItems.find((item) => item.severity === 'critical') ?? null
+    const relatedTimeline = timeline.entries.find((entry) => entry.traceHref?.includes(failedNonce) || entry.href?.includes(encodeURIComponent(workspaceSlug)))
+
+    const result = {
+      ok: true,
+      date: formatDate(),
+      workspace: digest.workspace.slug,
+      actionItems: digest.summary.actionItems,
+      escalations: digest.summary.escalations,
+      partnerChannels: digest.summary.partnerChannels,
+      openThreads: digest.summary.openThreads,
+      criticalItem,
+      deliveryOutcome,
+      timelineEntries: timeline.total,
+      relatedTimelineId: relatedTimeline?.id ?? null,
+    }
+
+    const markdown = `# Beam 1.1.0 Operator Digest
+
+## Context
+
+- run date: \`${formatDate()}\`
+- generated at: \`${formatDateTime()}\`
+- environment: local workspace harness
+
+## Result
+
+\`PASS\`
+
+## Digest Summary
+
+- Workspace: \`${digest.workspace.slug}\`
+- Action items: \`${digest.summary.actionItems}\`
+- Escalations: \`${digest.summary.escalations}\`
+- Partner channels: \`${digest.summary.partnerChannels}\`
+- Open threads: \`${digest.summary.openThreads}\`
+
+## Escalation Sample
+
+- Title: ${criticalItem?.title ?? 'n/a'}
+- Severity: \`${criticalItem?.severity ?? 'n/a'}\`
+- Next action: ${criticalItem?.nextAction ?? 'n/a'}
+- Surface: ${criticalItem?.href ?? 'n/a'}
+
+## Delivery Path
+
+- Status: \`${deliveryOutcome.status}\`
+- Note: ${deliveryOutcome.note}
+
+## Evidence
+
+${toJsonBlock(result)}
+`
+
+    await writeMarkdownReport(outputPath, markdown)
+    console.log(JSON.stringify({ ...result, report: outputPath }, null, 2))
+  } finally {
+    await harness.cleanup()
+  }
+}
+
+main().catch((error) => {
+  console.error('[workspace:digest] failed:', error)
+  process.exitCode = 1
+})

--- a/scripts/workspace/operator-dry-run.mjs
+++ b/scripts/workspace/operator-dry-run.mjs
@@ -1,0 +1,230 @@
+import path from 'node:path'
+import { formatDate, formatDateTime, optionalFlag, requestJson, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { startWorkspaceHarness } from './shared.mjs'
+
+const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.1.0-operator-dry-run.md'))
+
+async function main() {
+  const {
+    harness,
+    token,
+    workspaceSlug,
+    workflowType,
+    failedNonce,
+    localBindingId,
+    partnerBindingId,
+    partnerChannelId,
+    blockedThreadId,
+    linkedThreadId,
+  } = await startWorkspaceHarness()
+
+  try {
+    const adminHeaders = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/identities/${localBindingId}`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        canInitiateExternal: true,
+        notes: 'Operator approved the runtime for external motion after checking the workflow rule.',
+      }),
+    })
+
+    await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/partner-channels/${partnerChannelId}`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        owner: harness.adminEmail,
+        notes: 'Operator assigned the partner channel to the current workspace owner for live follow-up.',
+      }),
+    })
+
+    await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Invoice appeal blocked draft',
+        summary: 'Escalated draft that stays blocked until the approver signs off.',
+        owner: harness.adminEmail,
+        status: 'blocked',
+        workflowType: `${workflowType}.appeal`,
+        participants: [
+          {
+            principalId: 'procurement@acme.beam.directory',
+            principalType: 'agent',
+            beamId: 'procurement@acme.beam.directory',
+            workspaceBindingId: localBindingId,
+            role: 'owner',
+          },
+          {
+            principalId: 'finance@northwind.beam.directory',
+            principalType: 'partner',
+            beamId: 'finance@northwind.beam.directory',
+            workspaceBindingId: partnerBindingId,
+            role: 'participant',
+          },
+        ],
+      }),
+    })
+
+    await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/policy`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        defaults: {
+          externalInitiation: 'binding',
+          allowedPartners: ['finance@northwind.beam.directory'],
+        },
+        workflowRules: [
+          {
+            workflowType,
+            requireApproval: true,
+            allowedPartners: ['finance@northwind.beam.directory'],
+            approvers: [harness.adminEmail],
+          },
+          {
+            workflowType: `${workflowType}.appeal`,
+            requireApproval: true,
+            allowedPartners: ['finance@northwind.beam.directory'],
+            approvers: [harness.adminEmail],
+          },
+        ],
+        metadata: {
+          notes: 'Operator verified both the baseline invoice review and the appeal path.',
+        },
+      }),
+    })
+
+    const [overview, identities, channels, threads, blockedThread, linkedThread, policy, timeline, digest] = await Promise.all([
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/overview`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/identities`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/partner-channels`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads/${blockedThreadId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads/${linkedThreadId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/policy`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/timeline?limit=40`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/digest?days=7`, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ])
+
+    const localBinding = identities.bindings.find((entry) => entry.id === localBindingId)
+    if (!localBinding || localBinding.canInitiateExternal !== true) {
+      throw new Error('Workspace operator dry run did not persist the binding approval action.')
+    }
+
+    const partnerChannel = channels.channels.find((entry) => entry.id === partnerChannelId)
+    if (!partnerChannel || partnerChannel.owner !== harness.adminEmail) {
+      throw new Error('Workspace operator dry run did not persist the partner channel owner assignment.')
+    }
+
+    if (!linkedThread.thread.trace?.href || !linkedThread.thread.trace.href.includes(failedNonce)) {
+      throw new Error('Workspace linked handoff thread detail is missing the Beam trace.')
+    }
+
+    if (policy.previews.workflows.length < 2) {
+      throw new Error('Workspace policy preview did not include the additional appeal workflow.')
+    }
+
+    if (timeline.total < 6) {
+      throw new Error(`Expected at least 6 workspace timeline entries, found ${timeline.total}`)
+    }
+
+    const result = {
+      ok: true,
+      date: formatDate(),
+      workspace: overview.workspace.slug,
+      localBinding: {
+        id: localBinding.id,
+        canInitiateExternal: localBinding.canInitiateExternal,
+        lifecycleStatus: localBinding.lifecycleStatus,
+      },
+      partnerChannel: {
+        id: partnerChannel.id,
+        healthStatus: partnerChannel.healthStatus,
+        owner: partnerChannel.owner,
+      },
+      blockedThread: {
+        id: blockedThread.thread.id,
+        status: blockedThread.thread.status,
+        traceHref: blockedThread.thread.trace?.href ?? null,
+      },
+      linkedThread: {
+        id: linkedThread.thread.id,
+        status: linkedThread.thread.status,
+        traceHref: linkedThread.thread.trace?.href ?? null,
+      },
+      summary: overview.summary,
+      digestSummary: digest.summary,
+      policyWorkflows: policy.previews.workflows.map((entry) => entry.workflowType),
+      threadCount: threads.total,
+      timelineEntries: timeline.total,
+    }
+
+    const markdown = `# Beam 1.1.0 Operator Dry Run
+
+## Context
+
+- run date: \`${formatDate()}\`
+- generated at: \`${formatDateTime()}\`
+- environment: local workspace harness
+
+## Result
+
+\`PASS\`
+
+## Scenario
+
+1. Approve the local runtime binding for external motion.
+2. Assign the blocked partner channel to the current operator.
+3. Create a second blocked handoff draft for the appeal path.
+4. Patch the workspace policy to cover both workflow variants.
+5. Re-open overview, identities, partner channels, thread detail, timeline, and digest.
+
+## Verification
+
+- Local binding external-ready: \`${localBinding.canInitiateExternal}\`
+- Partner channel owner: \`${partnerChannel.owner}\`
+- Blocked draft status: \`${blockedThread.thread.status}\`
+- Linked trace: \`${linkedThread.thread.trace?.href}\`
+- Policy workflows: \`${policy.previews.workflows.length}\`
+- Timeline entries: \`${timeline.total}\`
+- Digest action items: \`${digest.summary.actionItems}\`
+
+## Evidence
+
+${toJsonBlock(result)}
+`
+
+    await writeMarkdownReport(outputPath, markdown)
+    console.log(JSON.stringify({ ...result, report: outputPath }, null, 2))
+  } finally {
+    await harness.cleanup()
+  }
+}
+
+main().catch((error) => {
+  console.error('[workspace:operator-dry-run] failed:', error)
+  process.exitCode = 1
+})

--- a/scripts/workspace/shared.mjs
+++ b/scripts/workspace/shared.mjs
@@ -1,0 +1,211 @@
+import {
+  createAdminHeaders,
+  requestJson,
+  seedAckedIntent,
+  seedFailedIntent,
+  seedProofAgents,
+  startProductionHarness,
+} from '../production/shared.mjs'
+
+export function minutesAgoIso(minutesAgo) {
+  return new Date(Date.now() - minutesAgo * 60_000).toISOString()
+}
+
+export async function startWorkspaceHarness() {
+  const failedNonce = 'workspace-control-failed'
+  const ackedNonce = 'workspace-control-acked'
+  const workspaceSlug = 'acme-finance'
+  const workflowType = 'invoice.review'
+
+  const harness = await startProductionHarness({
+    withMessageBus: false,
+    seed: {
+      directory(db, directoryDbApi) {
+        seedProofAgents(db, directoryDbApi)
+        seedAckedIntent(db, directoryDbApi, ackedNonce, minutesAgoIso(140))
+        seedFailedIntent(db, directoryDbApi, failedNonce, minutesAgoIso(35))
+      },
+    },
+  })
+
+  const token = await harness.createAdminToken()
+  const adminHeaders = createAdminHeaders(token)
+
+  await requestJson(`${harness.directoryUrl}/admin/workspaces`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      name: 'Acme Finance',
+      slug: workspaceSlug,
+      description: 'Workspace control plane for Acme finance approvals and Northwind partner motion.',
+      externalHandoffsEnabled: true,
+    }),
+  })
+
+  const localBinding = await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/identities`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      beamId: 'procurement@acme.beam.directory',
+      bindingType: 'agent',
+      owner: harness.adminEmail,
+      runtimeType: 'codex:workspace',
+      policyProfile: 'finance-outbound',
+      canInitiateExternal: false,
+      notes: 'Manual review is required until the approval rule is in place.',
+    }),
+  })
+
+  const partnerBinding = await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/identities`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      beamId: 'finance@northwind.beam.directory',
+      bindingType: 'partner',
+      owner: 'northwind@example.com',
+      policyProfile: 'partner-finance',
+      notes: 'Primary partner finance receiver.',
+    }),
+  })
+
+  const partnerChannel = await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/partner-channels`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      partnerBeamId: 'finance@northwind.beam.directory',
+      label: 'Northwind Finance',
+      owner: 'northwind@example.com',
+      status: 'blocked',
+      notes: 'Blocked until operator approval is recorded for the workflow.',
+    }),
+  })
+
+  await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/partner-channels/${partnerChannel.channel.id}`, {
+    method: 'PATCH',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      lastIntentNonce: failedNonce,
+      lastFailureAt: minutesAgoIso(30),
+    }),
+  })
+
+  await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/policy`, {
+    method: 'PATCH',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      defaults: {
+        externalInitiation: 'binding',
+        allowedPartners: ['finance@northwind.beam.directory'],
+      },
+      workflowRules: [
+        {
+          workflowType,
+          requireApproval: true,
+          allowedPartners: ['finance@northwind.beam.directory'],
+          approvers: [harness.adminEmail],
+        },
+      ],
+      metadata: {
+        notes: 'Invoice review requires an operator approval before the runtime is allowed to send outward.',
+      },
+    }),
+  })
+
+  await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      kind: 'internal',
+      title: 'Collect invoice proof',
+      summary: 'Gather operator evidence before external motion.',
+      owner: harness.adminEmail,
+      participants: [
+        {
+          principalId: harness.adminEmail,
+          principalType: 'human',
+          displayName: 'Workspace operator',
+          role: 'owner',
+        },
+        {
+          principalId: 'procurement@acme.beam.directory',
+          principalType: 'agent',
+          beamId: 'procurement@acme.beam.directory',
+          workspaceBindingId: localBinding.binding.id,
+          role: 'participant',
+        },
+      ],
+    }),
+  })
+
+  const blockedThread = await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      kind: 'handoff',
+      title: 'Invoice approval draft',
+      summary: 'Blocked until the workflow approval is explicitly granted.',
+      owner: harness.adminEmail,
+      status: 'blocked',
+      workflowType,
+      participants: [
+        {
+          principalId: 'procurement@acme.beam.directory',
+          principalType: 'agent',
+          beamId: 'procurement@acme.beam.directory',
+          workspaceBindingId: localBinding.binding.id,
+          role: 'owner',
+        },
+        {
+          principalId: 'finance@northwind.beam.directory',
+          principalType: 'partner',
+          beamId: 'finance@northwind.beam.directory',
+          workspaceBindingId: partnerBinding.binding.id,
+          role: 'participant',
+        },
+      ],
+    }),
+  })
+
+  const linkedThread = await requestJson(`${harness.directoryUrl}/admin/workspaces/${workspaceSlug}/threads`, {
+    method: 'POST',
+    headers: adminHeaders,
+    body: JSON.stringify({
+      kind: 'handoff',
+      title: 'Invoice approval failure trace',
+      summary: 'Linked failure trace for operator review.',
+      owner: harness.adminEmail,
+      workflowType,
+      linkedIntentNonce: failedNonce,
+      participants: [
+        {
+          principalId: 'procurement@acme.beam.directory',
+          principalType: 'agent',
+          beamId: 'procurement@acme.beam.directory',
+          workspaceBindingId: localBinding.binding.id,
+          role: 'owner',
+        },
+        {
+          principalId: 'finance@northwind.beam.directory',
+          principalType: 'partner',
+          beamId: 'finance@northwind.beam.directory',
+          workspaceBindingId: partnerBinding.binding.id,
+          role: 'participant',
+        },
+      ],
+    }),
+  })
+
+  return {
+    harness,
+    token,
+    workspaceSlug,
+    workflowType,
+    failedNonce,
+    ackedNonce,
+    localBindingId: localBinding.binding.id,
+    partnerBindingId: partnerBinding.binding.id,
+    partnerChannelId: partnerChannel.channel.id,
+    blockedThreadId: blockedThread.thread.id,
+    linkedThreadId: linkedThread.thread.id,
+  }
+}


### PR DESCRIPTION
## Summary
- finish the workspace control plane surface across directory and dashboard APIs
- add workspace digest and dry-run scripts plus repo-visible 1.1.0 reports/checklist/notes
- document the final 1.1.0 workspace surface and draft changelog entry

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run workspace:buyer-dry-run
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run workspace:digest
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run workspace:operator-dry-run

Closes #121
Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #128