### PR TITLE
Add 1.4.0 OpenClaw fleet automation plan

### DIFF
--- a/reports/1.4.0-openclaw-fleet-automation-plan.md
+++ b/reports/1.4.0-openclaw-fleet-automation-plan.md
@@ -1,0 +1,209 @@
+# Beam 1.4.0 OpenClaw Fleet Automation Plan
+
+## Goal
+
+Beam `1.4.0` should turn the OpenClaw fleet surface from a strong operator console into a **low-toil operations system**.
+
+The milestone goal is:
+
+**make one central Beam control plane able to run, schedule, and enforce the recurring operational loops for an OpenClaw fleet without relying on operator memory**
+
+At the end of `1.4.0`, Beam should feel less like "a fleet UI with actions" and more like "the operating system for a live OpenClaw fleet."
+
+## Target Outcome
+
+By **October 1, 2026**, the team should be able to do this cleanly:
+
+1. see fleet health, receipts, stale state, and route latency in one place,
+2. schedule recurring digest and escalation loops instead of running scripts ad hoc,
+3. rotate host credentials on policy with clear recovery windows,
+4. manage host groups and environments with safe bulk actions,
+5. handle approval-heavy external motion without operator tab-hopping,
+6. resolve route conflicts through guided remediation instead of raw state inspection,
+7. run repeatable failover and recovery drills against a 3+ host fleet,
+8. cut `1.4.0` from committed automation, drill, and smoke evidence.
+
+## North Star
+
+Beam `1.4.0` succeeds if one operator can run this loop without undocumented shell work:
+
+`fleet digest -> receipt/SLO review -> conflict/rotation action -> approval/recovery action -> scheduled follow-through`
+
+## Non-Goals
+
+`1.4.0` is not for:
+
+- adding a second connector family as the headline story,
+- introducing custom DID editing,
+- patching OpenClaw core,
+- building a generic agent workspace/chat product,
+- broadening Beam protocol semantics,
+- packaging hosted billing or procurement workflows.
+
+## Current Position After 1.3.0
+
+Beam already has:
+
+- OpenClaw host enrollment, approval, heartbeat, inventory, and revoke,
+- host credential rotation and recovery,
+- duplicate identity conflict detection and route-owner actions,
+- Linux/systemd parity for `beam-openclaw-host`,
+- fleet digest and evidence-backed operator loops,
+- released `v1.3.0` with live API truth, npm packages, docs, and public status aligned.
+
+What is still missing is the difference between **operable** and **boringly operable**:
+
+- recurring loops still depend on humans remembering to run them,
+- receipts and latency are visible but not yet summarized as a real fleet health layer,
+- host grouping and bulk remediation do not exist,
+- approval-heavy outbound motion is still more manual than necessary,
+- failover and drill workflows need stronger repeatability.
+
+## Product Thesis For 1.4.0
+
+The key bet for `1.4.0` is:
+
+**Beam becomes the true home for OpenClaw fleet operations when daily review, escalation, rotation, and recovery happen on a schedule with explicit safety rails, not from human memory.**
+
+That means the milestone should optimize for:
+
+- recurring operations over one-off actions,
+- summarized fleet health over raw event tables,
+- environment-aware safety over more surface area,
+- guided remediation over expert-only knowledge,
+- proof-backed drills over assumed readiness.
+
+## Success Criteria
+
+`1.4.0` is done when all of the following are true:
+
+- recurring fleet digests can run on schedule and produce actionable next steps,
+- host credentials support policy-driven review and scheduled rotation windows,
+- fleet surfaces expose delivery receipts, missing receipts, and latency/SLO-oriented summaries,
+- operators can group hosts by environment or function and run safe bulk actions,
+- approval-required outbound motion can be triaged and completed from Beam with minimal context switching,
+- conflict remediation is guided with recommended owner actions and clear impact,
+- one failover drill and one recovery drill are committed under `reports/`,
+- the release decision is made from explicit automation, drill, and smoke evidence.
+
+## Workstreams
+
+### 1. Credential Policy And Rotation Windows
+
+Goal: move credential work from reactive actions to managed policy.
+
+Primary issue:
+
+- `#152` Add host credential policies, rotation windows, and recovery runbook state
+
+Scope:
+
+- credential age and next-rotation visibility,
+- scheduled rotation windows,
+- recovery handoff notes and operator ownership,
+- safer post-recovery cleanup.
+
+### 2. Fleet Receipts, Latency, And SLO Summary
+
+Goal: make route health visible as fleet health, not just per-event detail.
+
+Primary issue:
+
+- `#153` Add fleet receipts, latency summaries, and route-health SLO views
+
+Scope:
+
+- receipt coverage summaries,
+- latency buckets and recent degradation,
+- stale/no-receipt surfacing,
+- links into traces and affected workspaces.
+
+### 3. Approval Automation For External Motion
+
+Goal: keep Beam as the place where approval-gated external action actually gets completed.
+
+Primary issue:
+
+- `#154` Add approval queue and outbound policy automation for fleet-backed workspaces
+
+Scope:
+
+- approval queue for blocked outbound motion,
+- bulk approve/reject for safe repetitive cases,
+- policy-backed defaults for known partner channels,
+- stronger operator context around why work is blocked.
+
+### 4. Guided Conflict Resolution
+
+Goal: make conflicts obvious and fast to resolve under pressure.
+
+Primary issue:
+
+- `#155` Add guided duplicate conflict remediation and route-owner recommendations
+
+Scope:
+
+- recommended owner suggestion,
+- clearer conflict impact summary,
+- explicit disable/reassign/revoke flows,
+- retained audit trail for every remediation.
+
+### 5. Host Groups, Environments, And Bulk Actions
+
+Goal: let one operator manage more than a handful of hosts without noise.
+
+Primary issue:
+
+- `#156` Add host groups, environment labels, and safe fleet bulk actions
+
+Scope:
+
+- group hosts by prod/staging/lab or team,
+- filter and summarize by group,
+- safe bulk actions such as digest send, restart guidance, or staged revoke prompts,
+- guardrails around bulk destructive actions.
+
+### 6. Scheduled Fleet Digest And Escalation Engine
+
+Goal: make daily fleet review happen without remembering to run it.
+
+Primary issue:
+
+- `#157` Add scheduled fleet digests and escalation delivery paths
+
+Scope:
+
+- repo-owned schedule entrypoints,
+- digest inbox and escalation output,
+- one canonical daily operator loop,
+- delivery tracking for digests themselves.
+
+### 7. Drills And Evidence
+
+Goal: keep the fleet honest under failure.
+
+Primary issue:
+
+- `#158` Run 1.4.0 failover, recovery, and operator drills
+
+Scope:
+
+- failover drill,
+- recovery drill,
+- buyer/operator dry runs on the new automation path,
+- new blockers filed as issues.
+
+### 8. Cut Control
+
+Goal: keep `1.4.0` boring, explicit, and evidence-backed.
+
+Primary issue:
+
+- `#159` Prepare 1.4.0 checklist, release notes, and go-no-go gates
+
+Scope:
+
+- RC checklist,
+- release notes draft,
+- final smoke and automation proof,
+- explicit go/no-go gates tied to fleet ops evidence.


### PR DESCRIPTION
## Summary
- add the post-1.3.0 plan for OpenClaw fleet automation under reports/
- define the next release thesis around recurring ops, SLO views, host groups, and guided remediation
- map the plan to milestone #9 and issues #152-#159

## Testing
- not run (planning and GitHub backlog update only)