### PR TITLE
Add workspace route-aware handoff targeting

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -30,6 +30,7 @@ The workspace foundation now adds these records to the directory:
 
 The current operator-facing surface now covers workspace creation, identity bindings, lifecycle state, partner channels, thread composition, timeline history, digest delivery, and policy previews.
 It also supports direct operator dispatch: a blocked handoff thread can now be approved and sent as a real Beam message from the workspace surface, without waiting for a separate runtime UI.
+Partner channels now also resolve back into the local control plane when the target Beam ID belongs to another Beam-managed workspace identity. That gives operators a real cross-workspace route instead of a raw external address.
 
 ## Why Beam Needs This
 
@@ -226,6 +227,8 @@ The dispatch route now sends the selected Beam intent, persists the draft on the
   "notes": "Primary finance route for invoice approvals."
 }
 ```
+
+When you fetch partner channels, each channel may now include a `workspaceRoute` block. This appears when the target `partnerBeamId` is also bound as a non-partner identity inside another Beam workspace. The dashboard uses that to surface "routes into workspace X" instead of showing only a bare Beam ID.
 
 ### Patch a workspace policy
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -199,6 +199,24 @@ export interface WorkspacePartnerChannel {
     trustScore: number | null
     lastSeen: string | null
   }
+  workspaceRoute: {
+    workspaceId: number
+    workspaceSlug: string
+    workspaceName: string
+    bindingId: number
+    bindingType: WorkspaceBindingType
+    bindingStatus: WorkspaceBindingStatus
+    displayName: string | null
+    runtimeType: string | null
+    runtime: {
+      mode: 'runtime-backed' | 'service' | 'partner' | 'manual'
+      connector: string | null
+      label: string | null
+      connected: boolean
+      httpEndpoint: string | null
+      deliveryMode: 'websocket' | 'http' | 'hybrid' | 'unavailable' | null
+    }
+  } | null
   trace: {
     nonce: string
     status: IntentLifecycleStatus

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -288,10 +288,49 @@ function renderBindingTransport(binding: WorkspaceIdentityBinding): string {
 
 function renderChannelMeta(channel: WorkspacePartnerChannel): string {
   return [
+    channel.workspaceRoute ? `Routes to ${channel.workspaceRoute.workspaceName}` : 'External lane',
     channel.owner ? `Owner ${channel.owner}` : 'No owner',
     channel.lastSuccessAt ? `Last success ${formatRelativeTime(channel.lastSuccessAt)}` : 'No successful handoff yet',
     channel.lastFailureAt ? `Last failure ${formatRelativeTime(channel.lastFailureAt)}` : 'No recent failures',
   ].join(' · ')
+}
+
+function renderPartnerChannelOptionLabel(channel: WorkspacePartnerChannel): string {
+  if (channel.workspaceRoute) {
+    return `${channel.workspaceRoute.workspaceName} · ${displayName(channel.workspaceRoute.displayName, channel.partnerBeamId)}`
+  }
+
+  return channel.label || channel.partnerBeamId
+}
+
+function sortPartnerChannelsForComposer(channels: WorkspacePartnerChannel[]): WorkspacePartnerChannel[] {
+  return [...channels].sort((left, right) => {
+    const leftRoute = left.workspaceRoute ? 0 : 1
+    const rightRoute = right.workspaceRoute ? 0 : 1
+    if (leftRoute !== rightRoute) {
+      return leftRoute - rightRoute
+    }
+
+    const statusOrder = (value: WorkspacePartnerChannelStatus) => {
+      switch (value) {
+        case 'active':
+          return 0
+        case 'trial':
+          return 1
+        case 'blocked':
+          return 2
+        default:
+          return 3
+      }
+    }
+
+    const statusDelta = statusOrder(left.status) - statusOrder(right.status)
+    if (statusDelta !== 0) {
+      return statusDelta
+    }
+
+    return renderPartnerChannelOptionLabel(left).localeCompare(renderPartnerChannelOptionLabel(right))
+  })
 }
 
 function buildPolicyDefaultsState(policy: WorkspacePolicyResponse | null) {
@@ -378,6 +417,26 @@ export default function WorkspacesPage() {
       ?? FALLBACK_CONVERSATION_INTENT,
     [defaultHandoffIntentId, intentCatalog, threadForm.draftIntentType],
   )
+  const availableHandoffChannels = useMemo(
+    () => sortPartnerChannelsForComposer(channels),
+    [channels],
+  )
+  const selectedPartnerChannel = useMemo(
+    () => channels.find((channel) => channel.id === Number.parseInt(threadForm.partnerChannelId, 10)) ?? null,
+    [channels, threadForm.partnerChannelId],
+  )
+  const threadDetailWorkspaceRoute = useMemo(() => {
+    if (!threadDetail) {
+      return null
+    }
+
+    const partnerBeamId = threadDetail.participants.find((participant) => participant.principalType === 'partner')?.beamId
+    if (!partnerBeamId) {
+      return null
+    }
+
+    return channels.find((channel) => channel.partnerBeamId === partnerBeamId)?.workspaceRoute ?? null
+  }, [channels, threadDetail])
 
   async function loadWorkspaces() {
     const response = await directoryApi.listWorkspaces()
@@ -1137,6 +1196,20 @@ export default function WorkspacesPage() {
                         <div>{formatNumber(channel.stats.recentFailures)} recent failures</div>
                       </div>
 
+                      {channel.workspaceRoute ? (
+                        <div className="mt-3 rounded-2xl border border-orange-200 bg-orange-50/70 px-4 py-3 text-sm text-slate-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-slate-200">
+                          <div className="font-medium text-slate-900 dark:text-slate-100">Local workspace route</div>
+                          <div className="mt-1">
+                            {channel.workspaceRoute.workspaceName} · {displayName(channel.workspaceRoute.displayName, channel.partnerBeamId)}
+                          </div>
+                          <div className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                            {channel.workspaceRoute.runtime.label || channel.workspaceRoute.runtime.mode}
+                            {channel.workspaceRoute.runtime.deliveryMode ? ` · ${channel.workspaceRoute.runtime.deliveryMode}` : ''}
+                            {channel.workspaceRoute.bindingStatus !== 'active' ? ` · binding ${channel.workspaceRoute.bindingStatus}` : ''}
+                          </div>
+                        </div>
+                      ) : null}
+
                       {channel.notes ? (
                         <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{channel.notes}</div>
                       ) : null}
@@ -1174,6 +1247,11 @@ export default function WorkspacesPage() {
                         {channel.trace ? (
                           <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-orange-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-orange-300 dark:hover:bg-slate-800" to={channel.trace.href}>
                             Open last trace
+                          </Link>
+                        ) : null}
+                        {channel.workspaceRoute ? (
+                          <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-orange-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-orange-300 dark:hover:bg-slate-800" to={`/workspaces?workspace=${encodeURIComponent(channel.workspaceRoute.workspaceSlug)}`}>
+                            Open target workspace
                           </Link>
                         ) : null}
                       </div>
@@ -1239,9 +1317,10 @@ export default function WorkspacesPage() {
                   <>
                     <select className="input-field" value={threadForm.partnerChannelId} onChange={(event) => setThreadForm((current) => ({ ...current, partnerChannelId: event.target.value }))}>
                       <option value="">Select partner channel</option>
-                      {channels.map((channel) => (
+                      {availableHandoffChannels.map((channel) => (
                         <option key={channel.id} value={channel.id}>
-                          {channel.label || channel.partnerBeamId}
+                          {renderPartnerChannelOptionLabel(channel)}
+                          {channel.status !== 'active' ? ` (${channel.status})` : ''}
                         </option>
                       ))}
                     </select>
@@ -1263,6 +1342,34 @@ export default function WorkspacesPage() {
                         </option>
                       ))}
                     </select>
+                    {selectedPartnerChannel ? (
+                      <div className="md:col-span-2 rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                        <div className="font-medium text-slate-900 dark:text-slate-100">
+                          {selectedPartnerChannel.workspaceRoute ? 'Cross-workspace target' : 'External partner target'}
+                        </div>
+                        <div className="mt-1">
+                          {selectedPartnerChannel.workspaceRoute
+                            ? `${selectedPartnerChannel.workspaceRoute.workspaceName} · ${displayName(selectedPartnerChannel.workspaceRoute.displayName, selectedPartnerChannel.partnerBeamId)}`
+                            : `${selectedPartnerChannel.label || displayName(selectedPartnerChannel.partner.displayName, selectedPartnerChannel.partnerBeamId)} · ${selectedPartnerChannel.partnerBeamId}`}
+                        </div>
+                        <div className="mt-2 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-3">
+                          <div>Channel {selectedPartnerChannel.status}</div>
+                          <div>Health {selectedPartnerChannel.healthStatus}</div>
+                          <div>
+                            {selectedPartnerChannel.workspaceRoute
+                              ? `${selectedPartnerChannel.workspaceRoute.runtime.label || selectedPartnerChannel.workspaceRoute.runtime.mode} · ${selectedPartnerChannel.workspaceRoute.runtime.deliveryMode || 'manual'}`
+                              : 'Partner-side runtime managed externally'}
+                          </div>
+                        </div>
+                        {selectedPartnerChannel.workspaceRoute ? (
+                          <div className="mt-3">
+                            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/workspaces?workspace=${encodeURIComponent(selectedPartnerChannel.workspaceRoute.workspaceSlug)}`}>
+                              Open target workspace
+                            </Link>
+                          </div>
+                        ) : null}
+                      </div>
+                    ) : null}
                     <div className="md:col-span-2 rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
                       <div className="font-medium text-slate-900 dark:text-slate-100">{selectedIntent.id}</div>
                       <div className="mt-1">{selectedIntent.description || 'No catalog description is available for this intent yet.'}</div>
@@ -1287,7 +1394,13 @@ export default function WorkspacesPage() {
                     <button
                       className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
                       type="button"
-                      disabled={actionBusy === 'thread-composer-create' || actionBusy === 'thread-composer-dispatch' || !threadForm.partnerChannelId || !threadForm.localBindingId}
+                      disabled={
+                        actionBusy === 'thread-composer-create'
+                        || actionBusy === 'thread-composer-dispatch'
+                        || !threadForm.partnerChannelId
+                        || !threadForm.localBindingId
+                        || selectedPartnerChannel?.status === 'blocked'
+                      }
                       onClick={() => { void handleThreadComposerSubmit('dispatch') }}
                     >
                       {actionBusy === 'thread-composer-dispatch'
@@ -1298,7 +1411,7 @@ export default function WorkspacesPage() {
                     </button>
                   ) : null}
                   <div className="text-xs text-slate-500 dark:text-slate-400">
-                    Handoff threads can stay blocked for review, link to an existing nonce, or send a catalog-backed Beam intent directly from this workspace surface.
+                    Handoff threads can stay blocked for review, link to an existing nonce, or send a catalog-backed Beam intent directly from this workspace surface. Cross-workspace routes now resolve local target workspaces when a partner channel points at another Beam-controlled identity.
                   </div>
                 </div>
               </form>
@@ -1398,6 +1511,12 @@ export default function WorkspacesPage() {
                           <div className="text-xs uppercase tracking-wide text-slate-400">Draft intent</div>
                           <div>{threadDetail.thread.draftIntentType || 'No draft intent stored'}</div>
                         </div>
+                        {threadDetailWorkspaceRoute ? (
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Target workspace</div>
+                            <div>{threadDetailWorkspaceRoute.workspaceName}</div>
+                          </div>
+                        ) : null}
                       </div>
                     </div>
 

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -1149,6 +1149,39 @@ export function listWorkspaceIdentityBindings(db: DB, workspaceId: number): Work
   `).all(workspaceId) as WorkspaceIdentityBindingRow[]
 }
 
+export function listWorkspaceIdentityBindingsByBeamId(
+  db: DB,
+  beamId: string,
+  options?: {
+    excludeWorkspaceId?: number
+  },
+): WorkspaceIdentityBindingRow[] {
+  const clauses = ['beam_id = ?']
+  const params: Array<number | string> = [beamId]
+
+  if (options?.excludeWorkspaceId != null) {
+    clauses.push('workspace_id != ?')
+    params.push(options.excludeWorkspaceId)
+  }
+
+  return db.prepare(`
+    SELECT *
+    FROM workspace_identity_bindings
+    WHERE ${clauses.join(' AND ')}
+    ORDER BY
+      CASE status
+        WHEN 'active' THEN 0
+        ELSE 1
+      END ASC,
+      CASE binding_type
+        WHEN 'partner' THEN 1
+        ELSE 0
+      END ASC,
+      workspace_id ASC,
+      id ASC
+  `).all(...params) as WorkspaceIdentityBindingRow[]
+}
+
 export function getWorkspacePartnerChannelById(db: DB, id: number): WorkspacePartnerChannelRow | null {
   const row = db.prepare(`
     SELECT *

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -11,6 +11,7 @@ import {
   getAgent,
   getIntentLogByNonce,
   getOrg,
+  getWorkspaceById,
   getWorkspaceBySlug,
   getWorkspaceIdentityBindingByBeamId,
   getWorkspaceIdentityBindingById,
@@ -21,6 +22,7 @@ import {
   getWorkspaceThreadById,
   listAgentKeys,
   listWorkspaceIdentityBindings,
+  listWorkspaceIdentityBindingsByBeamId,
   listWorkspacePartnerChannels,
   listWorkspaceThreadParticipants,
   listWorkspaceThreads,
@@ -162,6 +164,17 @@ type SerializedWorkspacePartnerChannel = {
     trustScore: number | null
     lastSeen: string | null
   }
+  workspaceRoute: {
+    workspaceId: number
+    workspaceSlug: string
+    workspaceName: string
+    bindingId: number
+    bindingType: WorkspaceIdentityBindingType
+    bindingStatus: WorkspaceIdentityBindingStatus
+    displayName: string | null
+    runtimeType: string | null
+    runtime: SerializedWorkspaceIdentityBinding['runtime']
+  } | null
   trace: {
     nonce: string
     status: IntentLogRow['status']
@@ -838,6 +851,42 @@ function classifyWorkspacePartnerChannelHealth(
   return 'healthy'
 }
 
+function resolveWorkspacePartnerRoute(
+  db: Database,
+  row: WorkspacePartnerChannelRow,
+): SerializedWorkspacePartnerChannel['workspaceRoute'] {
+  const routeBinding = listWorkspaceIdentityBindingsByBeamId(db, row.partner_beam_id, {
+    excludeWorkspaceId: row.workspace_id,
+  }).find((binding) => binding.binding_type !== 'partner')
+
+  if (!routeBinding) {
+    return null
+  }
+
+  const routeWorkspace = getWorkspaceById(db, routeBinding.workspace_id)
+  if (!routeWorkspace) {
+    return null
+  }
+
+  const routeIdentity = getAgent(db, routeBinding.beam_id)
+  const runtime = parseRuntimeMetadata(routeBinding.binding_type, routeBinding.runtime_type)
+
+  return {
+    workspaceId: routeWorkspace.id,
+    workspaceSlug: routeWorkspace.slug,
+    workspaceName: routeWorkspace.name,
+    bindingId: routeBinding.id,
+    bindingType: routeBinding.binding_type,
+    bindingStatus: routeBinding.status,
+    displayName: routeIdentity?.display_name ?? null,
+    runtimeType: routeBinding.runtime_type,
+    runtime: {
+      ...runtime,
+      connected: routeBinding.binding_type !== 'partner' && isAgentConnected(routeBinding.beam_id),
+    },
+  }
+}
+
 function serializeWorkspacePartnerChannel(
   db: Database,
   row: WorkspacePartnerChannelRow,
@@ -847,6 +896,7 @@ function serializeWorkspacePartnerChannel(
   const stats = countWorkspacePartnerTraffic(db, localBeamIds, row.partner_beam_id)
   const healthStatus = classifyWorkspacePartnerChannelHealth(row, stats)
   const trace = row.last_intent_nonce ? getIntentLogByNonce(db, row.last_intent_nonce) : null
+  const workspaceRoute = resolveWorkspacePartnerRoute(db, row)
 
   return {
     id: row.id,
@@ -871,6 +921,7 @@ function serializeWorkspacePartnerChannel(
       trustScore: partner?.trust_score ?? null,
       lastSeen: partner?.last_seen ?? null,
     },
+    workspaceRoute,
     trace: trace ? {
       nonce: trace.nonce,
       status: trace.status,

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -859,6 +859,13 @@ test('workspace partner channels, timeline, and digest expose operator-ready con
       publicKey: 'MCowBQYDK2VwAyEAw2QJY0YH7e1L2+2VQ1bH4TqL6wCnC8n9v8m8z4vPsxM=',
       personal: true,
     })
+    registerAgent(db, {
+      beamId: 'finance@northwind.beam.directory',
+      displayName: 'Northwind Finance Bot',
+      capabilities: ['invoice.review'],
+      publicKey: 'MCowBQYDK2VwAyEA3n3d9X0+uB4bSv9C0L+QW6T8wdkM3Vn2QJw1bE8W2dQ=',
+      personal: false,
+    })
 
     const app = createApp(db)
     const adminHeaders = {
@@ -873,6 +880,28 @@ test('workspace partner channels, timeline, and digest expose operator-ready con
         name: 'Acme Finance',
         slug: 'acme-finance',
         externalHandoffsEnabled: true,
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Northwind Runtime',
+        slug: 'northwind-runtime',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces/northwind-runtime/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'finance@northwind.beam.directory',
+        bindingType: 'agent',
+        owner: 'northwind@example.com',
+        runtimeType: 'codex:finance',
+        canInitiateExternal: true,
       }),
     }))
 
@@ -969,11 +998,21 @@ test('workspace partner channels, timeline, and digest expose operator-ready con
       channels: Array<{
         status: string
         healthStatus: string
+        workspaceRoute: {
+          workspaceSlug: string
+          workspaceName: string
+          runtime: {
+            mode: string
+          }
+        } | null
       }>
     }
     assert.equal(channelsListBody.total, 1)
     assert.equal(channelsListBody.channels[0]?.status, 'blocked')
     assert.equal(channelsListBody.channels[0]?.healthStatus, 'critical')
+    assert.equal(channelsListBody.channels[0]?.workspaceRoute?.workspaceSlug, 'northwind-runtime')
+    assert.equal(channelsListBody.channels[0]?.workspaceRoute?.workspaceName, 'Northwind Runtime')
+    assert.equal(channelsListBody.channels[0]?.workspaceRoute?.runtime.mode, 'runtime-backed')
 
     const timelineResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-finance/timeline?limit=20', {
       headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),


### PR DESCRIPTION
## Summary
- resolve workspace partner channels back to local Beam-managed workspace identities when possible
- surface local workspace routes in partner channel cards and the workspace handoff composer
- add API and test coverage for route-aware cross-workspace targeting

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/packages/dashboard run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e