### PR TITLE
Cut 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.3.0 (draft)
+## v1.3.0 (2026-04-02)
 
 ### OpenClaw Fleet Operations
 - rotate and recover OpenClaw host credentials without rebuilding workspace bindings

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-04-01T19:00:00.000Z",
   "release": {
-    "version": "1.2.0",
+    "version": "1.3.0",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-04-01T19:00:00.000Z"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol-docs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "devDependencies": {
         "vitepress": "1.6.4"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "1.2.0"
+  "version": "1.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.2.0",
+        "beam-protocol-sdk": "^1.3.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.2.0"
+        "beam-protocol-sdk": "^1.3.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.2.0",
+    "beam-protocol-sdk": "^1.3.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.2.0"
+    "beam-protocol-sdk": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- bump Beam packages and docs metadata to 1.3.0
- regenerate root and docs lockfiles for the release cut
- update changelog and API release examples to the 1.3.0 release version

## Testing
- npm run build
- npm test
- npm run test:e2e
- npm -C docs run build
- npm pack --dry-run --workspace=packages/sdk-typescript --workspace=packages/cli