### PR TITLE
Add 1.3.0 OpenClaw fleet operations plan

### DIFF
--- a/reports/1.3.0-openclaw-fleet-operations-plan.md
+++ b/reports/1.3.0-openclaw-fleet-operations-plan.md
@@ -1,0 +1,297 @@
+# Beam 1.3.0 OpenClaw Fleet Operations Plan
+
+## Goal
+
+Beam `1.3.0` should turn the new OpenClaw fleet connector from a strong first release into a boring day-2 operating surface.
+
+The milestone goal is:
+
+**make one central Beam control plane the place where an operator can enroll, approve, inspect, rotate, recover, and trust a multi-host OpenClaw fleet without local heroics**
+
+At the end of `1.3.0`, Beam should feel less like “a working fleet connector” and more like “the reliable control plane for OpenClaw hosts in production.”
+
+## Target Outcome
+
+By **August 13, 2026**, the team should be able to do this cleanly:
+
+1. install and enroll a new OpenClaw host without hand-editing local files,
+2. approve or revoke that host from Beam with explicit host state and auditability,
+3. see route health, heartbeat freshness, and delivery receipts from one fleet surface,
+4. rotate or recover host credentials without rebuilding the whole fleet by hand,
+5. resolve duplicate Beam identity conflicts from the operator surface instead of shell or DB work,
+6. run the same daemon model on macOS and Linux,
+7. use recurring digests and escalation loops for stale hosts, route conflicts, and failed deliveries,
+8. cut `1.3.0` only from committed dry-run and smoke evidence.
+
+## North Star
+
+Beam `1.3.0` succeeds if one operator can use Beam as:
+
+`host install -> pending enrollment -> operator approval -> live route health -> credential rotation/recovery -> conflict resolution -> recurring fleet loop`
+
+without undocumented shell knowledge or machine-specific hacks.
+
+## Non-Goals
+
+`1.3.0` is not for:
+
+- adding a generic non-OpenClaw connector marketplace,
+- introducing free-form custom DID editing,
+- patching OpenClaw core or depending on invasive runtime modifications,
+- building a Slack-like shared workspace or browser/file collaboration product,
+- broadening Beam protocol semantics as the headline milestone story,
+- self-serve billing, seat packaging, or enterprise procurement tooling.
+
+## Current Position After 1.2.0
+
+Beam already has the key fleet foundation:
+
+- first-class OpenClaw host enrollment, approval, heartbeat, inventory, and revoke behavior,
+- unified `beam-openclaw-host` daemon and route reporting,
+- central fleet dashboard plus workspace host badges and route metadata,
+- cross-host send/receive with one canonical Beam trace,
+- duplicate identity conflict blocking and revoked-host delivery denial,
+- repo-visible buyer, operator, and fleet smoke evidence under `reports/`,
+- released `v1.2.0` with live API truth, public site, docs, and npm packages aligned.
+
+What is still missing is the day-2 operator experience:
+
+- host install and enrollment still need a more productized path,
+- route and delivery health still need to feel explicit rather than inferred,
+- host credential rotation and machine replacement need a safer story,
+- conflict resolution should be an operator workflow instead of just a blocked state,
+- Linux parity must be as real as macOS parity,
+- recurring fleet follow-through should be procedural and visible.
+
+## Product Thesis For 1.3.0
+
+The key product bet for `1.3.0` is this:
+
+**Beam becomes the production home for OpenClaw fleets when host lifecycle, route ownership, and recovery are operator actions instead of shell rituals.**
+
+That means the milestone should optimize for:
+
+- installation clarity over more connector breadth,
+- route health visibility over more dashboard breadth,
+- recovery and rotation over new protocol experiments,
+- explicit conflict handling over implicit heuristics,
+- repeatable operator loops over one-off success paths.
+
+## Operating Rule
+
+`1.2.1` remains a hotfix and hygiene lane only.
+
+All material product work after `1.2.0` should land under the `1.3.0 OpenClaw Fleet Operations` track. If a live regression appears, fix it directly as a narrow hotfix without changing the `1.3.0` scope.
+
+## Success Criteria
+
+`1.3.0` is done when all of the following are true:
+
+- a new host can be installed, enrolled, approved, and activated without manual file editing,
+- fleet surfaces show live route totals, stale route totals, heartbeat freshness, and delivery receipts,
+- operators can rotate host credentials and recover or replace a host without rebuilding the whole fleet,
+- duplicate identity conflicts are visible, blocked, and resolvable from the operator surface,
+- Linux/systemd support is documented and exercised as a first-class daemon target,
+- recurring digests exist for stale hosts, conflicts, revoked state, and failed delivery paths,
+- one buyer-like and one operator-like dry run plus one fleet drill are documented under `reports/`,
+- the final release decision is made from a repo-visible checklist and explicit go/no-go gates.
+
+## Workstreams
+
+### 1. Host Install And Enrollment
+
+Goal: make a new host boring to bootstrap and join.
+
+Primary issue:
+
+- [#140](https://github.com/Beam-directory/beam-protocol/issues/140) Productize beam-openclaw-host install and host enrollment pack
+
+Scope:
+
+- unify install flow for the daemon,
+- foreground debug mode and managed service mode,
+- pending enrollment request plus operator approval,
+- documented reinstall and uninstall paths.
+
+### 2. Route Health And Delivery Receipts
+
+Goal: make route ownership and route quality explicit.
+
+Primary issue:
+
+- [#141](https://github.com/Beam-directory/beam-protocol/issues/141) Add fleet route health and delivery receipt surfaces
+
+Scope:
+
+- per-host route totals,
+- stale or unavailable routes,
+- delivery receipts and failure reasons,
+- links from fleet/workspace surfaces into traces.
+
+### 3. Credential Rotation And Recovery
+
+Goal: make host credentials safe to rotate and recover.
+
+Primary issue:
+
+- [#142](https://github.com/Beam-directory/beam-protocol/issues/142) Add host credential rotation and recovery flows
+
+Scope:
+
+- host credential reissue and rotation,
+- revoke and replace paths,
+- recovery for lost or replaced machines,
+- documented recovery runbook.
+
+### 4. Conflict Resolution And Route Ownership
+
+Goal: turn duplicate identity conflicts into a real operator workflow.
+
+Primary issue:
+
+- [#143](https://github.com/Beam-directory/beam-protocol/issues/143) Add duplicate identity conflict resolution and route ownership actions
+
+Scope:
+
+- conflict visibility in fleet and workspace views,
+- delivery blocked while conflicting,
+- route owner actions for resolve, revoke, or reassign,
+- auditable conflict history.
+
+### 5. Recurring Fleet Operator Loop
+
+Goal: make the fleet operationally boring between incidents.
+
+Primary issue:
+
+- [#144](https://github.com/Beam-directory/beam-protocol/issues/144) Add recurring fleet digest and escalation loop
+
+Scope:
+
+- stale host digest,
+- conflict and failed delivery digest,
+- escalation links and runbook hooks,
+- reproducible operator output from repo-owned scripts.
+
+### 6. Linux Parity
+
+Goal: treat multi-host Linux deployment as first-class, not as a footnote.
+
+Primary issue:
+
+- [#145](https://github.com/Beam-directory/beam-protocol/issues/145) Ship Linux/systemd parity for beam-openclaw-host
+
+Scope:
+
+- systemd install and uninstall,
+- Linux secret storage defaults,
+- docs and smoke coverage,
+- keep macOS launchd support intact.
+
+### 7. Final Dry Runs
+
+Goal: make the candidate earn the release.
+
+Primary issue:
+
+- [#146](https://github.com/Beam-directory/beam-protocol/issues/146) Run 1.3.0 buyer/operator/fleet dry runs
+
+Scope:
+
+- buyer-style pass for fleet onboarding and host-management understanding,
+- operator-style pass for approval, stale host, rotate, revoke, and recovery,
+- one mixed multi-host fleet drill,
+- new blockers filed as GitHub issues.
+
+### 8. Cut Control
+
+Goal: keep the first fleet-operations release boring and explicit.
+
+Primary issue:
+
+- [#147](https://github.com/Beam-directory/beam-protocol/issues/147) Prepare the 1.3.0 cut checklist, release notes, and go-no-go gates
+
+Scope:
+
+- repo-visible RC checklist,
+- draft release notes,
+- explicit go/no-go gates tied to fleet evidence,
+- final cut only after smoke and dry-run proof is green.
+
+## Sequence
+
+### Phase 1: Install And Join
+
+**April 6, 2026 to April 24, 2026**
+
+- make `beam-openclaw-host` feel like one product instead of a script bundle,
+- ship pending enrollment plus explicit operator approval,
+- keep the local debug path straightforward.
+
+Primary issues:
+
+- [#140](https://github.com/Beam-directory/beam-protocol/issues/140)
+- [#145](https://github.com/Beam-directory/beam-protocol/issues/145)
+
+### Phase 2: Health And Route Truth
+
+**April 27, 2026 to May 22, 2026**
+
+- make route health, delivery receipts, and route ownership explicit,
+- surface conflicts instead of only blocking on them,
+- give the operator a direct path from fleet view to trace and workspace.
+
+Primary issues:
+
+- [#141](https://github.com/Beam-directory/beam-protocol/issues/141)
+- [#143](https://github.com/Beam-directory/beam-protocol/issues/143)
+
+### Phase 3: Recovery And Rotation
+
+**May 25, 2026 to June 19, 2026**
+
+- make host rotation and recovery safe,
+- ensure stale or replaced machines have a documented path back,
+- add recurring digest and escalation loops for the boring day-2 cases.
+
+Primary issues:
+
+- [#142](https://github.com/Beam-directory/beam-protocol/issues/142)
+- [#144](https://github.com/Beam-directory/beam-protocol/issues/144)
+
+### Phase 4: Candidate Validation
+
+**June 22, 2026 to July 17, 2026**
+
+- run the buyer-like and operator-like passes,
+- run the mixed-fleet drill,
+- file any blockers that show up in the real workflow.
+
+Primary issue:
+
+- [#146](https://github.com/Beam-directory/beam-protocol/issues/146)
+
+### Phase 5: Cut Control
+
+**July 20, 2026 to August 13, 2026**
+
+- freeze the release criteria,
+- prepare release notes and checklist,
+- cut only after explicit smoke and live route evidence.
+
+Primary issue:
+
+- [#147](https://github.com/Beam-directory/beam-protocol/issues/147)
+
+## Release Logic
+
+`1.3.0` should ship only if the fleet slice is operationally boring.
+
+That means:
+
+- host install works on both supported OS targets,
+- enrollment and approval are explicit and auditable,
+- route ownership and route health are visible,
+- stale, revoked, and conflicting hosts have operator workflows,
+- fleet evidence exists in committed reports,
+- the release is decided from proof, not optimism.


### PR DESCRIPTION
## Summary
- close the stale 1.1.0 milestone and open the 1.3.0 OpenClaw Fleet Operations milestone
- create issues #140 to #147 for the next post-1.2.0 workstreams
- add the repo-visible 1.3.0 plan report with sequence, success criteria, and phase breakdown

## Testing
- not run (planning and GitHub bookkeeping only)
