### PR TITLE
Sync routed workspace handoffs across local workspaces

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -216,6 +216,9 @@ The dispatch route now sends the selected Beam intent, persists the draft on the
 - under `payload.context.beam` for `conversation.message`
 - under `payload.beamContext` for all other intents
 
+If the selected partner channel resolves to another local Beam-managed workspace identity, dispatch also mirrors the handoff into that target workspace as an inbound thread. The dispatch response then includes a `workspaceSync` block with the target workspace slug and thread id.
+That local routed handoff runs under workspace policy, so operators do not need to duplicate the same trust edge again as a separate low-level intent ACL between the two local identities.
+
 ### Create a partner channel
 
 ```json

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -416,6 +416,16 @@ export interface WorkspaceThreadDispatchResponse extends WorkspaceThreadDetailRe
     errorCode: string | null
     traceHref: string | null
   }
+  workspaceSync: {
+    workspaceId: number
+    workspaceSlug: string
+    workspaceName: string
+    threadId: number
+    threadHref: string
+    bindingId: number
+    beamId: string
+    disposition: 'created' | 'updated'
+  } | null
 }
 
 export interface WorkspacePolicyBindingRule {

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -828,6 +828,9 @@ export default function WorkspacesPage() {
         noticeMessage = dispatchResponse.dispatch.success
           ? 'Workspace handoff dispatched through Beam.'
           : `Workspace handoff dispatched with a failed Beam response${dispatchResponse.dispatch.errorCode ? ` (${dispatchResponse.dispatch.errorCode})` : ''}.`
+        if (dispatchResponse.workspaceSync) {
+          noticeMessage += ` Synced to ${dispatchResponse.workspaceSync.workspaceName}.`
+        }
       } else if (mode === 'dispatch' && linkedIntentNonce) {
         noticeMessage = 'Workspace thread linked to an existing Beam trace.'
       }
@@ -884,6 +887,10 @@ export default function WorkspacesPage() {
           ? 'Workspace handoff dispatched through Beam.'
           : `Workspace handoff dispatched with a failed Beam response${response.dispatch.errorCode ? ` (${response.dispatch.errorCode})` : ''}.`,
       )
+      if (response.workspaceSync) {
+        const syncedWorkspaceName = response.workspaceSync.workspaceName
+        setNotice((current) => `${current ?? 'Workspace handoff dispatched through Beam.'} Synced to ${syncedWorkspaceName}.`)
+      }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Workspace handoff dispatch failed')
     } finally {

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -1426,6 +1426,22 @@ export function getWorkspaceThreadById(db: DB, id: number): WorkspaceThreadRow |
   return row ?? null
 }
 
+export function getWorkspaceThreadByLinkedIntentNonce(
+  db: DB,
+  workspaceId: number,
+  linkedIntentNonce: string,
+): WorkspaceThreadRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM workspace_threads
+    WHERE workspace_id = ? AND linked_intent_nonce = ?
+    ORDER BY id ASC
+    LIMIT 1
+  `).get(workspaceId, linkedIntentNonce) as WorkspaceThreadRow | undefined
+
+  return row ?? null
+}
+
 export function listWorkspaceThreads(db: DB, workspaceId: number): WorkspaceThreadRow[] {
   return db.prepare(`
     SELECT *

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -20,6 +20,7 @@ import {
   getWorkspacePolicyDocument,
   getWorkspaceSummary,
   getWorkspaceThreadById,
+  getWorkspaceThreadByLinkedIntentNonce,
   listAgentKeys,
   listWorkspaceIdentityBindings,
   listWorkspaceIdentityBindingsByBeamId,
@@ -185,6 +186,17 @@ type SerializedWorkspacePartnerChannel = {
     href: string
   } | null
 }
+
+type SerializedWorkspaceThreadSync = {
+  workspaceId: number
+  workspaceSlug: string
+  workspaceName: string
+  threadId: number
+  threadHref: string
+  bindingId: number
+  beamId: string
+  disposition: 'created' | 'updated'
+} | null
 
 type WorkspaceTimelineEntry = {
   id: number
@@ -663,6 +675,8 @@ function summarizeWorkspaceAuditAction(action: string, details: Record<string, u
       return 'Workspace thread created.'
     case 'admin.workspace_thread.dispatched':
       return 'Workspace handoff dispatched.'
+    case 'admin.workspace_thread.synced':
+      return 'Inbound workspace handoff synced.'
     case 'admin.workspace_partner_channel.created':
       return 'Partner channel added.'
     case 'admin.workspace_partner_channel.updated':
@@ -1193,6 +1207,125 @@ function serializeWorkspaceThread(
       errorCode: intent.error_code,
       href: `/intents/${encodeURIComponent(intent.nonce)}`,
     } : null,
+  }
+}
+
+function syncRoutedWorkspaceThread(
+  db: Database,
+  input: {
+    actor: string
+    actorRole: 'admin' | 'operator' | 'viewer'
+    sourceWorkspace: WorkspaceRow
+    sourceThread: WorkspaceThreadRow
+    sourceSenderBinding: WorkspaceIdentityBindingRow
+    partnerChannel: WorkspacePartnerChannelRow
+    linkedIntentNonce: string
+    intentType: string
+    draftPayload: Record<string, unknown>
+  },
+): SerializedWorkspaceThreadSync {
+  const targetRoute = resolveWorkspacePartnerRoute(db, input.partnerChannel)
+  if (!targetRoute) {
+    return null
+  }
+
+  const targetWorkspace = getWorkspaceById(db, targetRoute.workspaceId)
+  if (!targetWorkspace) {
+    return null
+  }
+
+  const targetBinding = getWorkspaceIdentityBindingById(db, targetRoute.bindingId)
+  if (!targetBinding || targetBinding.workspace_id !== targetWorkspace.id || targetBinding.binding_type === 'partner') {
+    return null
+  }
+
+  const existingThread = getWorkspaceThreadByLinkedIntentNonce(db, targetWorkspace.id, input.linkedIntentNonce)
+  const now = new Date().toISOString()
+  const targetOwner = targetBinding.owner ?? null
+  const syncedSummary = input.sourceThread.summary?.trim() || `Inbound handoff from ${input.sourceWorkspace.name}.`
+
+  const syncedThread = existingThread
+    ? updateWorkspaceThread(db, {
+        id: existingThread.id,
+        title: input.sourceThread.title,
+        summary: syncedSummary,
+        owner: targetOwner,
+        status: 'open',
+        workflowType: input.sourceThread.workflow_type,
+        draftIntentType: input.intentType,
+        draftPayloadJson: JSON.stringify(input.draftPayload),
+        linkedIntentNonce: input.linkedIntentNonce,
+        lastActivityAt: now,
+      })
+    : createWorkspaceThread(db, {
+        workspaceId: targetWorkspace.id,
+        kind: 'handoff',
+        title: input.sourceThread.title,
+        summary: syncedSummary,
+        owner: targetOwner,
+        status: 'open',
+        workflowType: input.sourceThread.workflow_type,
+        draftIntentType: input.intentType,
+        draftPayloadJson: JSON.stringify(input.draftPayload),
+        linkedIntentNonce: input.linkedIntentNonce,
+        lastActivityAt: now,
+      })
+
+  if (!syncedThread) {
+    return null
+  }
+
+  if (!existingThread) {
+    const sourceIdentity = getAgent(db, input.sourceSenderBinding.beam_id)
+    const targetIdentity = getAgent(db, targetBinding.beam_id)
+
+    createWorkspaceThreadParticipant(db, {
+      threadId: syncedThread.id,
+      principalId: targetBinding.beam_id,
+      principalType: targetBinding.binding_type === 'service' ? 'service' : 'agent',
+      displayName: targetIdentity?.display_name ?? targetBinding.beam_id,
+      beamId: targetBinding.beam_id,
+      workspaceBindingId: targetBinding.id,
+      role: targetOwner ? 'owner' : 'participant',
+    })
+
+    createWorkspaceThreadParticipant(db, {
+      threadId: syncedThread.id,
+      principalId: input.sourceSenderBinding.beam_id,
+      principalType: 'partner',
+      displayName: sourceIdentity?.display_name ?? input.sourceWorkspace.name,
+      beamId: input.sourceSenderBinding.beam_id,
+      role: 'participant',
+    })
+  }
+
+  logAuditEvent(db, {
+    action: 'admin.workspace_thread.synced',
+    actor: input.actor,
+    target: `${targetWorkspace.slug}:${syncedThread.id}`,
+    details: {
+      role: input.actorRole,
+      linkedIntentNonce: input.linkedIntentNonce,
+      intentType: input.intentType,
+      workflowType: input.sourceThread.workflow_type,
+      sourceWorkspaceSlug: input.sourceWorkspace.slug,
+      sourceWorkspaceName: input.sourceWorkspace.name,
+      sourceThreadId: input.sourceThread.id,
+      fromBeamId: input.sourceSenderBinding.beam_id,
+      toBeamId: input.partnerChannel.partner_beam_id,
+      disposition: existingThread ? 'updated' : 'created',
+    },
+  })
+
+  return {
+    workspaceId: targetWorkspace.id,
+    workspaceSlug: targetWorkspace.slug,
+    workspaceName: targetWorkspace.name,
+    threadId: syncedThread.id,
+    threadHref: `/workspaces?workspace=${encodeURIComponent(targetWorkspace.slug)}&thread=${encodeURIComponent(String(syncedThread.id))}`,
+    bindingId: targetBinding.id,
+    beamId: targetBinding.beam_id,
+    disposition: existingThread ? 'updated' : 'created',
   }
 }
 
@@ -2231,6 +2364,23 @@ export function workspacesRouter(db: Database): Hono {
           : { lastFailureAt: now }),
       })
 
+      let workspaceSync: SerializedWorkspaceThreadSync = null
+      try {
+        workspaceSync = syncRoutedWorkspaceThread(db, {
+          actor: auth.session.email,
+          actorRole: auth.session.role,
+          sourceWorkspace: workspace,
+          sourceThread: thread,
+          sourceSenderBinding: senderBinding,
+          partnerChannel,
+          linkedIntentNonce: result.nonce,
+          intentType: effectiveIntentType,
+          draftPayload,
+        })
+      } catch (err) {
+        console.error('Workspace route sync error:', err)
+      }
+
       logAuditEvent(db, {
         action: 'admin.workspace_thread.dispatched',
         actor: auth.session.email,
@@ -2247,6 +2397,8 @@ export function workspacesRouter(db: Database): Hono {
           approvers: policyPreview.approvers,
           success: result.success,
           errorCode: result.errorCode,
+          workspaceSyncSlug: workspaceSync?.workspaceSlug ?? null,
+          workspaceSyncThreadId: workspaceSync?.threadId ?? null,
         },
       })
 
@@ -2275,12 +2427,15 @@ export function workspacesRouter(db: Database): Hono {
           errorCode: result.errorCode,
           traceHref: `/intents/${encodeURIComponent(result.nonce)}`,
         },
+        workspaceSync,
       })
     }
 
     try {
+      const workspaceRoute = resolveWorkspacePartnerRoute(db, partnerChannel)
       const result = await relayIntentFromHttp(db, frame, 60_000, {
         trustedControlPlane: true,
+        skipLocalAclCheck: workspaceRoute != null,
       })
 
       return finalizeDispatch({

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -746,6 +746,7 @@ export async function relayIntentFromHttp(
     sourceDirectory?: string
     hopCount?: number
     trustedControlPlane?: boolean
+    skipLocalAclCheck?: boolean
   } = {},
 ): Promise<ResultFrame> {
   const prepared = normalizeAndValidateFrame(frame)
@@ -766,6 +767,7 @@ export async function relayIntentFromHttp(
   try {
     enforceSecurityChecks(db, prepared, senderPublicKey, {
       skipSignatureVerification: options.trustedControlPlane === true,
+      skipLocalAclCheck: options.skipLocalAclCheck === true,
     })
     recordShieldDecision(db, prepared, { timestamp: prepared.timestamp })
   } catch (err) {
@@ -1435,7 +1437,7 @@ function enforceSecurityChecks(
   db: Database,
   frame: IntentFrame,
   senderPublicKey: string,
-  options: { skipSignatureVerification?: boolean } = {},
+  options: { skipSignatureVerification?: boolean; skipLocalAclCheck?: boolean } = {},
 ): void {
   if (!checkAgentRateLimit(frame.from, getRateLimitPerMinute())) {
     throw new RelayError('RATE_LIMITED', `Rate limit exceeded for ${frame.from}`)
@@ -1446,7 +1448,7 @@ function enforceSecurityChecks(
   }
 
   const localTarget = getAgent(db, frame.to)
-  if (localTarget && !isIntentAllowed(db, {
+  if (localTarget && !options.skipLocalAclCheck && !isIntentAllowed(db, {
     targetBeamId: frame.to,
     intentType: frame.intent,
     fromBeamId: frame.from,

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -847,6 +847,217 @@ test('operators can approve and dispatch blocked workspace handoff threads throu
   }
 })
 
+test('dispatching through a routed partner channel syncs an inbound thread into the target workspace', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['handoff'],
+      publicKey: 'MCowBQYDK2VwAyEA5vDJ0M7W0h6lJ6uQ0P+GlVj9s4m1kzJ3aPj4v5n2u7o=',
+      personal: true,
+    })
+    registerAgent(db, {
+      beamId: 'echo@beam.directory',
+      displayName: 'Beam Echo',
+      capabilities: ['conversation.message'],
+      publicKey: 'MCowBQYDK2VwAyEAwq0kQ4gJ9J5fWfT3vA7l0v3mQ9Jw1d1lR2z6b8x7lQk=',
+      personal: false,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Acme Dispatch Workspace',
+        slug: 'acme-dispatch-sync',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Northwind Runtime',
+        slug: 'northwind-runtime-sync',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    const localBindingResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch-sync/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex:operator',
+        policyProfile: 'ops-default',
+        canInitiateExternal: true,
+      }),
+    }))
+    const localBinding = await localBindingResponse.json() as { binding: { id: number } }
+
+    const targetBindingResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-runtime-sync/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'echo@beam.directory',
+        bindingType: 'service',
+        owner: 'northwind@example.com',
+        runtimeType: 'builtin:echo',
+        canInitiateExternal: true,
+      }),
+    }))
+    const targetBinding = await targetBindingResponse.json() as { binding: { id: number } }
+
+    const policyResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch-sync/policy', {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        workflowRules: [{
+          workflowType: 'partner.review',
+          requireApproval: true,
+          allowedPartners: ['echo@beam.directory'],
+          approvers: ['ops@example.com'],
+        }],
+      }),
+    }))
+    assert.equal(policyResponse.status, 200)
+
+    const channelResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch-sync/partner-channels', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        partnerBeamId: 'echo@beam.directory',
+        label: 'Northwind Echo',
+        owner: 'ops@example.com',
+        status: 'active',
+      }),
+    }))
+    assert.equal(channelResponse.status, 201)
+
+    const createThreadResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-dispatch-sync/threads', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Sync this handoff into the routed workspace',
+        summary: 'The target workspace should receive an inbound mirrored thread.',
+        owner: 'ops@example.com',
+        workflowType: 'partner.review',
+        status: 'blocked',
+        draftIntentType: 'conversation.message',
+        draftPayload: {
+          message: 'Please confirm the inbound thread sync path.',
+          language: 'en',
+        },
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: localBinding.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'echo@beam.directory',
+            principalType: 'partner',
+            beamId: 'echo@beam.directory',
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+    assert.equal(createThreadResponse.status, 201)
+    const createdThread = await createThreadResponse.json() as { thread: { id: number } }
+
+    const dispatchResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-dispatch-sync/threads/${createdThread.thread.id}/dispatch`, {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    }))
+    assert.equal(dispatchResponse.status, 200)
+
+    const dispatchBody = await dispatchResponse.json() as {
+      dispatch: {
+        nonce: string
+        success: boolean
+      }
+      workspaceSync: {
+        workspaceSlug: string
+        workspaceName: string
+        threadId: number
+        disposition: string
+      } | null
+    }
+    assert.equal(dispatchBody.dispatch.success, true)
+    assert.equal(dispatchBody.workspaceSync?.workspaceSlug, 'northwind-runtime-sync')
+    assert.equal(dispatchBody.workspaceSync?.workspaceName, 'Northwind Runtime')
+    assert.equal(dispatchBody.workspaceSync?.disposition, 'created')
+
+    const targetThreadResponse = await app.request(new Request(`http://localhost/admin/workspaces/northwind-runtime-sync/threads/${dispatchBody.workspaceSync?.threadId}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(targetThreadResponse.status, 200)
+    const targetThreadBody = await targetThreadResponse.json() as {
+      thread: {
+        kind: string
+        linkedIntentNonce: string | null
+        draftIntentType: string | null
+        owner: string | null
+      }
+      participants: Array<{
+        beamId: string | null
+        workspaceBindingId: number | null
+        principalType: string
+      }>
+    }
+    assert.equal(targetThreadBody.thread.kind, 'handoff')
+    assert.equal(targetThreadBody.thread.linkedIntentNonce, dispatchBody.dispatch.nonce)
+    assert.equal(targetThreadBody.thread.draftIntentType, 'conversation.message')
+    assert.equal(targetThreadBody.thread.owner, 'northwind@example.com')
+    assert.ok(targetThreadBody.participants.some((participant) => participant.beamId === 'ops-bot@beam.directory' && participant.principalType === 'partner'))
+    assert.ok(targetThreadBody.participants.some((participant) => participant.beamId === 'echo@beam.directory' && participant.workspaceBindingId === targetBinding.binding.id))
+
+    const targetTimelineResponse = await app.request(new Request('http://localhost/admin/workspaces/northwind-runtime-sync/timeline?limit=20', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(targetTimelineResponse.status, 200)
+    const targetTimelineBody = await targetTimelineResponse.json() as {
+      entries: Array<{
+        action: string
+        traceHref: string | null
+      }>
+    }
+    const syncEntry = targetTimelineBody.entries.find((entry) => entry.action === 'admin.workspace_thread.synced')
+    assert.equal(syncEntry?.traceHref, `/intents/${dispatchBody.dispatch.nonce}`)
+  } finally {
+    db.close()
+  }
+})
+
 test('workspace partner channels, timeline, and digest expose operator-ready control-plane state', async () => {
   const db = createDatabase(':memory:')
 


### PR DESCRIPTION
## Summary
- mirror routed partner-channel dispatches into the target local workspace as inbound handoff threads
- let trusted workspace-routed dispatches use workspace policy without duplicating a low-level local ACL edge
- surface workspace sync metadata in the dashboard and cover the flow with a cross-workspace dispatch test

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/packages/directory run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/packages/dashboard run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e