### PR TITLE
Add workspace handoff dispatch flow

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -29,6 +29,7 @@ The workspace foundation now adds these records to the directory:
   - the policy document for external initiation and approval rules
 
 The current operator-facing surface now covers workspace creation, identity bindings, lifecycle state, partner channels, thread composition, timeline history, digest delivery, and policy previews.
+It also supports direct operator dispatch: a blocked handoff thread can now be approved and sent as a real Beam message from the workspace surface, without waiting for a separate runtime UI.
 
 ## Why Beam Needs This
 
@@ -56,6 +57,7 @@ The first routes are all admin-authenticated and now include the controls requir
 - `GET /admin/workspaces/:slug/threads`
 - `GET /admin/workspaces/:slug/threads/:id`
 - `POST /admin/workspaces/:slug/threads`
+- `POST /admin/workspaces/:slug/threads/:id/dispatch`
 - `GET /admin/workspaces/:slug/policy`
 - `PATCH /admin/workspaces/:slug/policy`
 - `GET /admin/workspaces/:slug/partner-channels`
@@ -178,6 +180,19 @@ Blocked handoff drafts are valid without a `linkedIntentNonce`. This is the cont
 }
 ```
 
+### Dispatch a blocked handoff thread through Beam
+
+This is the approval-path action. The workspace thread remains the operator record, but Beam generates the real cross-instance trace and links it back to the thread.
+
+```json
+{
+  "message": "Please confirm whether this approval lane is ready for the next purchase review.",
+  "language": "en"
+}
+```
+
+The dispatch route currently sends a real `conversation.message` Beam intent with workspace, thread, partner-channel, and approval context attached under `payload.context`.
+
 ### Create a partner channel
 
 ```json
@@ -256,8 +271,9 @@ That is why Workspaces start as a control-plane surface first.
 The dashboard now surfaces:
 
 1. workspace overview metrics for stale identities, manual review, blocked outbound motion, and the digest queue with overdue action items
-2. internal and external workspace threads on one page, covering blocked handoff drafts, linked handoff threads with trace links, and policy-driven workflows
+2. internal and external workspace threads on one page, covering blocked handoff drafts, direct `approve and send` actions, linked handoff threads with trace links, and policy-driven workflows
 3. partner channel health plus partner-channel ownership controls that can trial, unblock, or escalate a partner relationship
+4. runtime-backed identity visibility that now distinguishes live WebSocket presence, HTTP endpoints, and effective delivery mode for each local binding
 4. identity lifecycle cards showing `lastSeenAgeHours`, ownership state, and controls for pausing or toggling outbound permission
 5. the timeline drawer that collapses partner, policy, identity, thread, and digest events so the operator sees a unified audit trail
 6. the digest delivery panel that bottles action items, escalations, and summary stats and can deliver markdown to the operator mailbox

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -148,6 +148,9 @@ export interface WorkspaceIdentityBinding {
     mode: 'runtime-backed' | 'service' | 'partner' | 'manual'
     connector: string | null
     label: string | null
+    connected: boolean
+    httpEndpoint: string | null
+    deliveryMode: 'websocket' | 'http' | 'hybrid' | 'unavailable' | null
   }
   identity: {
     existsLocally: boolean
@@ -374,6 +377,22 @@ export interface WorkspaceThreadDetailResponse {
   workspace: WorkspaceRecord
   thread: WorkspaceThread
   participants: WorkspaceThreadParticipant[]
+}
+
+export interface WorkspaceThreadDispatchInput {
+  message?: string | null
+  language?: string | null
+}
+
+export interface WorkspaceThreadDispatchResponse extends WorkspaceThreadDetailResponse {
+  partnerChannel: WorkspacePartnerChannel | null
+  dispatch: {
+    nonce: string
+    success: boolean
+    error: string | null
+    errorCode: string | null
+    traceHref: string | null
+  }
 }
 
 export interface WorkspacePolicyBindingRule {
@@ -1767,6 +1786,10 @@ export const directoryApi = {
     body: JSON.stringify(input),
   }, { admin: true }),
   getWorkspaceThread: (slug: string, id: number) => request<WorkspaceThreadDetailResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads/${id}`, undefined, { admin: true }),
+  dispatchWorkspaceThread: (slug: string, id: number, input: WorkspaceThreadDispatchInput) => request<WorkspaceThreadDispatchResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/threads/${id}/dispatch`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   getWorkspacePolicy: (slug: string) => request<WorkspacePolicyResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, undefined, { admin: true }),
   updateWorkspacePolicy: (slug: string, input: WorkspacePolicyPatchInput) => request<WorkspacePolicyResponse & { updated: boolean }>(`/admin/workspaces/${encodeURIComponent(slug)}/policy`, {
     method: 'PATCH',

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -182,10 +182,31 @@ function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
 }
 
 function renderBindingRuntime(binding: WorkspaceIdentityBinding): string {
-  if (binding.runtime.label) {
-    return binding.runtime.connector ? `${binding.runtime.connector} · ${binding.runtime.label}` : binding.runtime.label
+  const label = binding.runtime.label
+    ? (binding.runtime.connector ? `${binding.runtime.connector} · ${binding.runtime.label}` : binding.runtime.label)
+    : binding.runtime.mode
+
+  if (binding.runtime.deliveryMode) {
+    return `${label} · ${binding.runtime.deliveryMode}`
   }
-  return binding.runtime.mode
+
+  return label
+}
+
+function renderBindingTransport(binding: WorkspaceIdentityBinding): string {
+  if (binding.runtime.connected && binding.runtime.httpEndpoint) {
+    return 'WebSocket live · HTTP endpoint configured'
+  }
+  if (binding.runtime.connected) {
+    return 'WebSocket live'
+  }
+  if (binding.runtime.httpEndpoint) {
+    return 'HTTP endpoint configured'
+  }
+  if (binding.bindingType === 'partner') {
+    return 'Partner-side delivery managed externally'
+  }
+  return 'No live transport currently visible'
 }
 
 function renderChannelMeta(channel: WorkspacePartnerChannel): string {
@@ -240,6 +261,8 @@ export default function WorkspacesPage() {
     kind: 'internal' as WorkspaceThreadKind,
     title: '',
     summary: '',
+    message: '',
+    language: 'en',
     owner: '',
     workflowType: '',
     localBindingId: '',
@@ -525,8 +548,7 @@ export default function WorkspacesPage() {
     }, `${channel.label || channel.partnerBeamId} moved to ${status}.`)
   }
 
-  async function handleThreadComposerSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
+  async function handleThreadComposerSubmit(mode: 'create' | 'dispatch') {
     if (!selectedWorkspace || !threadForm.title.trim()) return
 
     const localBinding = localBindings.find((binding) => binding.id === Number.parseInt(threadForm.localBindingId, 10))
@@ -572,23 +594,51 @@ export default function WorkspacesPage() {
       })
     }
 
-    await runAction('thread-composer', async () => {
+    const linkedIntentNonce = threadForm.linkedIntentNonce.trim()
+    const shouldDispatch = mode === 'dispatch' && threadForm.kind === 'handoff' && linkedIntentNonce.length === 0
+    const dispatchMessage = threadForm.message.trim() || threadForm.summary.trim() || threadForm.title.trim()
+    let createdThreadId: number | null = null
+
+    try {
+      setActionBusy(shouldDispatch ? 'thread-composer-dispatch' : 'thread-composer-create')
+      setNotice(null)
+      setError(null)
+
       const response = await directoryApi.createWorkspaceThread(selectedWorkspace.slug, {
         kind: threadForm.kind,
         title: threadForm.title.trim(),
         summary: threadForm.summary.trim() || null,
         owner: threadForm.owner.trim() || null,
         workflowType: threadForm.workflowType.trim() || null,
-        linkedIntentNonce: threadForm.linkedIntentNonce.trim() || null,
-        status: threadForm.kind === 'handoff' && !threadForm.linkedIntentNonce.trim() ? 'blocked' : 'open',
+        linkedIntentNonce: linkedIntentNonce || null,
+        status: threadForm.kind === 'handoff' && !linkedIntentNonce ? 'blocked' : 'open',
         participants,
       })
 
+      createdThreadId = response.thread.id
+      let activeThreadId = response.thread.id
+      let noticeMessage = 'Workspace thread created.'
+      if (shouldDispatch) {
+        const dispatchResponse = await directoryApi.dispatchWorkspaceThread(selectedWorkspace.slug, response.thread.id, {
+          message: dispatchMessage,
+          language: threadForm.language.trim() || null,
+        })
+        activeThreadId = dispatchResponse.thread.id
+        noticeMessage = dispatchResponse.dispatch.success
+          ? 'Workspace handoff dispatched through Beam.'
+          : `Workspace handoff dispatched with a failed Beam response${dispatchResponse.dispatch.errorCode ? ` (${dispatchResponse.dispatch.errorCode})` : ''}.`
+      } else if (mode === 'dispatch' && linkedIntentNonce) {
+        noticeMessage = 'Workspace thread linked to an existing Beam trace.'
+      }
+
       await loadWorkspaceSurface(selectedWorkspace.slug)
+      await loadThreadDetail(selectedWorkspace.slug, activeThreadId)
       setThreadForm({
         kind: 'internal',
         title: '',
         summary: '',
+        message: '',
+        language: 'en',
         owner: '',
         workflowType: '',
         localBindingId: '',
@@ -598,9 +648,48 @@ export default function WorkspacesPage() {
 
       const next = new URLSearchParams(searchParams)
       next.set('workspace', selectedWorkspace.slug)
-      next.set('thread', String(response.thread.id))
+      next.set('thread', String(activeThreadId))
       setSearchParams(next, { replace: true })
-    }, 'Workspace thread created.')
+      setNotice(noticeMessage)
+    } catch (err) {
+      if (createdThreadId) {
+        try {
+          await loadWorkspaceSurface(selectedWorkspace.slug)
+          await loadThreadDetail(selectedWorkspace.slug, createdThreadId)
+        } catch {
+          // Ignore secondary refresh errors and surface the original failure below.
+        }
+      }
+      setError(err instanceof ApiError ? err.message : 'Workspace thread action failed')
+    } finally {
+      setActionBusy(null)
+    }
+  }
+
+  async function handleThreadDispatch(thread: WorkspaceThread) {
+    if (!selectedWorkspace) return
+
+    try {
+      setActionBusy(`thread-dispatch-${thread.id}`)
+      setNotice(null)
+      setError(null)
+
+      const response = await directoryApi.dispatchWorkspaceThread(selectedWorkspace.slug, thread.id, {
+        message: thread.summary || thread.title,
+        language: 'en',
+      })
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      await loadThreadDetail(selectedWorkspace.slug, thread.id)
+      setNotice(
+        response.dispatch.success
+          ? 'Workspace handoff dispatched through Beam.'
+          : `Workspace handoff dispatched with a failed Beam response${response.dispatch.errorCode ? ` (${response.dispatch.errorCode})` : ''}.`,
+      )
+    } catch (err) {
+      setError(err instanceof ApiError ? err.message : 'Workspace handoff dispatch failed')
+    } finally {
+      setActionBusy(null)
+    }
   }
 
   async function handleDeliverDigest() {
@@ -807,6 +896,8 @@ export default function WorkspacesPage() {
                         <div>{renderBindingRuntime(binding)}</div>
                         <div>{binding.identity.lastSeen ? `Last seen ${formatRelativeTime(binding.identity.lastSeen)}` : 'No heartbeat recorded'}</div>
                         <div>{binding.canInitiateExternal ? 'Can initiate external' : 'Manual review required'}</div>
+                        <div>{renderBindingTransport(binding)}</div>
+                        <div>{binding.identity.capabilities.length > 0 ? `${binding.identity.capabilities.length} capabilities declared` : 'No capabilities declared'}</div>
                       </div>
 
                       {binding.notes ? (
@@ -959,20 +1050,26 @@ export default function WorkspacesPage() {
                 <div>
                   <div className="panel-title">Thread composer</div>
                   <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                    Draft internal coordination threads or blocked handoff threads before a runtime sends the real Beam message.
+                    Create internal coordination threads or dispatch a real cross-instance Beam handoff from the workspace control plane.
                   </p>
                 </div>
-                <StatusPill label={threadForm.kind === 'handoff' ? 'Handoff draft' : 'Internal thread'} tone={threadForm.kind === 'handoff' ? 'warning' : 'default'} />
+                <StatusPill label={threadForm.kind === 'handoff' ? 'Beam handoff' : 'Internal thread'} tone={threadForm.kind === 'handoff' ? 'warning' : 'default'} />
               </div>
 
-              <form className="mt-4 grid gap-3 md:grid-cols-2" onSubmit={(event) => { void handleThreadComposerSubmit(event) }}>
+              <form
+                className="mt-4 grid gap-3 md:grid-cols-2"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void handleThreadComposerSubmit('create')
+                }}
+              >
                 <select className="input-field" value={threadForm.kind} onChange={(event) => setThreadForm((current) => ({ ...current, kind: event.target.value as WorkspaceThreadKind }))}>
                   <option value="internal">internal</option>
                   <option value="handoff">handoff</option>
                 </select>
                 <input className="input-field" placeholder="Owner email" value={threadForm.owner} onChange={(event) => setThreadForm((current) => ({ ...current, owner: event.target.value }))} />
                 <input className="input-field md:col-span-2" placeholder="Thread title" value={threadForm.title} onChange={(event) => setThreadForm((current) => ({ ...current, title: event.target.value }))} />
-                <textarea className="input-field md:col-span-2 min-h-24" placeholder="Summary or operator brief" value={threadForm.summary} onChange={(event) => setThreadForm((current) => ({ ...current, summary: event.target.value }))} />
+                <textarea className="input-field md:col-span-2 min-h-24" placeholder={threadForm.kind === 'handoff' ? 'Operator brief or traceable summary' : 'Summary or operator brief'} value={threadForm.summary} onChange={(event) => setThreadForm((current) => ({ ...current, summary: event.target.value }))} />
                 <select className="input-field" value={threadForm.localBindingId} onChange={(event) => setThreadForm((current) => ({ ...current, localBindingId: event.target.value }))}>
                   <option value="">Select local identity</option>
                   {localBindings.map((binding) => (
@@ -992,15 +1089,31 @@ export default function WorkspacesPage() {
                         </option>
                       ))}
                     </select>
+                    <input className="input-field" placeholder="Language hint (default en)" value={threadForm.language} onChange={(event) => setThreadForm((current) => ({ ...current, language: event.target.value }))} />
+                    <textarea className="input-field md:col-span-2 min-h-24" placeholder="Message to send over Beam (defaults to summary/title if blank)" value={threadForm.message} onChange={(event) => setThreadForm((current) => ({ ...current, message: event.target.value }))} />
                     <input className="input-field" placeholder="Linked intent nonce (optional if still blocked)" value={threadForm.linkedIntentNonce} onChange={(event) => setThreadForm((current) => ({ ...current, linkedIntentNonce: event.target.value }))} />
                   </>
                 ) : null}
                 <div className="md:col-span-2 flex flex-wrap gap-2">
-                  <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white" type="submit" disabled={actionBusy === 'thread-composer'}>
-                    {actionBusy === 'thread-composer' ? 'Creating…' : 'Create thread'}
+                  <button className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white" type="submit" disabled={actionBusy === 'thread-composer-create' || actionBusy === 'thread-composer-dispatch'}>
+                    {actionBusy === 'thread-composer-create' ? 'Creating…' : 'Create thread'}
                   </button>
+                  {threadForm.kind === 'handoff' ? (
+                    <button
+                      className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      type="button"
+                      disabled={actionBusy === 'thread-composer-create' || actionBusy === 'thread-composer-dispatch' || !threadForm.partnerChannelId || !threadForm.localBindingId}
+                      onClick={() => { void handleThreadComposerSubmit('dispatch') }}
+                    >
+                      {actionBusy === 'thread-composer-dispatch'
+                        ? 'Sending…'
+                        : threadForm.linkedIntentNonce.trim()
+                          ? 'Create and link'
+                          : 'Create and send'}
+                    </button>
+                  ) : null}
                   <div className="text-xs text-slate-500 dark:text-slate-400">
-                    Handoff drafts without a linked nonce are created as blocked threads until a runtime sends the real outbound message.
+                    Handoff threads can stay blocked for review, link to an existing nonce, or be sent directly from this workspace surface.
                   </div>
                 </div>
               </form>
@@ -1159,8 +1272,20 @@ export default function WorkspacesPage() {
                           </div>
                         </div>
                       ) : (
-                        <div className="mt-3 text-sm text-slate-500 dark:text-slate-400">
-                          This thread is still internal or blocked. Once a runtime sends the real outbound Beam handoff, attach the nonce here and the full trace will appear.
+                        <div className="mt-3 space-y-3">
+                          <div className="text-sm text-slate-500 dark:text-slate-400">
+                            This thread is still internal or blocked. You can now approve and send a blocked handoff directly from the workspace control plane; once Beam accepts it, the full trace appears here.
+                          </div>
+                          {threadDetail.thread.kind === 'handoff' && threadDetail.thread.status === 'blocked' ? (
+                            <button
+                              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                              type="button"
+                              disabled={actionBusy === `thread-dispatch-${threadDetail.thread.id}`}
+                              onClick={() => { void handleThreadDispatch(threadDetail.thread) }}
+                            >
+                              {actionBusy === `thread-dispatch-${threadDetail.thread.id}` ? 'Sending…' : 'Approve and send'}
+                            </button>
+                          ) : null}
                         </div>
                       )}
                     </div>

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -1449,6 +1449,51 @@ export function createWorkspaceThread(
   return thread
 }
 
+export function updateWorkspaceThread(
+  db: DB,
+  input: {
+    id: number
+    title?: string | null
+    summary?: string | null
+    owner?: string | null
+    status?: WorkspaceThreadRow['status']
+    workflowType?: string | null
+    linkedIntentNonce?: string | null
+    lastActivityAt?: string
+  },
+): WorkspaceThreadRow | null {
+  const existing = getWorkspaceThreadById(db, input.id)
+  if (!existing) {
+    return null
+  }
+
+  const updatedAt = nowIso()
+  db.prepare(`
+    UPDATE workspace_threads
+    SET title = ?,
+        summary = ?,
+        owner = ?,
+        status = ?,
+        workflow_type = ?,
+        linked_intent_nonce = ?,
+        last_activity_at = ?,
+        updated_at = ?
+    WHERE id = ?
+  `).run(
+    input.title ?? existing.title,
+    input.summary === undefined ? existing.summary : input.summary,
+    input.owner === undefined ? existing.owner : input.owner,
+    input.status ?? existing.status,
+    input.workflowType === undefined ? existing.workflow_type : input.workflowType,
+    input.linkedIntentNonce === undefined ? existing.linked_intent_nonce : input.linkedIntentNonce,
+    input.lastActivityAt ?? existing.last_activity_at,
+    updatedAt,
+    input.id,
+  )
+
+  return getWorkspaceThreadById(db, input.id)
+}
+
 export function listWorkspaceThreadParticipants(db: DB, threadId: number): WorkspaceThreadParticipantRow[] {
   return db.prepare(`
     SELECT *

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
 import { requireAdminRole } from '../admin-auth.js'
@@ -25,12 +26,14 @@ import {
   listWorkspaceThreads,
   listWorkspaces,
   logAuditEvent,
+  updateWorkspaceThread,
   updateWorkspacePartnerChannel,
   updateWorkspacePolicyDocument,
   updateWorkspaceIdentityBinding,
 } from '../db.js'
 import type {
   AuditLogRow,
+  IntentFrame,
   IntentLogRow,
   WorkspaceIdentityBindingRow,
   WorkspaceIdentityBindingStatus,
@@ -52,6 +55,7 @@ import type {
 } from '../types.js'
 import { serializeAgentKeyState } from '../utils/serialize.js'
 import { evaluateWorkspacePolicy } from '../workspace-policy.js'
+import { RelayError, isAgentConnected, relayIntentFromHttp } from '../websocket.js'
 import { sendOperatorDigestEmail } from '../email.js'
 
 const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
@@ -112,6 +116,9 @@ type SerializedWorkspaceIdentityBinding = {
     mode: 'runtime-backed' | 'service' | 'partner' | 'manual'
     connector: string | null
     label: string | null
+    connected: boolean
+    httpEndpoint: string | null
+    deliveryMode: 'websocket' | 'http' | 'hybrid' | 'unavailable' | null
   }
   identity: {
     existsLocally: boolean
@@ -471,6 +478,9 @@ function parseRuntimeMetadata(
       mode: 'partner',
       connector: null,
       label: runtimeType,
+      connected: false,
+      httpEndpoint: null,
+      deliveryMode: null,
     }
   }
 
@@ -480,6 +490,9 @@ function parseRuntimeMetadata(
       mode: 'service',
       connector: connector ?? null,
       label: rest.join(' · ') || runtimeType,
+      connected: false,
+      httpEndpoint: null,
+      deliveryMode: null,
     }
   }
 
@@ -489,6 +502,9 @@ function parseRuntimeMetadata(
       mode: 'runtime-backed',
       connector: connector ?? null,
       label: rest.join(' · ') || runtimeType,
+      connected: false,
+      httpEndpoint: null,
+      deliveryMode: null,
     }
   }
 
@@ -496,6 +512,9 @@ function parseRuntimeMetadata(
     mode: 'manual',
     connector: null,
     label: null,
+    connected: false,
+    httpEndpoint: null,
+    deliveryMode: null,
   }
 }
 
@@ -597,6 +616,8 @@ function summarizeWorkspaceAuditAction(action: string, details: Record<string, u
       return 'Workspace identity binding updated.'
     case 'admin.workspace_thread.created':
       return 'Workspace thread created.'
+    case 'admin.workspace_thread.dispatched':
+      return 'Workspace handoff dispatched.'
     case 'admin.workspace_partner_channel.created':
       return 'Partner channel added.'
     case 'admin.workspace_partner_channel.updated':
@@ -641,6 +662,17 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
   const keyState = agent ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) : null
   const lastSeenAgeHours = hoursSince(agent?.last_seen ?? null)
   const runtime = parseRuntimeMetadata(row.binding_type, row.runtime_type)
+  const connected = agent ? isAgentConnected(agent.beam_id) : false
+  const httpEndpoint = agent?.http_endpoint ?? null
+  const deliveryMode = agent
+    ? connected && httpEndpoint
+      ? 'hybrid'
+      : connected
+        ? 'websocket'
+        : httpEndpoint
+          ? 'http'
+          : 'unavailable'
+    : null
   const lifecycleStatus = classifyWorkspaceIdentityLifecycle(row, {
     existsLocally: Boolean(agent),
     lastSeenAgeHours,
@@ -665,7 +697,12 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
     lastSeenAgeHours,
     ownershipState: row.owner ? 'owned' : 'unowned',
     lifecycleStatus,
-    runtime,
+    runtime: {
+      ...runtime,
+      connected,
+      httpEndpoint,
+      deliveryMode,
+    },
     identity: agent ? {
       existsLocally: true,
       beamId: agent.beam_id,
@@ -1836,6 +1873,269 @@ export function workspacesRouter(db: Database): Hono {
       thread: serializeWorkspaceThread(db, thread, participants),
       participants: participants.map((row) => serializeWorkspaceThreadParticipant(db, row)),
     }, 201)
+  })
+
+  router.post('/:slug/threads/:id/dispatch', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const threadId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(threadId) || threadId <= 0) {
+      return c.json({ error: 'Invalid thread id', errorCode: 'INVALID_THREAD_ID' }, 400)
+    }
+
+    const thread = getWorkspaceThreadById(db, threadId)
+    if (!thread || thread.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace thread not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    if (thread.kind !== 'handoff') {
+      return c.json({ error: 'Only handoff threads can dispatch Beam messages', errorCode: 'THREAD_NOT_HANDOFF' }, 400)
+    }
+
+    if (thread.linked_intent_nonce) {
+      return c.json({ error: 'This handoff thread is already linked to a Beam trace', errorCode: 'THREAD_ALREADY_LINKED' }, 409)
+    }
+
+    if (thread.status === 'closed') {
+      return c.json({ error: 'Closed workspace threads cannot dispatch handoffs', errorCode: 'THREAD_CLOSED' }, 409)
+    }
+
+    if (workspace.external_handoffs_enabled !== 1) {
+      return c.json({ error: 'Workspace external handoffs are disabled', errorCode: 'WORKSPACE_EXTERNAL_DISABLED' }, 409)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      body = {}
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const participants = listWorkspaceThreadParticipants(db, thread.id)
+    const senderParticipant = participants.find((participant) => (
+      participant.workspace_binding_id != null
+      && participant.principal_type !== 'partner'
+      && typeof participant.beam_id === 'string'
+      && participant.beam_id.length > 0
+    ))
+    if (!senderParticipant?.workspace_binding_id || !senderParticipant.beam_id) {
+      return c.json({ error: 'Thread is missing a local workspace identity to send the handoff', errorCode: 'THREAD_MISSING_SENDER' }, 409)
+    }
+
+    const senderBinding = getWorkspaceIdentityBindingById(db, senderParticipant.workspace_binding_id)
+    if (!senderBinding || senderBinding.workspace_id !== workspace.id || senderBinding.binding_type === 'partner') {
+      return c.json({ error: 'Thread sender binding is invalid for this workspace', errorCode: 'INVALID_SENDER_BINDING' }, 409)
+    }
+
+    if (senderBinding.status !== 'active') {
+      return c.json({ error: 'Thread sender binding is paused', errorCode: 'SENDER_BINDING_PAUSED' }, 409)
+    }
+
+    const partnerParticipant = participants.find((participant) => (
+      participant.principal_type === 'partner'
+      && typeof participant.beam_id === 'string'
+      && participant.beam_id.length > 0
+    ))
+    if (!partnerParticipant?.beam_id) {
+      return c.json({ error: 'Thread is missing a partner participant', errorCode: 'THREAD_MISSING_PARTNER' }, 409)
+    }
+
+    const partnerChannel = getWorkspacePartnerChannelByBeamId(db, workspace.id, partnerParticipant.beam_id)
+    if (!partnerChannel) {
+      return c.json({ error: 'Partner participant is not attached to an active workspace partner channel', errorCode: 'PARTNER_CHANNEL_NOT_FOUND' }, 409)
+    }
+
+    if (partnerChannel.status === 'blocked') {
+      return c.json({ error: 'Partner channel is blocked', errorCode: 'PARTNER_CHANNEL_BLOCKED' }, 409)
+    }
+
+    const { policy } = getWorkspacePolicyDocument(db, workspace.id)
+    const policyPreview = evaluateWorkspacePolicy(policy, senderBinding, {
+      workflowType: thread.workflow_type,
+      partnerBeamId: partnerChannel.partner_beam_id,
+    })
+    if (policyPreview.externalInitiation !== 'allow') {
+      return c.json({ error: 'Workspace policy denied this external handoff', errorCode: 'WORKSPACE_POLICY_DENIED' }, 403)
+    }
+
+    const fallbackMessage = thread.summary?.trim() || thread.title.trim()
+    const message = normalizeOptionalString(raw.message) ?? fallbackMessage
+    if (!message) {
+      return c.json({ error: 'A message is required to dispatch a handoff thread', errorCode: 'MISSING_HANDOFF_MESSAGE' }, 400)
+    }
+
+    const language = normalizeOptionalString(raw.language)
+    const nonce = randomUUID()
+    const timestamp = new Date().toISOString()
+    const frame: IntentFrame = {
+      v: '1',
+      nonce,
+      timestamp,
+      from: senderBinding.beam_id,
+      to: partnerChannel.partner_beam_id,
+      intent: 'conversation.message',
+      payload: {
+        message,
+        ...(language ? { language } : {}),
+        context: {
+          workspace: {
+            id: workspace.id,
+            slug: workspace.slug,
+            name: workspace.name,
+          },
+          thread: {
+            id: thread.id,
+            title: thread.title,
+            summary: thread.summary,
+            workflowType: thread.workflow_type,
+            owner: thread.owner,
+          },
+          approval: {
+            action: 'workspace_thread_dispatch',
+            approvedBy: auth.session.email,
+            approvalRequired: policyPreview.approvalRequired,
+            approvers: policyPreview.approvers,
+          },
+          partnerChannel: {
+            id: partnerChannel.id,
+            label: partnerChannel.label,
+            status: partnerChannel.status,
+          },
+          participants: participants
+            .filter((participant) => participant.beam_id)
+            .map((participant) => ({
+              beamId: participant.beam_id,
+              role: participant.role,
+              principalType: participant.principal_type,
+            })),
+        },
+      },
+    }
+
+    const finalizeDispatch = (result: {
+      nonce: string
+      success: boolean
+      error: string | null
+      errorCode: string | null
+    }) => {
+      const now = new Date().toISOString()
+      const updatedThread = updateWorkspaceThread(db, {
+        id: thread.id,
+        status: 'open',
+        linkedIntentNonce: result.nonce,
+        lastActivityAt: now,
+      })
+      const updatedChannel = updateWorkspacePartnerChannel(db, {
+        id: partnerChannel.id,
+        label: partnerChannel.label,
+        owner: partnerChannel.owner,
+        status: partnerChannel.status,
+        notes: partnerChannel.notes,
+        lastIntentNonce: result.nonce,
+        ...(result.success
+          ? { lastSuccessAt: now }
+          : { lastFailureAt: now }),
+      })
+
+      logAuditEvent(db, {
+        action: 'admin.workspace_thread.dispatched',
+        actor: auth.session.email,
+        target: `${workspace.slug}:${thread.id}`,
+        details: {
+          role: auth.session.role,
+          linkedIntentNonce: result.nonce,
+          workflowType: thread.workflow_type,
+          intentType: 'conversation.message',
+          fromBeamId: senderBinding.beam_id,
+          toBeamId: partnerChannel.partner_beam_id,
+          partnerChannelId: partnerChannel.id,
+          approvalRequired: policyPreview.approvalRequired,
+          approvers: policyPreview.approvers,
+          success: result.success,
+          errorCode: result.errorCode,
+        },
+      })
+
+      const currentThread = updatedThread ?? thread
+      const currentParticipants = listWorkspaceThreadParticipants(db, thread.id)
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        workspace: serializeWorkspace(db, workspace),
+        thread: serializeWorkspaceThread(db, currentThread, currentParticipants),
+        participants: currentParticipants.map((row) => serializeWorkspaceThreadParticipant(db, row)),
+        partnerChannel: updatedChannel
+          ? serializeWorkspacePartnerChannel(
+            db,
+            updatedChannel,
+            listWorkspaceIdentityBindings(db, workspace.id)
+              .filter((binding) => binding.binding_type !== 'partner')
+              .map((binding) => binding.beam_id),
+          )
+          : null,
+        dispatch: {
+          nonce: result.nonce,
+          success: result.success,
+          error: result.error,
+          errorCode: result.errorCode,
+          traceHref: `/intents/${encodeURIComponent(result.nonce)}`,
+        },
+      })
+    }
+
+    try {
+      const result = await relayIntentFromHttp(db, frame, 60_000, {
+        trustedControlPlane: true,
+      })
+
+      return finalizeDispatch({
+        nonce,
+        success: result.success,
+        error: result.error ?? null,
+        errorCode: result.errorCode ?? null,
+      })
+    } catch (err) {
+      const loggedIntent = getIntentLogByNonce(db, nonce)
+      if (loggedIntent) {
+        return finalizeDispatch({
+          nonce,
+          success: loggedIntent.status === 'acked',
+          error: err instanceof Error ? err.message : 'Beam handoff dispatch failed',
+          errorCode: err instanceof RelayError ? err.code : loggedIntent.error_code,
+        })
+      }
+
+      if (err instanceof RelayError) {
+        const status = err.code === 'OFFLINE'
+          ? 503
+          : err.code === 'TIMEOUT'
+            ? 504
+            : err.code === 'FORBIDDEN'
+              ? 403
+              : err.code === 'BAD_REQUEST'
+                ? 400
+                : err.code === 'RATE_LIMITED'
+                  ? 429
+                  : 502
+        return c.json({ error: err.message, errorCode: err.code }, status)
+      }
+
+      console.error('Workspace thread dispatch error:', err)
+      return c.json({ error: 'Failed to dispatch workspace handoff thread', errorCode: 'DISPATCH_FAILED' }, 500)
+    }
   })
 
   router.get('/:slug/policy', (c) => {

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -742,7 +742,11 @@ export async function relayIntentFromHttp(
   db: Database,
   frame: IntentFrame,
   timeoutMs = Number(process.env.RELAY_TIMEOUT_MS || 120_000),
-  options: { sourceDirectory?: string; hopCount?: number } = {}
+  options: {
+    sourceDirectory?: string
+    hopCount?: number
+    trustedControlPlane?: boolean
+  } = {},
 ): Promise<ResultFrame> {
   const prepared = normalizeAndValidateFrame(frame)
   const sourceDirectory = options.sourceDirectory ?? getLocalDirectoryUrl()
@@ -760,7 +764,9 @@ export async function relayIntentFromHttp(
   }
 
   try {
-    enforceSecurityChecks(db, prepared, senderPublicKey)
+    enforceSecurityChecks(db, prepared, senderPublicKey, {
+      skipSignatureVerification: options.trustedControlPlane === true,
+    })
     recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
   } catch (err) {
     recordShieldDecision(db, prepared, {

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -155,6 +155,8 @@ test('workspace identity bindings can be created, listed, and updated through th
         runtime: {
           mode: string
           connector: string | null
+          connected: boolean
+          deliveryMode: string | null
         }
         lastSeenAgeHours: number | null
         identity: {
@@ -172,6 +174,8 @@ test('workspace identity bindings can be created, listed, and updated through th
     assert.equal(localBindingBody.binding.ownershipState, 'owned')
     assert.equal(localBindingBody.binding.runtime.mode, 'runtime-backed')
     assert.equal(localBindingBody.binding.runtime.connector, 'codex')
+    assert.equal(localBindingBody.binding.runtime.connected, false)
+    assert.equal(localBindingBody.binding.runtime.deliveryMode, 'unavailable')
     assert.equal(typeof localBindingBody.binding.lastSeenAgeHours, 'number')
     assert.equal(localBindingBody.binding.identity.existsLocally, true)
     assert.equal(localBindingBody.binding.identity.displayName, 'Ops Bot')
@@ -646,6 +650,187 @@ test('workspace threads model internal discussion and external handoffs in one t
     assert.equal(detailBody.thread.trace?.fromBeamId, 'ops-bot@beam.directory')
     assert.equal(detailBody.thread.trace?.toBeamId, 'finance@northwind.beam.directory')
     assert.deepEqual(detailBody.participants.map((entry) => entry.principalType).sort(), ['agent', 'partner'])
+  } finally {
+    db.close()
+  }
+})
+
+test('operators can approve and dispatch blocked workspace handoff threads through Beam', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['handoff'],
+      publicKey: 'MCowBQYDK2VwAyEA4Qw1l2rK2LwH5FNN+1mQ2kD2mP1eJ0C8n9rPq4xS2fI=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Acme Dispatch Workspace',
+        slug: 'acme-dispatch',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    const localBindingResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex:operator',
+        policyProfile: 'ops-default',
+        canInitiateExternal: true,
+      }),
+    }))
+    const localBinding = await localBindingResponse.json() as { binding: { id: number } }
+
+    const policyResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch/policy', {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        workflowRules: [{
+          workflowType: 'partner.review',
+          requireApproval: true,
+          allowedPartners: ['echo@beam.directory'],
+          approvers: ['ops@example.com'],
+        }],
+      }),
+    }))
+    assert.equal(policyResponse.status, 200)
+
+    const channelResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch/partner-channels', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        partnerBeamId: 'echo@beam.directory',
+        label: 'Beam Echo',
+        owner: 'ops@example.com',
+        status: 'active',
+      }),
+    }))
+    assert.equal(channelResponse.status, 201)
+
+    const createThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch/threads', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Send cross-instance approval ping',
+        summary: 'Please confirm the approval lane and respond with the next action.',
+        owner: 'ops@example.com',
+        workflowType: 'partner.review',
+        status: 'blocked',
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: localBinding.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'echo@beam.directory',
+            principalType: 'partner',
+            beamId: 'echo@beam.directory',
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(createThreadResponse.status, 201)
+    const createdThread = await createThreadResponse.json() as { thread: { id: number } }
+
+    const dispatchResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-dispatch/threads/${createdThread.thread.id}/dispatch`, {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: 'Show me how this cross-instance Beam handoff works.',
+        language: 'en',
+      }),
+    }))
+    assert.equal(dispatchResponse.status, 200)
+
+    const dispatchBody = await dispatchResponse.json() as {
+      thread: {
+        status: string
+        linkedIntentNonce: string | null
+        trace: {
+          intentType: string
+          toBeamId: string
+          status: string
+        } | null
+      }
+      partnerChannel: {
+        lastIntentNonce: string | null
+        trace: { nonce: string } | null
+      } | null
+      dispatch: {
+        nonce: string
+        success: boolean
+        traceHref: string | null
+      }
+    }
+    assert.equal(dispatchBody.dispatch.success, true)
+    assert.equal(typeof dispatchBody.dispatch.nonce, 'string')
+    assert.equal(dispatchBody.thread.status, 'open')
+    assert.equal(dispatchBody.thread.linkedIntentNonce, dispatchBody.dispatch.nonce)
+    assert.equal(dispatchBody.thread.trace?.intentType, 'conversation.message')
+    assert.equal(dispatchBody.thread.trace?.toBeamId, 'echo@beam.directory')
+    assert.equal(dispatchBody.thread.trace?.status, 'acked')
+    assert.equal(dispatchBody.partnerChannel?.lastIntentNonce, dispatchBody.dispatch.nonce)
+    assert.equal(dispatchBody.partnerChannel?.trace?.nonce, dispatchBody.dispatch.nonce)
+
+    const detailResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-dispatch/threads/${createdThread.thread.id}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(detailResponse.status, 200)
+    const detailBody = await detailResponse.json() as {
+      thread: {
+        linkedIntentNonce: string | null
+        trace: { nonce: string | null } | null
+      }
+    }
+    assert.equal(detailBody.thread.linkedIntentNonce, dispatchBody.dispatch.nonce)
+    assert.equal(detailBody.thread.trace?.nonce, dispatchBody.dispatch.nonce)
+
+    const timelineResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch/timeline', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(timelineResponse.status, 200)
+    const timelineBody = await timelineResponse.json() as {
+      entries: Array<{
+        action: string
+        traceHref: string | null
+      }>
+    }
+    const dispatchEntry = timelineBody.entries.find((entry) => entry.action === 'admin.workspace_thread.dispatched')
+    assert.equal(dispatchEntry?.traceHref, `/intents/${dispatchBody.dispatch.nonce}`)
   } finally {
     db.close()
   }


### PR DESCRIPTION
## Summary
- let operators dispatch blocked workspace handoff threads into real Beam traces
- surface richer runtime-backed identity delivery details in the workspace dashboard
- add end-to-end tests and docs for create-and-send / approve-and-send flows

## Verification
- npm test --workspace=packages/directory
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build