### PR TITLE
Add workspace intent composer flows

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -152,6 +152,7 @@ The first routes are all admin-authenticated and now include the controls requir
 ### Create a blocked handoff draft
 
 Blocked handoff drafts are valid without a `linkedIntentNonce`. This is the control-plane representation of "the operator has staged the outbound motion, but policy or approval is still stopping it."
+The draft now carries both the target Beam intent and the structured payload that should be sent once the operator approves the motion.
 
 ```json
 {
@@ -161,6 +162,12 @@ Blocked handoff drafts are valid without a `linkedIntentNonce`. This is the cont
   "owner": "ops@example.com",
   "status": "blocked",
   "workflowType": "quote.approval",
+  "draftIntentType": "task.delegate",
+  "draftPayload": {
+    "task": "Confirm the approval lane and return the next operator action.",
+    "context": "Workspace-triggered cross-instance approval dispatch.",
+    "priority": "high"
+  },
   "participants": [
     {
       "principalId": "ops-bot@beam.directory",
@@ -184,14 +191,29 @@ Blocked handoff drafts are valid without a `linkedIntentNonce`. This is the cont
 
 This is the approval-path action. The workspace thread remains the operator record, but Beam generates the real cross-instance trace and links it back to the thread.
 
+If the thread already stores a draft intent and draft payload, the dispatch body can be empty:
+
+```json
+{}
+```
+
+You can also override the stored draft and dispatch a specific intent explicitly:
+
 ```json
 {
-  "message": "Please confirm whether this approval lane is ready for the next purchase review.",
-  "language": "en"
+  "intentType": "quote.request",
+  "payload": {
+    "sku": "INV-APPROVAL",
+    "quantity": 1,
+    "shipTo": "Acme HQ"
+  }
 }
 ```
 
-The dispatch route currently sends a real `conversation.message` Beam intent with workspace, thread, partner-channel, and approval context attached under `payload.context`.
+The dispatch route now sends the selected Beam intent, persists the draft on the thread, and attaches workspace, thread, partner-channel, and approval context automatically:
+
+- under `payload.context.beam` for `conversation.message`
+- under `payload.beamContext` for all other intents
 
 ### Create a partner channel
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -338,6 +338,8 @@ export interface WorkspaceThread {
   owner: string | null
   status: WorkspaceThreadStatus
   workflowType: string | null
+  draftIntentType: string | null
+  draftPayload: Record<string, unknown> | null
   linkedIntentNonce: string | null
   lastActivityAt: string
   createdAt: string
@@ -380,6 +382,8 @@ export interface WorkspaceThreadDetailResponse {
 }
 
 export interface WorkspaceThreadDispatchInput {
+  intentType?: string | null
+  payload?: Record<string, unknown> | null
   message?: string | null
   language?: string | null
 }
@@ -388,6 +392,7 @@ export interface WorkspaceThreadDispatchResponse extends WorkspaceThreadDetailRe
   partnerChannel: WorkspacePartnerChannel | null
   dispatch: {
     nonce: string
+    intentType: string
     success: boolean
     error: string | null
     errorCode: string | null
@@ -498,6 +503,8 @@ export interface WorkspaceThreadCreateInput {
   owner?: string | null
   status?: WorkspaceThreadStatus
   workflowType?: string | null
+  draftIntentType?: string | null
+  draftPayload?: Record<string, unknown> | null
   linkedIntentNonce?: string | null
   participants?: WorkspaceThreadParticipantInput[]
 }
@@ -942,9 +949,25 @@ export interface OrgDetailsResponse {
 }
 
 export interface IntentCatalogItem {
-  type: string
+  id: string
   description?: string
-  payloadSchema?: Record<string, unknown>
+  params?: Record<string, {
+    type?: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'integer'
+    enum?: unknown[]
+    required?: boolean
+    description?: string
+    default?: unknown
+    maxLength?: number
+  }>
+  payload?: Record<string, {
+    type?: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'integer'
+    enum?: unknown[]
+    required?: boolean
+    description?: string
+    default?: unknown
+    maxLength?: number
+  }>
+  response?: Record<string, unknown>
 }
 
 export interface IntentCatalogResponse {

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -4,6 +4,7 @@ import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Ob
 import {
   ApiError,
   directoryApi,
+  type IntentCatalogItem,
   type IntentLifecycleStatus,
   type WorkspaceBindingStatus,
   type WorkspaceDigestActionItem,
@@ -27,6 +28,16 @@ import {
   type WorkspaceTimelineEventKind,
 } from '../lib/api'
 import { formatDateTime, formatLatency, formatNumber, formatRelativeTime } from '../lib/utils'
+
+const FALLBACK_CONVERSATION_INTENT: IntentCatalogItem = {
+  id: 'conversation.message',
+  description: 'Natural language message with optional language and context.',
+  params: {
+    message: { type: 'string', required: true },
+    language: { type: 'string', default: 'en' },
+    context: { type: 'object' },
+  },
+}
 
 function workspaceStatusTone(status: WorkspaceStatus): 'default' | 'success' | 'warning' {
   switch (status) {
@@ -168,6 +179,72 @@ function summarizeList(values: string[], fallback: string): string {
   return values.length > 0 ? values.join(', ') : fallback
 }
 
+function getIntentRules(intent: IntentCatalogItem | null): Record<string, NonNullable<IntentCatalogItem['params']>[string]> {
+  if (!intent) {
+    return {}
+  }
+
+  return (intent.params ?? intent.payload ?? {}) as Record<string, NonNullable<IntentCatalogItem['params']>[string]>
+}
+
+function buildIntentPayloadTemplate(intent: IntentCatalogItem | null): string {
+  const rules = getIntentRules(intent)
+  const payload: Record<string, unknown> = {}
+
+  for (const [key, rule] of Object.entries(rules)) {
+    if (rule.default !== undefined) {
+      payload[key] = rule.default
+      continue
+    }
+
+    switch (rule.type) {
+      case 'integer':
+      case 'number':
+        payload[key] = rule.required ? 1 : 0
+        break
+      case 'boolean':
+        payload[key] = rule.required ? true : false
+        break
+      case 'array':
+        payload[key] = []
+        break
+      case 'object':
+        payload[key] = {}
+        break
+      default:
+        payload[key] = ''
+        break
+    }
+  }
+
+  if (intent?.id === 'conversation.message') {
+    payload.message = typeof payload.message === 'string' ? payload.message : ''
+    payload.language = typeof payload.language === 'string' && payload.language.length > 0 ? payload.language : 'en'
+  }
+
+  return JSON.stringify(payload, null, 2)
+}
+
+function parseJsonObjectInput(value: string, label: string): Record<string, unknown> | null {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`${label} must be a JSON object.`)
+    }
+    return parsed as Record<string, unknown>
+  } catch (err) {
+    if (err instanceof Error && err.message.includes(label)) {
+      throw err
+    }
+    throw new Error(`${label} must be valid JSON.`)
+  }
+}
+
 function renderAttentionMeta(item: WorkspaceOverviewAttentionItem): string {
   const parts = [
     item.binding.owner ? `Owner ${item.binding.owner}` : 'No owner',
@@ -236,6 +313,7 @@ export default function WorkspacesPage() {
   const [policy, setPolicy] = useState<WorkspacePolicyResponse | null>(null)
   const [timeline, setTimeline] = useState<WorkspaceTimelineEntry[]>([])
   const [digest, setDigest] = useState<WorkspaceDigestResponse | null>(null)
+  const [intentCatalog, setIntentCatalog] = useState<IntentCatalogItem[]>([FALLBACK_CONVERSATION_INTENT])
   const [loading, setLoading] = useState(true)
   const [surfaceLoading, setSurfaceLoading] = useState(false)
   const [threadDetailLoading, setThreadDetailLoading] = useState(false)
@@ -261,10 +339,10 @@ export default function WorkspacesPage() {
     kind: 'internal' as WorkspaceThreadKind,
     title: '',
     summary: '',
-    message: '',
-    language: 'en',
     owner: '',
     workflowType: '',
+    draftIntentType: FALLBACK_CONVERSATION_INTENT.id,
+    draftPayloadJson: buildIntentPayloadTemplate(FALLBACK_CONVERSATION_INTENT),
     localBindingId: '',
     partnerChannelId: '',
     linkedIntentNonce: '',
@@ -290,10 +368,26 @@ export default function WorkspacesPage() {
     () => bindings.filter((binding) => binding.bindingType !== 'partner'),
     [bindings],
   )
+  const defaultHandoffIntentId = useMemo(
+    () => intentCatalog.find((entry) => entry.id === 'conversation.message')?.id ?? intentCatalog[0]?.id ?? FALLBACK_CONVERSATION_INTENT.id,
+    [intentCatalog],
+  )
+  const selectedIntent = useMemo(
+    () => intentCatalog.find((entry) => entry.id === threadForm.draftIntentType)
+      ?? intentCatalog.find((entry) => entry.id === defaultHandoffIntentId)
+      ?? FALLBACK_CONVERSATION_INTENT,
+    [defaultHandoffIntentId, intentCatalog, threadForm.draftIntentType],
+  )
 
   async function loadWorkspaces() {
     const response = await directoryApi.listWorkspaces()
     setWorkspaces(response.workspaces)
+  }
+
+  async function loadIntentCatalog() {
+    const response = await directoryApi.getIntentCatalog()
+    const intents = response.intents.length > 0 ? response.intents : [FALLBACK_CONVERSATION_INTENT]
+    setIntentCatalog(intents)
   }
 
   async function loadWorkspaceSurface(slug: string) {
@@ -370,6 +464,35 @@ export default function WorkspacesPage() {
   useEffect(() => {
     void refreshAll()
   }, [])
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await loadIntentCatalog()
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to load intent catalog')
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    if (threadForm.kind !== 'handoff') {
+      return
+    }
+
+    if (threadForm.draftIntentType && intentCatalog.some((entry) => entry.id === threadForm.draftIntentType)) {
+      return
+    }
+
+    const nextIntent = intentCatalog.find((entry) => entry.id === defaultHandoffIntentId)
+      ?? intentCatalog[0]
+      ?? FALLBACK_CONVERSATION_INTENT
+    setThreadForm((current) => ({
+      ...current,
+      draftIntentType: nextIntent.id,
+      draftPayloadJson: buildIntentPayloadTemplate(nextIntent),
+    }))
+  }, [defaultHandoffIntentId, intentCatalog, threadForm.draftIntentType, threadForm.kind])
 
   useEffect(() => {
     if (!selectedWorkspace) {
@@ -595,9 +718,26 @@ export default function WorkspacesPage() {
     }
 
     const linkedIntentNonce = threadForm.linkedIntentNonce.trim()
+    const shouldPersistDraft = threadForm.kind === 'handoff' && linkedIntentNonce.length === 0
     const shouldDispatch = mode === 'dispatch' && threadForm.kind === 'handoff' && linkedIntentNonce.length === 0
-    const dispatchMessage = threadForm.message.trim() || threadForm.summary.trim() || threadForm.title.trim()
     let createdThreadId: number | null = null
+
+    let draftIntentType: string | null = null
+    let draftPayload: Record<string, unknown> | null = null
+    if (shouldPersistDraft) {
+      draftIntentType = threadForm.draftIntentType.trim() || defaultHandoffIntentId
+      try {
+        draftPayload = parseJsonObjectInput(threadForm.draftPayloadJson, 'Intent payload')
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Intent payload must be valid JSON.')
+        return
+      }
+
+      if (!draftPayload) {
+        setError('Intent payload is required for a blocked or directly dispatched handoff.')
+        return
+      }
+    }
 
     try {
       setActionBusy(shouldDispatch ? 'thread-composer-dispatch' : 'thread-composer-create')
@@ -610,6 +750,8 @@ export default function WorkspacesPage() {
         summary: threadForm.summary.trim() || null,
         owner: threadForm.owner.trim() || null,
         workflowType: threadForm.workflowType.trim() || null,
+        draftIntentType: shouldPersistDraft ? draftIntentType : null,
+        draftPayload: shouldPersistDraft ? draftPayload : null,
         linkedIntentNonce: linkedIntentNonce || null,
         status: threadForm.kind === 'handoff' && !linkedIntentNonce ? 'blocked' : 'open',
         participants,
@@ -620,8 +762,8 @@ export default function WorkspacesPage() {
       let noticeMessage = 'Workspace thread created.'
       if (shouldDispatch) {
         const dispatchResponse = await directoryApi.dispatchWorkspaceThread(selectedWorkspace.slug, response.thread.id, {
-          message: dispatchMessage,
-          language: threadForm.language.trim() || null,
+          intentType: draftIntentType,
+          payload: draftPayload,
         })
         activeThreadId = dispatchResponse.thread.id
         noticeMessage = dispatchResponse.dispatch.success
@@ -637,10 +779,10 @@ export default function WorkspacesPage() {
         kind: 'internal',
         title: '',
         summary: '',
-        message: '',
-        language: 'en',
         owner: '',
         workflowType: '',
+        draftIntentType: defaultHandoffIntentId,
+        draftPayloadJson: buildIntentPayloadTemplate(intentCatalog.find((entry) => entry.id === defaultHandoffIntentId) ?? FALLBACK_CONVERSATION_INTENT),
         localBindingId: '',
         partnerChannelId: '',
         linkedIntentNonce: '',
@@ -675,8 +817,6 @@ export default function WorkspacesPage() {
       setError(null)
 
       const response = await directoryApi.dispatchWorkspaceThread(selectedWorkspace.slug, thread.id, {
-        message: thread.summary || thread.title,
-        language: 'en',
       })
       await loadWorkspaceSurface(selectedWorkspace.slug)
       await loadThreadDetail(selectedWorkspace.slug, thread.id)
@@ -1063,7 +1203,23 @@ export default function WorkspacesPage() {
                   void handleThreadComposerSubmit('create')
                 }}
               >
-                <select className="input-field" value={threadForm.kind} onChange={(event) => setThreadForm((current) => ({ ...current, kind: event.target.value as WorkspaceThreadKind }))}>
+                <select
+                  className="input-field"
+                  value={threadForm.kind}
+                  onChange={(event) => {
+                    const nextKind = event.target.value as WorkspaceThreadKind
+                    setThreadForm((current) => ({
+                      ...current,
+                      kind: nextKind,
+                      ...(nextKind === 'handoff'
+                        ? {
+                            draftIntentType: current.draftIntentType || defaultHandoffIntentId,
+                            draftPayloadJson: current.draftPayloadJson || buildIntentPayloadTemplate(selectedIntent),
+                          }
+                        : {}),
+                    }))
+                  }}
+                >
                   <option value="internal">internal</option>
                   <option value="handoff">handoff</option>
                 </select>
@@ -1089,8 +1245,37 @@ export default function WorkspacesPage() {
                         </option>
                       ))}
                     </select>
-                    <input className="input-field" placeholder="Language hint (default en)" value={threadForm.language} onChange={(event) => setThreadForm((current) => ({ ...current, language: event.target.value }))} />
-                    <textarea className="input-field md:col-span-2 min-h-24" placeholder="Message to send over Beam (defaults to summary/title if blank)" value={threadForm.message} onChange={(event) => setThreadForm((current) => ({ ...current, message: event.target.value }))} />
+                    <select
+                      className="input-field"
+                      value={threadForm.draftIntentType}
+                      onChange={(event) => {
+                        const nextIntent = intentCatalog.find((entry) => entry.id === event.target.value) ?? FALLBACK_CONVERSATION_INTENT
+                        setThreadForm((current) => ({
+                          ...current,
+                          draftIntentType: nextIntent.id,
+                          draftPayloadJson: buildIntentPayloadTemplate(nextIntent),
+                        }))
+                      }}
+                    >
+                      {intentCatalog.map((intent) => (
+                        <option key={intent.id} value={intent.id}>
+                          {intent.id}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="md:col-span-2 rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                      <div className="font-medium text-slate-900 dark:text-slate-100">{selectedIntent.id}</div>
+                      <div className="mt-1">{selectedIntent.description || 'No catalog description is available for this intent yet.'}</div>
+                      <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                        Fields: {Object.keys(getIntentRules(selectedIntent)).length > 0 ? Object.keys(getIntentRules(selectedIntent)).join(', ') : 'No schema fields declared'}
+                      </div>
+                    </div>
+                    <textarea
+                      className="input-field md:col-span-2 min-h-48 font-mono text-xs"
+                      placeholder="Structured JSON payload"
+                      value={threadForm.draftPayloadJson}
+                      onChange={(event) => setThreadForm((current) => ({ ...current, draftPayloadJson: event.target.value }))}
+                    />
                     <input className="input-field" placeholder="Linked intent nonce (optional if still blocked)" value={threadForm.linkedIntentNonce} onChange={(event) => setThreadForm((current) => ({ ...current, linkedIntentNonce: event.target.value }))} />
                   </>
                 ) : null}
@@ -1113,7 +1298,7 @@ export default function WorkspacesPage() {
                     </button>
                   ) : null}
                   <div className="text-xs text-slate-500 dark:text-slate-400">
-                    Handoff threads can stay blocked for review, link to an existing nonce, or be sent directly from this workspace surface.
+                    Handoff threads can stay blocked for review, link to an existing nonce, or send a catalog-backed Beam intent directly from this workspace surface.
                   </div>
                 </div>
               </form>
@@ -1156,6 +1341,7 @@ export default function WorkspacesPage() {
                         <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
                           <div>{thread.workflowType ? `Workflow ${thread.workflowType}` : 'Internal coordination'}</div>
                           <div>{thread.owner ? `Owner ${thread.owner}` : 'No owner assigned'}</div>
+                          <div>{thread.draftIntentType ? `Draft intent ${thread.draftIntentType}` : thread.trace ? `Trace intent ${thread.trace.intentType}` : 'No Beam draft yet'}</div>
                           <div>{formatNumber(thread.participantCount)} participants</div>
                           <div>Last active {formatRelativeTime(thread.lastActivityAt)}</div>
                         </div>
@@ -1208,8 +1394,21 @@ export default function WorkspacesPage() {
                           <div className="text-xs uppercase tracking-wide text-slate-400">Last activity</div>
                           <div>{formatRelativeTime(threadDetail.thread.lastActivityAt)}</div>
                         </div>
+                        <div>
+                          <div className="text-xs uppercase tracking-wide text-slate-400">Draft intent</div>
+                          <div>{threadDetail.thread.draftIntentType || 'No draft intent stored'}</div>
+                        </div>
                       </div>
                     </div>
+
+                    {threadDetail.thread.draftPayload ? (
+                      <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Draft payload</div>
+                        <pre className="mt-3 overflow-x-auto rounded-2xl bg-slate-950/95 p-4 text-xs leading-6 text-slate-100">
+                          {JSON.stringify(threadDetail.thread.draftPayload, null, 2)}
+                        </pre>
+                      </div>
+                    ) : null}
 
                     <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
                       <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Participants</div>
@@ -1274,7 +1473,7 @@ export default function WorkspacesPage() {
                       ) : (
                         <div className="mt-3 space-y-3">
                           <div className="text-sm text-slate-500 dark:text-slate-400">
-                            This thread is still internal or blocked. You can now approve and send a blocked handoff directly from the workspace control plane; once Beam accepts it, the full trace appears here.
+                            This thread is still internal or blocked. You can now approve and send a blocked handoff directly from the workspace control plane with its stored draft intent and payload; once Beam accepts it, the full trace appears here.
                           </div>
                           {threadDetail.thread.kind === 'handoff' && threadDetail.thread.status === 'blocked' ? (
                             <button

--- a/packages/directory/src/db-migrations.test.ts
+++ b/packages/directory/src/db-migrations.test.ts
@@ -396,6 +396,8 @@ test('createDatabase adds beam workspace control-plane tables to legacy database
 
     const threadColumns = db.prepare('PRAGMA table_info(workspace_threads)').all() as Array<{ name: string }>
     assert.ok(threadColumns.some((column) => column.name === 'kind'))
+    assert.ok(threadColumns.some((column) => column.name === 'draft_intent_type'))
+    assert.ok(threadColumns.some((column) => column.name === 'draft_payload_json'))
     assert.ok(threadColumns.some((column) => column.name === 'linked_intent_nonce'))
 
     const participantColumns = db.prepare('PRAGMA table_info(workspace_thread_participants)').all() as Array<{ name: string }>

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -271,6 +271,8 @@ function initSchema(db: DB): void {
       owner TEXT,
       status TEXT NOT NULL DEFAULT 'open' CHECK(status IN ('open', 'blocked', 'closed')),
       workflow_type TEXT,
+      draft_intent_type TEXT,
+      draft_payload_json TEXT,
       linked_intent_nonce TEXT,
       last_activity_at TEXT NOT NULL,
       created_at TEXT NOT NULL,
@@ -721,6 +723,8 @@ function initSchema(db: DB): void {
   ensureColumn(db, 'shield_audit_log', 'nonce', 'TEXT')
   db.exec('CREATE INDEX IF NOT EXISTS idx_shield_audit_nonce ON shield_audit_log(nonce)')
   ensureColumn(db, 'intent_log', 'result_json', 'TEXT')
+  ensureColumn(db, 'workspace_threads', 'draft_intent_type', 'TEXT')
+  ensureColumn(db, 'workspace_threads', 'draft_payload_json', 'TEXT')
 
   db.prepare(`
     UPDATE agents
@@ -1408,6 +1412,8 @@ export function createWorkspaceThread(
     owner?: string | null
     status?: WorkspaceThreadRow['status']
     workflowType?: string | null
+    draftIntentType?: string | null
+    draftPayloadJson?: string | null
     linkedIntentNonce?: string | null
     lastActivityAt?: string
   },
@@ -1422,11 +1428,13 @@ export function createWorkspaceThread(
       owner,
       status,
       workflow_type,
+      draft_intent_type,
+      draft_payload_json,
       linked_intent_nonce,
       last_activity_at,
       created_at,
       updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     input.workspaceId,
     input.kind,
@@ -1435,6 +1443,8 @@ export function createWorkspaceThread(
     input.owner ?? null,
     input.status ?? 'open',
     input.workflowType ?? null,
+    input.draftIntentType ?? null,
+    input.draftPayloadJson ?? null,
     input.linkedIntentNonce ?? null,
     input.lastActivityAt ?? now,
     now,
@@ -1458,6 +1468,8 @@ export function updateWorkspaceThread(
     owner?: string | null
     status?: WorkspaceThreadRow['status']
     workflowType?: string | null
+    draftIntentType?: string | null
+    draftPayloadJson?: string | null
     linkedIntentNonce?: string | null
     lastActivityAt?: string
   },
@@ -1475,6 +1487,8 @@ export function updateWorkspaceThread(
         owner = ?,
         status = ?,
         workflow_type = ?,
+        draft_intent_type = ?,
+        draft_payload_json = ?,
         linked_intent_nonce = ?,
         last_activity_at = ?,
         updated_at = ?
@@ -1485,6 +1499,8 @@ export function updateWorkspaceThread(
     input.owner === undefined ? existing.owner : input.owner,
     input.status ?? existing.status,
     input.workflowType === undefined ? existing.workflow_type : input.workflowType,
+    input.draftIntentType === undefined ? existing.draft_intent_type : input.draftIntentType,
+    input.draftPayloadJson === undefined ? existing.draft_payload_json : input.draftPayloadJson,
     input.linkedIntentNonce === undefined ? existing.linked_intent_nonce : input.linkedIntentNonce,
     input.lastActivityAt ?? existing.last_activity_at,
     updatedAt,

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -57,6 +57,7 @@ import { serializeAgentKeyState } from '../utils/serialize.js'
 import { evaluateWorkspacePolicy } from '../workspace-policy.js'
 import { RelayError, isAgentConnected, relayIntentFromHttp } from '../websocket.js'
 import { sendOperatorDigestEmail } from '../email.js'
+import { validateIntentPayload } from '../validation.js'
 
 const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
 const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'handoff'])
@@ -266,6 +267,8 @@ type SerializedWorkspaceThread = {
   owner: string | null
   status: WorkspaceThreadStatus
   workflowType: string | null
+  draftIntentType: string | null
+  draftPayload: Record<string, unknown> | null
   linkedIntentNonce: string | null
   lastActivityAt: string
   createdAt: string
@@ -300,6 +303,35 @@ type SerializedWorkspacePolicyPreview = {
 
 function normalizeOptionalString(value: unknown): string | null {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeOptionalObject(value: unknown, fieldName: string): Record<string, unknown> | null {
+  if (value == null) {
+    return null
+  }
+
+  if (!isRecord(value)) {
+    throw new Error(`${fieldName} must be an object`)
+  }
+
+  return value
+}
+
+function parseJsonObject(value: string | null): Record<string, unknown> | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
 }
 
 function slugify(value: string): string {
@@ -1091,6 +1123,8 @@ function serializeWorkspaceThread(
     owner: row.owner,
     status: row.status,
     workflowType: row.workflow_type,
+    draftIntentType: row.draft_intent_type,
+    draftPayload: parseJsonObject(row.draft_payload_json),
     linkedIntentNonce: row.linked_intent_nonce,
     lastActivityAt: row.last_activity_at,
     createdAt: row.created_at,
@@ -1761,6 +1795,16 @@ export function workspacesRouter(db: Database): Hono {
     }
 
     const workflowType = normalizeOptionalString(raw.workflowType)
+    const draftIntentType = normalizeOptionalString(raw.draftIntentType)
+    let draftPayload: Record<string, unknown> | null = null
+    try {
+      draftPayload = normalizeOptionalObject(raw.draftPayload, 'draftPayload')
+    } catch (err) {
+      return c.json({
+        error: err instanceof Error ? err.message : 'draftPayload must be an object',
+        errorCode: 'INVALID_DRAFT_PAYLOAD',
+      }, 400)
+    }
     const linkedIntentNonce = normalizeOptionalString(raw.linkedIntentNonce)
     if (kind === 'handoff' && !linkedIntentNonce && (status ?? 'open') !== 'blocked') {
       return c.json({ error: 'linkedIntentNonce is required for non-blocked handoff threads', errorCode: 'MISSING_THREAD_NONCE' }, 400)
@@ -1768,10 +1812,34 @@ export function workspacesRouter(db: Database): Hono {
     if (kind === 'internal' && linkedIntentNonce) {
       return c.json({ error: 'Internal threads cannot link directly to a Beam trace', errorCode: 'INTERNAL_THREAD_CANNOT_LINK_TRACE' }, 400)
     }
+    if (kind === 'internal' && (draftIntentType || draftPayload)) {
+      return c.json({ error: 'Internal threads cannot carry Beam intent drafts', errorCode: 'INTERNAL_THREAD_CANNOT_DRAFT_INTENT' }, 400)
+    }
+    if (draftPayload && !draftIntentType) {
+      return c.json({ error: 'draftIntentType is required when draftPayload is provided', errorCode: 'MISSING_DRAFT_INTENT_TYPE' }, 400)
+    }
+    if (kind === 'handoff' && !linkedIntentNonce && draftIntentType && !draftPayload) {
+      return c.json({ error: 'draftPayload is required when draftIntentType is provided for a blocked handoff thread', errorCode: 'MISSING_DRAFT_PAYLOAD' }, 400)
+    }
 
     const linkedIntent = linkedIntentNonce ? getIntentLogByNonce(db, linkedIntentNonce) : null
     if (linkedIntentNonce && !linkedIntent) {
       return c.json({ error: 'linkedIntentNonce was not found', errorCode: 'INTENT_NOT_FOUND' }, 404)
+    }
+    if (linkedIntent && draftIntentType && linkedIntent.intent_type !== draftIntentType) {
+      return c.json({
+        error: `draftIntentType ${draftIntentType} does not match linked trace intent ${linkedIntent.intent_type}`,
+        errorCode: 'DRAFT_INTENT_TRACE_MISMATCH',
+      }, 400)
+    }
+    if (draftIntentType && draftPayload) {
+      const payloadValidation = validateIntentPayload(draftIntentType, draftPayload)
+      if (!payloadValidation.valid) {
+        return c.json({
+          error: payloadValidation.error ?? 'Invalid draft payload',
+          errorCode: 'INVALID_DRAFT_PAYLOAD',
+        }, 400)
+      }
     }
 
     const rawParticipants = Array.isArray(raw.participants) ? raw.participants : []
@@ -1829,6 +1897,8 @@ export function workspacesRouter(db: Database): Hono {
         owner,
         status: status ?? 'open',
         workflowType,
+        draftIntentType,
+        draftPayloadJson: draftPayload ? JSON.stringify(draftPayload) : null,
         linkedIntentNonce,
         lastActivityAt: linkedIntent?.requested_at,
       })
@@ -1863,6 +1933,7 @@ export function workspacesRouter(db: Database): Hono {
         role: auth.session.role,
         kind: thread.kind,
         workflowType: thread.workflow_type,
+        draftIntentType: thread.draft_intent_type,
         linkedIntentNonce: thread.linked_intent_nonce,
         participants: participants.length,
       },
@@ -1972,12 +2043,104 @@ export function workspacesRouter(db: Database): Hono {
     }
 
     const fallbackMessage = thread.summary?.trim() || thread.title.trim()
-    const message = normalizeOptionalString(raw.message) ?? fallbackMessage
-    if (!message) {
-      return c.json({ error: 'A message is required to dispatch a handoff thread', errorCode: 'MISSING_HANDOFF_MESSAGE' }, 400)
+    const requestedIntentType = normalizeOptionalString(raw.intentType)
+    const effectiveIntentType = requestedIntentType ?? thread.draft_intent_type ?? 'conversation.message'
+    let requestedPayload: Record<string, unknown> | null = null
+    try {
+      requestedPayload = normalizeOptionalObject(raw.payload, 'payload')
+    } catch (err) {
+      return c.json({
+        error: err instanceof Error ? err.message : 'payload must be an object',
+        errorCode: 'INVALID_DISPATCH_PAYLOAD',
+      }, 400)
+    }
+    const storedDraftPayload = requestedIntentType && requestedIntentType !== thread.draft_intent_type
+      ? null
+      : parseJsonObject(thread.draft_payload_json)
+    const message = normalizeOptionalString(raw.message)
+    const language = normalizeOptionalString(raw.language)
+    let draftPayload = requestedPayload ?? storedDraftPayload
+    if (!draftPayload && effectiveIntentType === 'conversation.message') {
+      const conversationPayload = isRecord(storedDraftPayload) ? storedDraftPayload : {}
+      const resolvedMessage = message
+        ?? normalizeOptionalString(conversationPayload.message)
+        ?? fallbackMessage
+      if (!resolvedMessage) {
+        return c.json({ error: 'A message is required to dispatch a conversation.message handoff', errorCode: 'MISSING_HANDOFF_MESSAGE' }, 400)
+      }
+      draftPayload = {
+        ...conversationPayload,
+        message: resolvedMessage,
+        ...(language
+          ? { language }
+          : normalizeOptionalString(conversationPayload.language)
+            ? { language: normalizeOptionalString(conversationPayload.language) }
+            : {}),
+      }
     }
 
-    const language = normalizeOptionalString(raw.language)
+    if (!draftPayload) {
+      return c.json({
+        error: `A payload is required to dispatch intent ${effectiveIntentType}`,
+        errorCode: 'MISSING_DISPATCH_PAYLOAD',
+      }, 400)
+    }
+
+    const workspaceContext = {
+      workspace: {
+        id: workspace.id,
+        slug: workspace.slug,
+        name: workspace.name,
+      },
+      thread: {
+        id: thread.id,
+        title: thread.title,
+        summary: thread.summary,
+        workflowType: thread.workflow_type,
+        owner: thread.owner,
+      },
+      approval: {
+        action: 'workspace_thread_dispatch',
+        approvedBy: auth.session.email,
+        approvalRequired: policyPreview.approvalRequired,
+        approvers: policyPreview.approvers,
+      },
+      partnerChannel: {
+        id: partnerChannel.id,
+        label: partnerChannel.label,
+        status: partnerChannel.status,
+      },
+      participants: participants
+        .filter((participant) => participant.beam_id)
+        .map((participant) => ({
+          beamId: participant.beam_id,
+          role: participant.role,
+          principalType: participant.principal_type,
+        })),
+    }
+    const payload = effectiveIntentType === 'conversation.message'
+      ? {
+          ...draftPayload,
+          context: {
+            ...(isRecord(draftPayload.context) ? draftPayload.context : {}),
+            beam: workspaceContext,
+          },
+        }
+      : {
+          ...draftPayload,
+          beamContext: {
+            ...(isRecord(draftPayload.beamContext) ? draftPayload.beamContext : {}),
+            ...workspaceContext,
+          },
+        }
+    const payloadValidation = validateIntentPayload(effectiveIntentType, payload)
+    if (!payloadValidation.valid) {
+      return c.json({
+        error: payloadValidation.error ?? 'Invalid payload',
+        errorCode: 'INVALID_DISPATCH_PAYLOAD',
+      }, 400)
+    }
+
     const nonce = randomUUID()
     const timestamp = new Date().toISOString()
     const frame: IntentFrame = {
@@ -1986,43 +2149,8 @@ export function workspacesRouter(db: Database): Hono {
       timestamp,
       from: senderBinding.beam_id,
       to: partnerChannel.partner_beam_id,
-      intent: 'conversation.message',
-      payload: {
-        message,
-        ...(language ? { language } : {}),
-        context: {
-          workspace: {
-            id: workspace.id,
-            slug: workspace.slug,
-            name: workspace.name,
-          },
-          thread: {
-            id: thread.id,
-            title: thread.title,
-            summary: thread.summary,
-            workflowType: thread.workflow_type,
-            owner: thread.owner,
-          },
-          approval: {
-            action: 'workspace_thread_dispatch',
-            approvedBy: auth.session.email,
-            approvalRequired: policyPreview.approvalRequired,
-            approvers: policyPreview.approvers,
-          },
-          partnerChannel: {
-            id: partnerChannel.id,
-            label: partnerChannel.label,
-            status: partnerChannel.status,
-          },
-          participants: participants
-            .filter((participant) => participant.beam_id)
-            .map((participant) => ({
-              beamId: participant.beam_id,
-              role: participant.role,
-              principalType: participant.principal_type,
-            })),
-        },
-      },
+      intent: effectiveIntentType,
+      payload,
     }
 
     const finalizeDispatch = (result: {
@@ -2035,6 +2163,8 @@ export function workspacesRouter(db: Database): Hono {
       const updatedThread = updateWorkspaceThread(db, {
         id: thread.id,
         status: 'open',
+        draftIntentType: effectiveIntentType,
+        draftPayloadJson: JSON.stringify(draftPayload),
         linkedIntentNonce: result.nonce,
         lastActivityAt: now,
       })
@@ -2058,7 +2188,7 @@ export function workspacesRouter(db: Database): Hono {
           role: auth.session.role,
           linkedIntentNonce: result.nonce,
           workflowType: thread.workflow_type,
-          intentType: 'conversation.message',
+          intentType: effectiveIntentType,
           fromBeamId: senderBinding.beam_id,
           toBeamId: partnerChannel.partner_beam_id,
           partnerChannelId: partnerChannel.id,
@@ -2088,6 +2218,7 @@ export function workspacesRouter(db: Database): Hono {
           : null,
         dispatch: {
           nonce: result.nonce,
+          intentType: effectiveIntentType,
           success: result.success,
           error: result.error,
           errorCode: result.errorCode,

--- a/packages/directory/src/server.ts
+++ b/packages/directory/src/server.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto'
-import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Hono } from 'hono'
@@ -64,9 +63,9 @@ import { createRateLimitMiddleware } from './middleware/rate-limit.js'
 import { getReleaseInfo } from './release.js'
 import { sendOperatorDigestEmail } from './email.js'
 import type { AgentRow, AuditLogRow, IntentFrame, IntentTraceEventRow, OperatorNotificationRow } from './types.js'
+import { loadIntentCatalogDocument } from './validation.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const catalogPath = resolve(__dirname, '../../../intents/catalog.yaml')
 const serverStartedAt = Date.now()
 
 function nowMinusDays(days: number): string {
@@ -1430,12 +1429,7 @@ function serializeAgent(row: AgentRow, connectedSet: Set<string>): object {
 }
 
 function loadIntentCatalog(): unknown {
-  try {
-    const raw = readFileSync(catalogPath, 'utf8')
-    return JSON.parse(raw)
-  } catch {
-    return { intents: [] }
-  }
+  return loadIntentCatalogDocument()
 }
 
 function hasFederationAuth(c: Context): boolean {

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -238,6 +238,8 @@ export interface WorkspaceThreadRow {
   owner: string | null
   status: WorkspaceThreadStatus
   workflow_type: string | null
+  draft_intent_type: string | null
+  draft_payload_json: string | null
   linked_intent_nonce: string | null
   last_activity_at: string
   created_at: string

--- a/packages/directory/src/validation.ts
+++ b/packages/directory/src/validation.ts
@@ -5,20 +5,26 @@ import AjvImport, { type ValidateFunction } from 'ajv'
 
 export const BEAM_ID_RE = /^[a-z0-9_-]+@(?:[a-z0-9_-]+\.)?beam\.directory$/
 
-interface CatalogParamRule {
+export interface IntentCatalogParamRule {
   type?: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'integer'
   enum?: unknown[]
   required?: boolean
+  description?: string
+  default?: unknown
+  maxLength?: number
 }
 
-interface CatalogIntent {
+export interface IntentCatalogIntent {
   id: string
-  payload?: Record<string, CatalogParamRule>
-  params?: Record<string, CatalogParamRule>
+  description?: string
+  payload?: Record<string, IntentCatalogParamRule>
+  params?: Record<string, IntentCatalogParamRule>
+  response?: Record<string, IntentCatalogParamRule>
+  [key: string]: unknown
 }
 
-interface CatalogFile {
-  intents?: CatalogIntent[]
+export interface IntentCatalogFile {
+  intents?: IntentCatalogIntent[]
 }
 
 interface ValidationResult {
@@ -38,11 +44,11 @@ const AjvCtor = AjvImport as unknown as {
 const ajv = new AjvCtor({ allErrors: true, strict: false })
 const validators = new Map<string, ValidateFunction>()
 
-function loadCatalog(): CatalogIntent[] {
+function loadCatalog(): IntentCatalogIntent[] {
   for (const catalogPath of catalogPaths) {
     try {
       const raw = readFileSync(catalogPath, 'utf8')
-      const parsed = JSON.parse(raw) as CatalogFile
+      const parsed = JSON.parse(raw) as IntentCatalogFile
       const intents = Array.isArray(parsed.intents) ? parsed.intents : []
       if (intents.length > 0) {
         return intents
@@ -54,7 +60,13 @@ function loadCatalog(): CatalogIntent[] {
   return []
 }
 
-function buildIntentSchema(intent: CatalogIntent): Record<string, unknown> {
+export function loadIntentCatalogDocument(): IntentCatalogFile {
+  return {
+    intents: loadCatalog(),
+  }
+}
+
+function buildIntentSchema(intent: IntentCatalogIntent): Record<string, unknown> {
   const rules = intent.payload ?? intent.params ?? {}
   const properties: Record<string, Record<string, unknown>> = {}
   const required: string[] = []

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -743,6 +743,12 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
         owner: 'ops@example.com',
         workflowType: 'partner.review',
         status: 'blocked',
+        draftIntentType: 'task.delegate',
+        draftPayload: {
+          task: 'Confirm the approval lane and return the next operator action.',
+          context: 'Workspace-triggered cross-instance approval dispatch.',
+          priority: 'high',
+        },
         participants: [
           {
             principalId: 'ops-bot@beam.directory',
@@ -769,16 +775,14 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
         ...createAdminHeaders(db, 'ops@example.com', 'operator'),
         'content-type': 'application/json',
       },
-      body: JSON.stringify({
-        message: 'Show me how this cross-instance Beam handoff works.',
-        language: 'en',
-      }),
+      body: JSON.stringify({}),
     }))
     assert.equal(dispatchResponse.status, 200)
 
     const dispatchBody = await dispatchResponse.json() as {
       thread: {
         status: string
+        draftIntentType: string | null
         linkedIntentNonce: string | null
         trace: {
           intentType: string
@@ -792,6 +796,7 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
       } | null
       dispatch: {
         nonce: string
+        intentType: string
         success: boolean
         traceHref: string | null
       }
@@ -800,7 +805,9 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
     assert.equal(typeof dispatchBody.dispatch.nonce, 'string')
     assert.equal(dispatchBody.thread.status, 'open')
     assert.equal(dispatchBody.thread.linkedIntentNonce, dispatchBody.dispatch.nonce)
-    assert.equal(dispatchBody.thread.trace?.intentType, 'conversation.message')
+    assert.equal(dispatchBody.dispatch.intentType, 'task.delegate')
+    assert.equal(dispatchBody.thread.draftIntentType, 'task.delegate')
+    assert.equal(dispatchBody.thread.trace?.intentType, 'task.delegate')
     assert.equal(dispatchBody.thread.trace?.toBeamId, 'echo@beam.directory')
     assert.equal(dispatchBody.thread.trace?.status, 'acked')
     assert.equal(dispatchBody.partnerChannel?.lastIntentNonce, dispatchBody.dispatch.nonce)
@@ -812,10 +819,14 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
     assert.equal(detailResponse.status, 200)
     const detailBody = await detailResponse.json() as {
       thread: {
+        draftIntentType: string | null
+        draftPayload: Record<string, unknown> | null
         linkedIntentNonce: string | null
         trace: { nonce: string | null } | null
       }
     }
+    assert.equal(detailBody.thread.draftIntentType, 'task.delegate')
+    assert.equal(detailBody.thread.draftPayload?.['task'], 'Confirm the approval lane and return the next operator action.')
     assert.equal(detailBody.thread.linkedIntentNonce, dispatchBody.dispatch.nonce)
     assert.equal(detailBody.thread.trace?.nonce, dispatchBody.dispatch.nonce)
 


### PR DESCRIPTION
## Summary
- add draft intent type and payload persistence for workspace handoff threads
- expose the real intent catalog to the dashboard and support catalog-backed JSON payload drafting
- dispatch stored workspace handoff drafts through Beam with generic intent types and trace linkage

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/packages/directory run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build