### PR TITLE
Add workspace identity control

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -31,6 +31,7 @@ The workspace foundation now adds these records to the directory:
 The current operator-facing surface now covers workspace creation, identity bindings, lifecycle state, partner channels, thread composition, timeline history, digest delivery, and policy previews.
 It also supports direct operator dispatch: a blocked handoff thread can now be approved and sent as a real Beam message from the workspace surface, without waiting for a separate runtime UI.
 Partner channels now also resolve back into the local control plane when the target Beam ID belongs to another Beam-managed workspace identity. That gives operators a real cross-workspace route instead of a raw external address.
+Each local identity card now also exposes the explicit Beam DID, key history, a one-time local credential reissue flow, and a per-agent partner-control override. That makes it practical to bind imported OpenClaw agents, hand them a Beam identity bundle, and keep partner policy close to the specific agent that is allowed to speak externally.
 
 ## Fast local sync demo
 
@@ -186,6 +187,8 @@ The first routes are all admin-authenticated and now include the controls requir
 - `GET /admin/workspaces/:slug/identities`
 - `POST /admin/workspaces/:slug/identities`
 - `PATCH /admin/workspaces/:slug/identities/:id`
+- `PATCH /admin/workspaces/:slug/identities/:id/policy`
+- `POST /admin/workspaces/:slug/identities/:id/reissue-local-credential`
 - `GET /admin/workspaces/:slug/threads`
 - `GET /admin/workspaces/:slug/threads/:id`
 - `POST /admin/workspaces/:slug/threads`
@@ -223,6 +226,42 @@ The first routes are all admin-authenticated and now include the controls requir
   "defaultThreadScope": "internal",
   "canInitiateExternal": true,
   "notes": "Primary internal operator agent."
+}
+```
+
+### Reissue a one-time local credential bundle
+
+Use this when a local runtime or imported OpenClaw agent needs a fresh Beam identity file, API key, and signing keypair.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <admin-session-token>" \
+  http://localhost:43100/admin/workspaces/openclaw-local/identities/12/reissue-local-credential
+```
+
+The response includes:
+
+- `beamId`
+- `did`
+- `apiKey`
+- `publicKey`
+- `privateKey`
+- `directoryUrl`
+- URLs for DID resolution, agent detail, and key history
+
+This bundle is returned only at issuance time, so copy or download it immediately from the dashboard.
+
+### Add a per-agent partner override
+
+Use this when one workspace identity should have a tighter or looser outbound policy than the workspace default.
+
+```json
+{
+  "externalInitiation": "allow",
+  "allowedPartners": [
+    "finance@northwind.beam.directory",
+    "*@partner.beam.directory"
+  ]
 }
 ```
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -155,6 +155,12 @@ export interface WorkspaceIdentityBinding {
   identity: {
     existsLocally: boolean
     beamId: string
+    did: {
+      id: string
+      resolutionUrl: string
+      agentUrl: string
+      keysUrl: string
+    }
     displayName: string | null
     org: string | null
     personal: boolean
@@ -162,7 +168,40 @@ export interface WorkspaceIdentityBinding {
     trustScore: number | null
     lastSeen: string | null
     capabilities: string[]
-    keyState: object | null
+    keyState: {
+      active: {
+        id: number
+        beamId: string
+        publicKey: string
+        createdAt: number
+        revokedAt: number | null
+        status: 'active' | 'revoked'
+      } | null
+      revoked: Array<{
+        id: number
+        beamId: string
+        publicKey: string
+        createdAt: number
+        revokedAt: number | null
+        status: 'active' | 'revoked'
+      }>
+      keys: Array<{
+        id: number
+        beamId: string
+        publicKey: string
+        createdAt: number
+        revokedAt: number | null
+        status: 'active' | 'revoked'
+      }>
+      total: number
+    } | null
+  }
+  workspacePolicy: {
+    effective: WorkspacePolicyPreview
+    bindingRule: {
+      externalInitiation: WorkspacePolicyRuleExternalInitiation
+      allowedPartners: string[]
+    } | null
   }
 }
 
@@ -495,6 +534,49 @@ export interface WorkspaceIdentityPatchInput {
   canInitiateExternal?: boolean
   status?: WorkspaceBindingStatus
   notes?: string | null
+}
+
+export interface WorkspaceIdentityPolicyPatchInput {
+  externalInitiation?: WorkspacePolicyRuleExternalInitiation
+  allowedPartners?: string[]
+}
+
+export interface WorkspaceIdentityPolicyResponse {
+  workspace: WorkspaceRecord
+  updatedAt: string | null
+  updatedBy: string | null
+  rule: {
+    beamId: string | null
+    bindingType: WorkspaceBindingType | null
+    policyProfile: string | null
+    externalInitiation: WorkspacePolicyRuleExternalInitiation
+    allowedPartners: string[]
+  } | null
+  preview: WorkspacePolicyPreview
+  binding: WorkspaceIdentityBinding
+}
+
+export interface WorkspaceIdentityCredentialBundle {
+  format: 'beam-local-identity/v1'
+  beamId: string
+  did: string
+  displayName: string | null
+  workspaceSlug: string
+  directoryUrl: string
+  generatedAt: string
+  publicKey: string
+  privateKey: string
+  apiKey: string
+  urls: {
+    didResolution: string
+    agent: string
+    keys: string
+  }
+}
+
+export interface WorkspaceIdentityReissueResponse {
+  binding: WorkspaceIdentityBinding
+  credential: WorkspaceIdentityCredentialBundle
 }
 
 export interface WorkspacePartnerChannelCreateInput {
@@ -1821,6 +1903,13 @@ export const directoryApi = {
   updateWorkspaceIdentity: (slug: string, id: number, input: WorkspaceIdentityPatchInput) => request<{ binding: WorkspaceIdentityBinding }>(`/admin/workspaces/${encodeURIComponent(slug)}/identities/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(input),
+  }, { admin: true }),
+  updateWorkspaceIdentityPolicy: (slug: string, id: number, input: WorkspaceIdentityPolicyPatchInput) => request<WorkspaceIdentityPolicyResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/identities/${id}/policy`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  reissueWorkspaceIdentityCredential: (slug: string, id: number) => request<WorkspaceIdentityReissueResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/identities/${id}/reissue-local-credential`, {
+    method: 'POST',
   }, { admin: true }),
   listWorkspacePartnerChannels: (slug: string) => request<WorkspacePartnerChannelsResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/partner-channels`, undefined, { admin: true }),
   createWorkspacePartnerChannel: (slug: string, input: WorkspacePartnerChannelCreateInput) => request<{ channel: WorkspacePartnerChannel }>(`/admin/workspaces/${encodeURIComponent(slug)}/partner-channels`, {

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -10,6 +10,7 @@ import {
   type WorkspaceDigestActionItem,
   type WorkspaceDigestResponse,
   type WorkspaceIdentityBinding,
+  type WorkspaceIdentityCredentialBundle,
   type WorkspaceIdentityLifecycleStatus,
   type WorkspaceOverviewAttentionCode,
   type WorkspaceOverviewAttentionItem,
@@ -18,6 +19,7 @@ import {
   type WorkspacePartnerChannelHealth,
   type WorkspacePartnerChannelStatus,
   type WorkspacePolicyResponse,
+  type WorkspacePolicyRuleExternalInitiation,
   type WorkspaceRecord,
   type WorkspaceStatus,
   type WorkspaceThread,
@@ -177,6 +179,32 @@ function parseCsvList(value: string): string[] {
 
 function summarizeList(values: string[], fallback: string): string {
   return values.length > 0 ? values.join(', ') : fallback
+}
+
+function summarizeKeyState(binding: WorkspaceIdentityBinding): string {
+  const keyState = binding.identity.keyState
+  if (!keyState) {
+    return binding.identity.existsLocally ? 'No key history recorded yet' : 'No local key material'
+  }
+
+  const active = keyState.active ? '1 active key' : 'No active key'
+  const revoked = keyState.revoked.length > 0 ? `${keyState.revoked.length} revoked` : '0 revoked'
+  return `${active} · ${revoked}`
+}
+
+function createBindingPolicyDraft(binding: WorkspaceIdentityBinding): {
+  externalInitiation: WorkspacePolicyRuleExternalInitiation
+  allowedPartners: string
+} {
+  return {
+    externalInitiation: binding.workspacePolicy.bindingRule?.externalInitiation ?? 'inherit',
+    allowedPartners: binding.workspacePolicy.bindingRule?.allowedPartners.join(', ') ?? '',
+  }
+}
+
+function credentialDownloadName(bundle: WorkspaceIdentityCredentialBundle): string {
+  const safeBeamId = bundle.beamId.replace(/[^a-z0-9._-]+/gi, '-')
+  return `${safeBeamId}.beam-identity.json`
 }
 
 function getIntentRules(intent: IntentCatalogItem | null): Record<string, NonNullable<IntentCatalogItem['params']>[string]> {
@@ -386,6 +414,14 @@ export default function WorkspacesPage() {
     partnerChannelId: '',
     linkedIntentNonce: '',
   })
+  const [bindingPolicyDrafts, setBindingPolicyDrafts] = useState<Record<number, {
+    externalInitiation: WorkspacePolicyRuleExternalInitiation
+    allowedPartners: string
+  }>>({})
+  const [issuedCredential, setIssuedCredential] = useState<{
+    bindingId: number
+    bundle: WorkspaceIdentityCredentialBundle
+  } | null>(null)
 
   const selectedSlug = searchParams.get('workspace') ?? ''
   const selectedThreadId = useMemo(() => {
@@ -437,6 +473,16 @@ export default function WorkspacesPage() {
 
     return channels.find((channel) => channel.partnerBeamId === partnerBeamId)?.workspaceRoute ?? null
   }, [channels, threadDetail])
+
+  useEffect(() => {
+    setBindingPolicyDrafts((current) => {
+      const next: typeof current = {}
+      for (const binding of bindings) {
+        next[binding.id] = current[binding.id] ?? createBindingPolicyDraft(binding)
+      }
+      return next
+    })
+  }, [bindings])
 
   async function loadWorkspaces() {
     const response = await directoryApi.listWorkspaces()
@@ -697,6 +743,72 @@ export default function WorkspacesPage() {
       await directoryApi.updateWorkspaceIdentity(selectedWorkspace.slug, binding.id, patch)
       await loadWorkspaceSurface(selectedWorkspace.slug)
     }, `${binding.beamId} updated.`)
+  }
+
+  function updateBindingPolicyDraft(
+    bindingId: number,
+    patch: Partial<{
+      externalInitiation: WorkspacePolicyRuleExternalInitiation
+      allowedPartners: string
+    }>,
+  ) {
+    setBindingPolicyDrafts((current) => ({
+      ...current,
+      [bindingId]: {
+        ...(current[bindingId] ?? {
+          externalInitiation: 'inherit',
+          allowedPartners: '',
+        }),
+        ...patch,
+      },
+    }))
+  }
+
+  async function handleBindingPolicySubmit(binding: WorkspaceIdentityBinding) {
+    if (!selectedWorkspace) return
+    const draft = bindingPolicyDrafts[binding.id] ?? createBindingPolicyDraft(binding)
+    await runAction(`binding-policy-${binding.id}`, async () => {
+      const response = await directoryApi.updateWorkspaceIdentityPolicy(selectedWorkspace.slug, binding.id, {
+        externalInitiation: draft.externalInitiation,
+        allowedPartners: parseCsvList(draft.allowedPartners),
+      })
+      setBindingPolicyDrafts((current) => ({
+        ...current,
+        [binding.id]: createBindingPolicyDraft(response.binding),
+      }))
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, `${binding.beamId} policy updated.`)
+  }
+
+  async function handleReissueCredential(binding: WorkspaceIdentityBinding) {
+    if (!selectedWorkspace) return
+    await runAction(`binding-credential-${binding.id}`, async () => {
+      const response = await directoryApi.reissueWorkspaceIdentityCredential(selectedWorkspace.slug, binding.id)
+      setIssuedCredential({
+        bindingId: binding.id,
+        bundle: response.credential,
+      })
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+    }, `${binding.beamId} local credential reissued.`)
+  }
+
+  async function handleCopyCredential(bundle: WorkspaceIdentityCredentialBundle) {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(bundle, null, 2))
+      setNotice(`Credential bundle copied for ${bundle.beamId}.`)
+    } catch {
+      setError('Clipboard access failed while copying the credential bundle.')
+    }
+  }
+
+  function handleDownloadCredential(bundle: WorkspaceIdentityCredentialBundle) {
+    const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = credentialDownloadName(bundle)
+    anchor.click()
+    URL.revokeObjectURL(url)
   }
 
   async function handlePartnerChannelSubmit(event: FormEvent<HTMLFormElement>) {
@@ -1106,6 +1218,46 @@ export default function WorkspacesPage() {
                         <div>{binding.identity.capabilities.length > 0 ? `${binding.identity.capabilities.length} capabilities declared` : 'No capabilities declared'}</div>
                       </div>
 
+                      <div className="mt-3 rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:text-slate-300">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Beam DID</div>
+                            <div className="mt-1 truncate font-mono text-xs text-slate-700 dark:text-slate-200">{binding.identity.did.id}</div>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <StatusPill
+                              label={binding.workspacePolicy.effective.externalInitiation === 'allow' ? 'Outbound allowed' : 'Outbound blocked'}
+                              tone={binding.workspacePolicy.effective.externalInitiation === 'allow' ? 'success' : 'warning'}
+                            />
+                            <StatusPill
+                              label={binding.workspacePolicy.effective.approvalRequired ? 'Approval path' : 'Direct path'}
+                              tone={binding.workspacePolicy.effective.approvalRequired ? 'warning' : 'success'}
+                            />
+                          </div>
+                        </div>
+
+                        <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                          <div>{summarizeKeyState(binding)}</div>
+                          <div>{summarizeList(binding.workspacePolicy.effective.allowedPartners, 'No partner allowlist override')}</div>
+                          <div>{binding.workspacePolicy.bindingRule ? 'Per-agent policy override active' : 'Inheriting workspace defaults'}</div>
+                          <div>{binding.workspacePolicy.effective.approvalRequired ? `Approvers: ${summarizeList(binding.workspacePolicy.effective.approvers, 'Not listed')}` : 'No workflow approvers attached here'}</div>
+                        </div>
+
+                        <div className="mt-3 flex flex-wrap gap-3 text-xs">
+                          <a className="text-orange-600 hover:text-orange-700 dark:text-orange-300" href={binding.identity.did.resolutionUrl} rel="noreferrer" target="_blank">
+                            Resolve DID
+                          </a>
+                          <a className="text-orange-600 hover:text-orange-700 dark:text-orange-300" href={binding.identity.did.keysUrl} rel="noreferrer" target="_blank">
+                            Open key history
+                          </a>
+                          {binding.identity.existsLocally ? (
+                            <a className="text-orange-600 hover:text-orange-700 dark:text-orange-300" href={binding.identity.did.agentUrl} rel="noreferrer" target="_blank">
+                              Open agent record
+                            </a>
+                          ) : null}
+                        </div>
+                      </div>
+
                       {binding.notes ? (
                         <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{binding.notes}</div>
                       ) : null}
@@ -1142,7 +1294,103 @@ export default function WorkspacesPage() {
                             Open agent
                           </Link>
                         ) : null}
+                        {binding.bindingType !== 'partner' && binding.identity.existsLocally ? (
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `binding-credential-${binding.id}`}
+                            onClick={() => { void handleReissueCredential(binding) }}
+                          >
+                            {actionBusy === `binding-credential-${binding.id}` ? 'Issuing…' : 'Reissue local credential'}
+                          </button>
+                        ) : null}
                       </div>
+
+                      {binding.bindingType !== 'partner' ? (
+                        <div className="mt-4 rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                          <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Per-agent partner control</div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                            Keep workspace defaults, or attach an explicit outbound override for this identity only.
+                          </div>
+                          <div className="mt-3 grid gap-3 md:grid-cols-2">
+                            <select
+                              className="input-field"
+                              value={(bindingPolicyDrafts[binding.id] ?? createBindingPolicyDraft(binding)).externalInitiation}
+                              onChange={(event) => updateBindingPolicyDraft(binding.id, {
+                                externalInitiation: event.target.value as WorkspacePolicyRuleExternalInitiation,
+                              })}
+                            >
+                              <option value="inherit">inherit workspace default</option>
+                              <option value="allow">allow outbound</option>
+                              <option value="deny">deny outbound</option>
+                            </select>
+                            <input
+                              className="input-field"
+                              placeholder="finance@northwind.beam.directory, *@partner.beam.directory"
+                              value={(bindingPolicyDrafts[binding.id] ?? createBindingPolicyDraft(binding)).allowedPartners}
+                              onChange={(event) => updateBindingPolicyDraft(binding.id, {
+                                allowedPartners: event.target.value,
+                              })}
+                            />
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            <button
+                              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                              type="button"
+                              disabled={actionBusy === `binding-policy-${binding.id}`}
+                              onClick={() => { void handleBindingPolicySubmit(binding) }}
+                            >
+                              {actionBusy === `binding-policy-${binding.id}` ? 'Saving…' : 'Save agent policy'}
+                            </button>
+                            <button
+                              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                              type="button"
+                              onClick={() => {
+                                setBindingPolicyDrafts((current) => ({
+                                  ...current,
+                                  [binding.id]: createBindingPolicyDraft(binding),
+                                }))
+                              }}
+                            >
+                              Reset form
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+
+                      {issuedCredential?.bindingId === binding.id ? (
+                        <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50/80 p-4 dark:border-emerald-500/20 dark:bg-emerald-500/10">
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">One-time local credential bundle</div>
+                              <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                Copy or download this now. The API key is only returned at issuance time.
+                              </div>
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                              <button
+                                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-white dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                                type="button"
+                                onClick={() => { void handleCopyCredential(issuedCredential.bundle) }}
+                              >
+                                Copy JSON
+                              </button>
+                              <button
+                                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-white dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+                                type="button"
+                                onClick={() => { handleDownloadCredential(issuedCredential.bundle) }}
+                              >
+                                Download
+                              </button>
+                            </div>
+                          </div>
+                          <textarea
+                            className="input-field mt-3 min-h-56 font-mono text-xs"
+                            readOnly
+                            value={JSON.stringify(issuedCredential.bundle, null, 2)}
+                          />
+                        </div>
+                      ) : null}
                     </div>
                   ))
                 )}

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -1,7 +1,8 @@
-import { randomUUID } from 'node:crypto'
+import { generateKeyPairSync, randomUUID } from 'node:crypto'
 import { Hono } from 'hono'
 import type { Database } from 'better-sqlite3'
 import { requireAdminRole } from '../admin-auth.js'
+import { createAgentApiKey, hashApiKey } from '../api-key.js'
 import {
   createWorkspace,
   createWorkspaceIdentityBinding,
@@ -29,6 +30,7 @@ import {
   listWorkspaceThreads,
   listWorkspaces,
   logAuditEvent,
+  registerAgent,
   updateWorkspaceThread,
   updateWorkspacePartnerChannel,
   updateWorkspacePolicyDocument,
@@ -46,6 +48,7 @@ import type {
   WorkspacePartnerChannelRow,
   WorkspacePartnerChannelStatus,
   WorkspacePolicy,
+  WorkspacePolicyRuleExternalInitiation,
   WorkspacePrincipalType,
   WorkspaceRow,
   WorkspaceTimelineEventKind,
@@ -61,6 +64,7 @@ import { evaluateWorkspacePolicy } from '../workspace-policy.js'
 import { RelayError, isAgentConnected, relayIntentFromHttp } from '../websocket.js'
 import { sendOperatorDigestEmail } from '../email.js'
 import { validateIntentPayload } from '../validation.js'
+import { toBeamDID } from '../did.js'
 
 const WORKSPACE_STATUS_SET = new Set<WorkspaceRow['status']>(['active', 'paused', 'archived'])
 const WORKSPACE_THREAD_SCOPE_SET = new Set<WorkspaceThreadScope>(['internal', 'handoff'])
@@ -127,6 +131,12 @@ type SerializedWorkspaceIdentityBinding = {
   identity: {
     existsLocally: boolean
     beamId: string
+    did: {
+      id: string
+      resolutionUrl: string
+      agentUrl: string
+      keysUrl: string
+    }
     displayName: string | null
     org: string | null
     personal: boolean
@@ -134,7 +144,37 @@ type SerializedWorkspaceIdentityBinding = {
     trustScore: number | null
     lastSeen: string | null
     capabilities: string[]
-    keyState: object | null
+    keyState: {
+      active: object | null
+      revoked: object[]
+      keys: object[]
+      total: number
+    } | null
+  }
+  workspacePolicy: {
+    effective: SerializedWorkspacePolicyPreview
+    bindingRule: {
+      externalInitiation: WorkspacePolicyRuleExternalInitiation
+      allowedPartners: string[]
+    } | null
+  }
+}
+
+type SerializedWorkspaceIdentityCredential = {
+  format: 'beam-local-identity/v1'
+  beamId: string
+  did: string
+  displayName: string | null
+  workspaceSlug: string
+  directoryUrl: string
+  generatedAt: string
+  publicKey: string
+  privateKey: string
+  apiKey: string
+  urls: {
+    didResolution: string
+    agent: string
+    keys: string
   }
 }
 
@@ -458,6 +498,35 @@ function normalizeBoolean(value: unknown): boolean | null {
   return null
 }
 
+function normalizeExternalInitiationRule(value: unknown): WorkspacePolicyRuleExternalInitiation | null {
+  if (value === 'inherit' || value === 'allow' || value === 'deny') {
+    return value
+  }
+
+  return null
+}
+
+function normalizeStringList(value: unknown): string[] | null {
+  if (value == null) {
+    return []
+  }
+
+  if (Array.isArray(value)) {
+    const normalized = value
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+
+    return normalized.length === value.length ? [...new Set(normalized)] : null
+  }
+
+  if (typeof value === 'string') {
+    return [...new Set(value.split(',').map((entry) => entry.trim()).filter(Boolean))]
+  }
+
+  return null
+}
+
 function normalizeWorkspaceSlug(value: unknown, fallback: string): string | null {
   const candidate = typeof value === 'string' && value.trim().length > 0 ? value.trim().toLowerCase() : slugify(fallback)
   if (!candidate || !WORKSPACE_SLUG_RE.test(candidate)) {
@@ -465,6 +534,21 @@ function normalizeWorkspaceSlug(value: unknown, fallback: string): string | null
   }
 
   return candidate
+}
+
+function getDirectoryBaseUrl(): string {
+  return (process.env['BEAM_DIRECTORY_BASE_URL'] ?? 'https://beam.directory').replace(/\/$/, '')
+}
+
+function buildWorkspaceIdentityDid(beamId: string): SerializedWorkspaceIdentityBinding['identity']['did'] {
+  const did = toBeamDID(beamId)
+  const baseUrl = getDirectoryBaseUrl()
+  return {
+    id: did,
+    resolutionUrl: `${baseUrl}/did/${encodeURIComponent(did)}`,
+    agentUrl: `${baseUrl}/agents/${encodeURIComponent(beamId)}`,
+    keysUrl: `${baseUrl}/agents/${encodeURIComponent(beamId)}/keys`,
+  }
 }
 
 function hoursSince(value: string | null): number | null {
@@ -671,6 +755,10 @@ function summarizeWorkspaceAuditAction(action: string, details: Record<string, u
       return 'Workspace identity binding added.'
     case 'admin.workspace_identity.updated':
       return 'Workspace identity binding updated.'
+    case 'admin.workspace_identity.policy_updated':
+      return 'Workspace identity policy updated.'
+    case 'admin.workspace_identity.credential_reissued':
+      return 'Local Beam credential reissued.'
     case 'admin.workspace_thread.created':
       return 'Workspace thread created.'
     case 'admin.workspace_thread.dispatched':
@@ -718,7 +806,9 @@ function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspac
 
 function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityBindingRow): SerializedWorkspaceIdentityBinding {
   const agent = getAgent(db, row.beam_id)
-  const keyState = agent ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) : null
+  const keyState = agent
+    ? serializeAgentKeyState(listAgentKeys(db, row.beam_id)) as SerializedWorkspaceIdentityBinding['identity']['keyState']
+    : null
   const lastSeenAgeHours = hoursSince(agent?.last_seen ?? null)
   const runtime = parseRuntimeMetadata(row.binding_type, row.runtime_type)
   const connected = agent ? isAgentConnected(agent.beam_id) : false
@@ -738,6 +828,9 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
     keyState,
     owner: row.owner,
   })
+  const { policy } = getWorkspacePolicyDocument(db, row.workspace_id)
+  const effectivePolicy = buildWorkspacePolicyPreview(policy, row)
+  const bindingRule = [...policy.bindingRules].reverse().find((rule) => rule.beamId === row.beam_id) ?? null
 
   return {
     id: row.id,
@@ -765,6 +858,7 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
     identity: agent ? {
       existsLocally: true,
       beamId: agent.beam_id,
+      did: buildWorkspaceIdentityDid(agent.beam_id),
       displayName: agent.display_name,
       org: agent.org,
       personal: agent.personal === 1,
@@ -776,6 +870,7 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
     } : {
       existsLocally: false,
       beamId: row.beam_id,
+      did: buildWorkspaceIdentityDid(row.beam_id),
       displayName: null,
       org: null,
       personal: false,
@@ -784,6 +879,15 @@ function serializeWorkspaceIdentityBinding(db: Database, row: WorkspaceIdentityB
       lastSeen: null,
       capabilities: [],
       keyState,
+    },
+    workspacePolicy: {
+      effective: effectivePolicy,
+      bindingRule: bindingRule
+        ? {
+            externalInitiation: bindingRule.externalInitiation,
+            allowedPartners: bindingRule.allowedPartners,
+          }
+        : null,
     },
   }
 }
@@ -2867,6 +2971,194 @@ export function workspacesRouter(db: Database): Hono {
 
     c.header('Cache-Control', 'no-store')
     return c.json({ binding: serializeWorkspaceIdentityBinding(db, updated) })
+  })
+
+  router.patch('/:slug/identities/:id/policy', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const bindingId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(bindingId) || bindingId <= 0) {
+      return c.json({ error: 'Invalid identity binding id', errorCode: 'INVALID_BINDING_ID' }, 400)
+    }
+
+    const binding = getWorkspaceIdentityBindingById(db, bindingId)
+    if (!binding || binding.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: unknown
+    try {
+      body = await c.req.json()
+    } catch {
+      return c.json({ error: 'Invalid JSON body', errorCode: 'INVALID_JSON' }, 400)
+    }
+
+    if (!body || typeof body !== 'object' || Array.isArray(body)) {
+      return c.json({ error: 'Body must be an object', errorCode: 'INVALID_BODY' }, 400)
+    }
+
+    const raw = body as Record<string, unknown>
+    const externalInitiation = 'externalInitiation' in raw
+      ? normalizeExternalInitiationRule(raw.externalInitiation)
+      : 'inherit'
+    if ('externalInitiation' in raw && !externalInitiation) {
+      return c.json({ error: 'Invalid externalInitiation', errorCode: 'INVALID_EXTERNAL_INITIATION' }, 400)
+    }
+
+    const allowedPartners = 'allowedPartners' in raw
+      ? normalizeStringList(raw.allowedPartners)
+      : []
+    if ('allowedPartners' in raw && !allowedPartners) {
+      return c.json({ error: 'allowedPartners must be an array of strings or a comma-separated string', errorCode: 'INVALID_ALLOWED_PARTNERS' }, 400)
+    }
+
+    const currentPolicy = getWorkspacePolicyDocument(db, workspace.id).policy
+    const nextBindingRules = currentPolicy.bindingRules.filter((rule) => rule.beamId !== binding.beam_id)
+
+    if ((externalInitiation ?? 'inherit') !== 'inherit' || (allowedPartners?.length ?? 0) > 0) {
+      nextBindingRules.push({
+        beamId: binding.beam_id,
+        bindingType: binding.binding_type,
+        policyProfile: binding.policy_profile,
+        externalInitiation: externalInitiation ?? 'inherit',
+        allowedPartners: allowedPartners ?? [],
+      })
+    }
+
+    const updatedPolicy = updateWorkspacePolicyDocument(db, workspace.id, {
+      bindingRules: nextBindingRules,
+    }, auth.session.email)
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_identity.policy_updated',
+      actor: auth.session.email,
+      target: `${workspace.slug}:${binding.beam_id}`,
+      details: {
+        role: auth.session.role,
+        externalInitiation: externalInitiation ?? 'inherit',
+        allowedPartners: allowedPartners ?? [],
+      },
+    })
+
+    const refreshedBinding = getWorkspaceIdentityBindingById(db, binding.id)
+    if (!refreshedBinding) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, workspace),
+      updatedAt: updatedPolicy.updatedAt,
+      updatedBy: updatedPolicy.updatedBy,
+      rule: [...updatedPolicy.policy.bindingRules]
+        .reverse()
+        .find((rule) => rule.beamId === binding.beam_id) ?? null,
+      preview: buildWorkspacePolicyPreview(updatedPolicy.policy, refreshedBinding),
+      binding: serializeWorkspaceIdentityBinding(db, refreshedBinding),
+    })
+  })
+
+  router.post('/:slug/identities/:id/reissue-local-credential', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const bindingId = Number.parseInt(c.req.param('id'), 10)
+    if (!Number.isFinite(bindingId) || bindingId <= 0) {
+      return c.json({ error: 'Invalid identity binding id', errorCode: 'INVALID_BINDING_ID' }, 400)
+    }
+
+    const binding = getWorkspaceIdentityBindingById(db, bindingId)
+    if (!binding || binding.workspace_id !== workspace.id) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    if (binding.binding_type === 'partner') {
+      return c.json({ error: 'Partner bindings do not own local Beam credentials', errorCode: 'PARTNER_BINDING_NO_LOCAL_CREDENTIAL' }, 400)
+    }
+
+    const agent = getAgent(db, binding.beam_id)
+    if (!agent) {
+      return c.json({ error: 'Local Beam identity not found', errorCode: 'AGENT_NOT_FOUND' }, 404)
+    }
+
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519')
+    const publicKeyBase64 = (publicKey.export({ type: 'spki', format: 'der' }) as Buffer).toString('base64')
+    const privateKeyBase64 = (privateKey.export({ type: 'pkcs8', format: 'der' }) as Buffer).toString('base64')
+    const apiKey = createAgentApiKey(agent.beam_id)
+    const updatedAgent = registerAgent(db, {
+      beamId: agent.beam_id,
+      displayName: agent.display_name,
+      capabilities: JSON.parse(agent.capabilities) as string[],
+      publicKey: publicKeyBase64,
+      apiKeyHash: hashApiKey(apiKey),
+      org: agent.org,
+      personal: agent.personal === 1,
+      email: agent.email,
+      emailVerified: agent.email_verified === 1,
+      description: agent.description,
+      logoUrl: agent.logo_url,
+      website: agent.website,
+      verificationTier: agent.verification_tier,
+      visibility: agent.visibility,
+      httpEndpoint: agent.http_endpoint,
+      dhPublicKey: agent.dh_public_key,
+    })
+
+    logAuditEvent(db, {
+      action: 'admin.workspace_identity.credential_reissued',
+      actor: auth.session.email,
+      target: `${workspace.slug}:${binding.beam_id}`,
+      details: {
+        role: auth.session.role,
+        did: toBeamDID(binding.beam_id),
+        workspace: workspace.slug,
+      },
+    })
+
+    const refreshedBinding = getWorkspaceIdentityBindingById(db, binding.id)
+    if (!refreshedBinding) {
+      return c.json({ error: 'Workspace identity not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const urls = buildWorkspaceIdentityDid(updatedAgent.beam_id)
+    const credential: SerializedWorkspaceIdentityCredential = {
+      format: 'beam-local-identity/v1',
+      beamId: updatedAgent.beam_id,
+      did: urls.id,
+      displayName: updatedAgent.display_name,
+      workspaceSlug: workspace.slug,
+      directoryUrl: getDirectoryBaseUrl(),
+      generatedAt: new Date().toISOString(),
+      publicKey: publicKeyBase64,
+      privateKey: privateKeyBase64,
+      apiKey,
+      urls: {
+        didResolution: urls.resolutionUrl,
+        agent: urls.agentUrl,
+        keys: urls.keysUrl,
+      },
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      binding: serializeWorkspaceIdentityBinding(db, refreshedBinding),
+      credential,
+    })
   })
 
   return router

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -208,12 +208,23 @@ test('workspace identity bindings can be created, listed, and updated through th
         status: string
         identity: {
           existsLocally: boolean
+          did: {
+            id: string
+          }
+        }
+        workspacePolicy: {
+          effective: {
+            externalInitiation: string
+          }
         }
       }>
     }
     assert.equal(listBody.total, 2)
     const partnerBinding = listBody.bindings.find((entry) => entry.beamId === 'finance-agent@northwind.beam.directory')
     assert.equal(partnerBinding?.identity.existsLocally, false)
+    const localBinding = listBody.bindings.find((entry) => entry.beamId === 'ops-bot@beam.directory')
+    assert.equal(localBinding?.identity.did.id, 'did:beam:ops-bot')
+    assert.equal(localBinding?.workspacePolicy.effective.externalInitiation, 'allow')
 
     const patchResponse = await app.request(new Request(`http://localhost/admin/workspaces/northwind-partner-ops/identities/${localBindingBody.binding.id}`, {
       method: 'PATCH',
@@ -238,6 +249,144 @@ test('workspace identity bindings can be created, listed, and updated through th
     assert.equal(patchBody.binding.status, 'paused')
     assert.equal(patchBody.binding.canInitiateExternal, false)
     assert.match(patchBody.binding.notes ?? '', /policy review/i)
+  } finally {
+    db.close()
+  }
+})
+
+test('workspace identities expose explicit did control, per-binding partner overrides, and local credential reissue', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['triage', 'handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAzJmQH9I0mL6MZzQ1+Qv6cMo5+2dH6+f8A6m2nYJ7rVY=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+
+    const workspaceResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: 'Acme Agent Control',
+        slug: 'acme-agent-control',
+      }),
+    }))
+    assert.equal(workspaceResponse.status, 201)
+
+    const bindResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-agent-control/identities', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'openclaw:workspace',
+        canInitiateExternal: false,
+      }),
+    }))
+    assert.equal(bindResponse.status, 201)
+    const bindBody = await bindResponse.json() as {
+      binding: {
+        id: number
+      }
+    }
+
+    const policyResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-agent-control/identities/${bindBody.binding.id}/policy`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        externalInitiation: 'allow',
+        allowedPartners: ['finance@northwind.beam.directory'],
+      }),
+    }))
+    assert.equal(policyResponse.status, 200)
+    const policyBody = await policyResponse.json() as {
+      rule: {
+        externalInitiation: string
+        allowedPartners: string[]
+      } | null
+      preview: {
+        externalInitiation: string
+        allowedPartners: string[]
+      }
+      binding: {
+        workspacePolicy: {
+          bindingRule: {
+            externalInitiation: string
+            allowedPartners: string[]
+          } | null
+        }
+      }
+    }
+    assert.equal(policyBody.rule?.externalInitiation, 'allow')
+    assert.deepEqual(policyBody.rule?.allowedPartners, ['finance@northwind.beam.directory'])
+    assert.equal(policyBody.preview.externalInitiation, 'allow')
+    assert.deepEqual(policyBody.preview.allowedPartners, ['finance@northwind.beam.directory'])
+    assert.equal(policyBody.binding.workspacePolicy.bindingRule?.externalInitiation, 'allow')
+
+    const reissueResponse = await app.request(new Request(`http://localhost/admin/workspaces/acme-agent-control/identities/${bindBody.binding.id}/reissue-local-credential`, {
+      method: 'POST',
+      headers: createAdminHeaders(db, 'admin@example.com', 'admin'),
+    }))
+    assert.equal(reissueResponse.status, 200)
+    const reissueBody = await reissueResponse.json() as {
+      binding: {
+        beamId: string
+        identity: {
+          did: {
+            id: string
+            resolutionUrl: string
+            keysUrl: string
+          }
+          keyState: {
+            total: number
+            active: { publicKey: string } | null
+            revoked: Array<{ publicKey: string }>
+          } | null
+        }
+      }
+      credential: {
+        format: string
+        beamId: string
+        did: string
+        apiKey: string
+        publicKey: string
+        privateKey: string
+        urls: {
+          didResolution: string
+          keys: string
+        }
+      }
+    }
+    assert.equal(reissueBody.binding.beamId, 'ops-bot@beam.directory')
+    assert.equal(reissueBody.binding.identity.did.id, 'did:beam:ops-bot')
+    assert.match(reissueBody.binding.identity.did.resolutionUrl, /\/did\//)
+    assert.match(reissueBody.credential.apiKey, /^bk_/)
+    assert.equal(reissueBody.credential.format, 'beam-local-identity/v1')
+    assert.equal(reissueBody.credential.beamId, 'ops-bot@beam.directory')
+    assert.equal(reissueBody.credential.did, 'did:beam:ops-bot')
+    assert.match(reissueBody.credential.privateKey, /^[A-Za-z0-9+/=]+$/)
+    assert.match(reissueBody.credential.publicKey, /^[A-Za-z0-9+/=]+$/)
+    assert.match(reissueBody.credential.urls.didResolution, /\/did\//)
+    assert.match(reissueBody.credential.urls.keys, /\/keys$/)
+    assert.equal(reissueBody.binding.identity.keyState?.total, 2)
+    assert.equal(reissueBody.binding.identity.keyState?.revoked.length, 1)
+    assert.equal(reissueBody.binding.identity.keyState?.active?.publicKey, reissueBody.credential.publicKey)
   } finally {
     db.close()
   }


### PR DESCRIPTION
## Summary\n- add explicit DID and key-state controls to workspace identities\n- add per-binding outbound partner policy overrides and local credential reissue\n- expose the new workspace identity controls in the dashboard and docs\n\n## Testing\n- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory\n- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build\n- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build\n- npm -C /Users/tobik/Documents/BEAM/beam-protocol test\n