### PR TITLE
Prepare 1.1.0 release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.1.0 (draft)
+## v1.1.0 (2026-04-01)
 
 ### Workspace Control Plane
 - expose workspace partner channels with health states and partner-channel ownership controls

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -4,7 +4,7 @@ Beam CLI covers identity setup, lookup, search, natural-language messaging, stru
 
 ## Compatibility contract
 
-`beam-protocol-cli` 0.6 targets `beam/1`.
+`beam-protocol-cli` 1.1 targets `beam/1`.
 
 - CLI requests stay within the same protocol family as the directory and SDKs
 - new optional fields can appear in JSON output without a major version bump

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-04-01T19:00:00.000Z",
   "release": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-04-01T19:00:00.000Z"

--- a/docs/api/typescript.md
+++ b/docs/api/typescript.md
@@ -4,7 +4,7 @@
 
 ## Compatibility contract
 
-`beam-protocol-sdk` 0.6 targets `beam/1`.
+`beam-protocol-sdk` 1.1 targets `beam/1`.
 
 - additive request and response fields are allowed
 - the SDK tolerates unknown fields in current frame validation and directory responses

--- a/docs/guide/compatibility.md
+++ b/docs/guide/compatibility.md
@@ -55,9 +55,9 @@ Within `beam/1`, the signed content for frames is fixed. If you need a different
 
 ### 6. CLI and SDK releases must track server compatibility explicitly
 
-- `beam-protocol-cli 0.6.x` targets `beam/1`
-- `beam-protocol-sdk 0.6.x` targets `beam/1`
-- `beam-directory 0.6.x` targets `beam/1`
+- `beam-protocol-cli 1.1.x` targets `beam/1`
+- `beam-protocol-sdk 1.1.x` targets `beam/1`
+- `beam-directory 1.1.x` targets `beam/1`
 
 Feature additions may land in minor releases, but protocol compatibility must remain intact.
 
@@ -75,7 +75,7 @@ If any answer is "no", you are not making a minor change anymore.
 
 ## Fixtures and Tests
 
-Beam 0.6 ships two compatibility fixture layers under [`spec/fixtures/compatibility`](https://github.com/Beam-directory/beam-protocol/tree/main/spec/fixtures/compatibility):
+Beam 1.1 ships two compatibility fixture layers under [`spec/fixtures/compatibility`](https://github.com/Beam-directory/beam-protocol/tree/main/spec/fixtures/compatibility):
 
 - parser fixtures in the root folder for additive decode behavior such as unknown-field tolerance and legacy `params`
 - archived signed release fixtures in [`spec/fixtures/compatibility/releases`](https://github.com/Beam-directory/beam-protocol/tree/main/spec/fixtures/compatibility/releases) for `v0.6.0` and `v0.6.1`

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol-docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "vitepress": "1.6.4"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.0.0",
+        "beam-protocol-sdk": "^1.1.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.0.0"
+        "beam-protocol-sdk": "^1.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.0.0",
+    "beam-protocol-sdk": "^1.1.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/create-beam-agent/src/index.ts
+++ b/packages/create-beam-agent/src/index.ts
@@ -12,7 +12,7 @@ const valid = (value: string) => /^[a-z0-9_-]+$/.test(value)
 function renderPackageJson(name: string): string {
   return JSON.stringify({
     name,
-    version: '0.8.0',
+    version: '1.1.0',
     private: true,
     type: 'module',
     scripts: {
@@ -21,7 +21,7 @@ function renderPackageJson(name: string): string {
       start: 'node dist/index.js'
     },
     dependencies: {
-      'beam-protocol-sdk': '^0.8.0'
+      'beam-protocol-sdk': '^1.1.0'
     },
     devDependencies: {
       '@types/node': '^20.11.0',

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.0.0"
+    "beam-protocol-sdk": "^1.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",

--- a/reports/1.1.0-release-notes-draft.md
+++ b/reports/1.1.0-release-notes-draft.md
@@ -1,6 +1,6 @@
 # Beam 1.1.0 Release Notes
 
-Status: draft for `v1.1.0` as of `2026-04-01`
+Status: prepared for `v1.1.0` on `2026-04-01`
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- bump Beam packages and workspace lockfiles from 1.0.0 to 1.1.0
- update release-facing docs and the 1.1.0 notes/changelog wording for the real cut
- fix the create-beam-agent scaffold to generate 1.1.x SDK references

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build