### PR TITLE
Add OpenClaw host policy and fleet receipt summaries

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -185,6 +185,15 @@ The fleet surface also gives operators explicit day-2 actions:
 - prefer, disable, or reset route ownership when duplicate Beam identities appear
 - deliver a fleet digest that calls out stale hosts, pending credential work, duplicate conflicts, and missing receipts
 
+The host detail and fleet summary now also expose the operational thresholds behind those actions:
+
+- credential rotation interval, next due time, and the next allowed rotation window
+- recovery owner, replacement host label, and cutover window notes
+- receipt coverage across active routes
+- p50 / p95 latency and latency SLO breaches for recent host-backed deliveries
+
+That means operators can treat the fleet page as the source of truth for both host health and the next required maintenance action, instead of jumping between traces and local host logs.
+
 If you have just pulled new Beam code and want the local containers rebuilt before importing again, run:
 
 ```bash

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -33,6 +33,8 @@ export type OpenClawRouteSource = 'agent-folder' | 'workspace-agent' | 'gateway-
 export type OpenClawRouteReportedState = 'live' | 'idle' | 'ended'
 export type OpenClawRouteRuntimeState = 'live' | 'idle' | 'stale' | 'ended' | 'conflict' | 'revoked'
 export type OpenClawRouteOwnerResolutionState = 'implicit' | 'preferred' | 'disabled'
+export type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
+export type OpenClawHostRecoveryRunbookState = 'idle' | 'prepared' | 'cutover_pending' | 'completed'
 export type WorkspaceOverviewAttentionCode =
   | 'identity_missing'
   | 'stale_check_in'
@@ -330,6 +332,27 @@ export interface OpenClawHostSummary {
   lastRouteEventAt: string | null
   createdAt: string
   updatedAt: string
+  policy: {
+    rotation: {
+      intervalHours: number
+      windowStartHour: number
+      windowDurationHours: number
+      nextRotationDueAt: string | null
+      nextRotationWindowStartsAt: string | null
+      nextRotationWindowEndsAt: string | null
+      dueInHours: number | null
+      reviewState: OpenClawHostRotationReviewState
+    }
+    recovery: {
+      owner: string | null
+      status: OpenClawHostRecoveryRunbookState
+      notes: string | null
+      replacementHostLabel: string | null
+      windowStartsAt: string | null
+      windowEndsAt: string | null
+      updatedAt: string | null
+    }
+  }
   enrollment: OpenClawEnrollmentRequest | null
   summary: {
     total: number
@@ -347,6 +370,21 @@ export interface OpenClawHostSummary {
       lastStatus: IntentLifecycleStatus | null
       lastErrorCode: string | null
       lastHref: string | null
+      coverage: {
+        activeRoutes: number
+        routesWithReceipts: number
+        missingReceipts: number
+        ratio: number | null
+      }
+      latency: {
+        targetMs: number
+        samples: number
+        avgMs: number | null
+        p50Ms: number | null
+        p95Ms: number | null
+        overSlo: number
+        degraded: boolean
+      }
     }
   }
 }
@@ -378,6 +416,12 @@ export interface OpenClawFleetOverviewResponse {
     conflictRoutes: number
     endedRoutes: number
     failedReceipts: number
+    routesMissingReceipts: number
+    receiptCoverageRatio: number | null
+    degradedHosts: number
+    latencySloBreaches: number
+    rotationDueHosts: number
+    recoveryRunbooksOpen: number
     duplicateIdentityConflicts: number
     pendingCredentialActions: number
     actionItems: number
@@ -412,6 +456,12 @@ export interface OpenClawFleetDigestResponse {
     liveRoutes: number
     staleRoutes: number
     failedReceipts: number
+    routesMissingReceipts: number
+    receiptCoverageRatio: number | null
+    degradedHosts: number
+    latencySloBreaches: number
+    rotationDueHosts: number
+    recoveryRunbooksOpen: number
     duplicateIdentityConflicts: number
     pendingCredentialActions: number
     actionItems: number
@@ -496,6 +546,22 @@ export interface OpenClawHostCredentialActionResponse {
       foregroundDebug: string
     }
   }
+}
+
+export interface OpenClawHostPolicyPatchInput {
+  rotationIntervalHours?: number | null
+  rotationWindowStartHour?: number | null
+  rotationWindowDurationHours?: number | null
+  recoveryOwner?: string | null
+  recoveryStatus?: OpenClawHostRecoveryRunbookState | null
+  recoveryNotes?: string | null
+  replacementHostLabel?: string | null
+  recoveryWindowStartsAt?: string | null
+  recoveryWindowEndsAt?: string | null
+}
+
+export interface OpenClawHostPolicyActionResponse {
+  host: OpenClawHostSummary
 }
 
 export interface OpenClawRouteActionResponse {
@@ -2223,6 +2289,10 @@ export const directoryApi = {
   }, { admin: true }),
   recoverOpenClawHost: (id: number) => request<OpenClawHostCredentialActionResponse>(`/admin/openclaw/hosts/${id}/recover`, {
     method: 'POST',
+  }, { admin: true }),
+  updateOpenClawHostPolicy: (id: number, input: OpenClawHostPolicyPatchInput) => request<OpenClawHostPolicyActionResponse>(`/admin/openclaw/hosts/${id}/policy`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
   }, { admin: true }),
   revokeOpenClawHost: (id: number, input?: { reason?: string | null }) => request<OpenClawHostRevokeResponse>(`/admin/openclaw/hosts/${id}/revoke`, {
     method: 'POST',

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -16,6 +16,8 @@ import {
   type OpenClawHostSummary,
   type OpenClawHostStatus,
   type OpenClawHostCredentialState,
+  type OpenClawHostPolicyPatchInput,
+  type OpenClawHostRecoveryRunbookState,
   type OpenClawRouteRuntimeState,
   type OpenClawRouteOwnerResolutionState,
   type OpenClawRouteSource,
@@ -129,6 +131,47 @@ function digestSeverityTone(severity: 'warning' | 'critical'): 'warning' | 'crit
   return severity === 'critical' ? 'critical' : 'warning'
 }
 
+function formatPercent(value: number | null): string {
+  return value === null ? '—' : `${Math.round(value * 100)}%`
+}
+
+function formatLatency(value: number | null): string {
+  return value === null ? '—' : `${formatNumber(value)} ms`
+}
+
+function toDateTimeLocalValue(value: string | null): string {
+  if (!value) {
+    return ''
+  }
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return ''
+  }
+  const localMs = parsed.getTime() - (parsed.getTimezoneOffset() * 60_000)
+  return new Date(localMs).toISOString().slice(0, 16)
+}
+
+function fromDateTimeLocalValue(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+  const parsed = new Date(trimmed)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+}
+
+type HostPolicyFormState = {
+  rotationIntervalHours: string
+  rotationWindowStartHour: string
+  rotationWindowDurationHours: string
+  recoveryOwner: string
+  recoveryStatus: OpenClawHostRecoveryRunbookState
+  recoveryNotes: string
+  replacementHostLabel: string
+  recoveryWindowStartsAt: string
+  recoveryWindowEndsAt: string
+}
+
 export default function OpenClawFleetPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [overview, setOverview] = useState<OpenClawFleetOverviewResponse | null>(null)
@@ -160,6 +203,17 @@ export default function OpenClawFleetPage() {
     workspaceSlug: '',
     notes: '',
     expiresInHours: 72,
+  })
+  const [policyForm, setPolicyForm] = useState<HostPolicyFormState>({
+    rotationIntervalHours: '720',
+    rotationWindowStartHour: '2',
+    rotationWindowDurationHours: '4',
+    recoveryOwner: '',
+    recoveryStatus: 'idle',
+    recoveryNotes: '',
+    replacementHostLabel: '',
+    recoveryWindowStartsAt: '',
+    recoveryWindowEndsAt: '',
   })
 
   const selectedHostId = useMemo(() => {
@@ -245,6 +299,24 @@ export default function OpenClawFleetPage() {
     })()
   }, [overview, searchParams, selectedHostId, setSearchParams])
 
+  useEffect(() => {
+    if (!selectedHost) {
+      return
+    }
+
+    setPolicyForm({
+      rotationIntervalHours: String(selectedHost.policy.rotation.intervalHours),
+      rotationWindowStartHour: String(selectedHost.policy.rotation.windowStartHour),
+      rotationWindowDurationHours: String(selectedHost.policy.rotation.windowDurationHours),
+      recoveryOwner: selectedHost.policy.recovery.owner ?? '',
+      recoveryStatus: selectedHost.policy.recovery.status,
+      recoveryNotes: selectedHost.policy.recovery.notes ?? '',
+      replacementHostLabel: selectedHost.policy.recovery.replacementHostLabel ?? '',
+      recoveryWindowStartsAt: toDateTimeLocalValue(selectedHost.policy.recovery.windowStartsAt),
+      recoveryWindowEndsAt: toDateTimeLocalValue(selectedHost.policy.recovery.windowEndsAt),
+    })
+  }, [selectedHost?.id, selectedHost?.updatedAt])
+
   async function runAction(actionKey: string, fn: () => Promise<void>, successMessage: string) {
     try {
       setActionBusy(actionKey)
@@ -313,6 +385,26 @@ export default function OpenClawFleetPage() {
       await Promise.all([loadOverview(), loadDigest()])
       await loadHost(host.id)
     }, `Recovery credential for ${hostTitle(host)} issued.`)
+  }
+
+  async function handleSavePolicy(host: OpenClawHostSummary) {
+    const input: OpenClawHostPolicyPatchInput = {
+      rotationIntervalHours: Number.parseInt(policyForm.rotationIntervalHours, 10) || host.policy.rotation.intervalHours,
+      rotationWindowStartHour: Number.parseInt(policyForm.rotationWindowStartHour, 10) || 0,
+      rotationWindowDurationHours: Number.parseInt(policyForm.rotationWindowDurationHours, 10) || 1,
+      recoveryOwner: policyForm.recoveryOwner.trim() || null,
+      recoveryStatus: policyForm.recoveryStatus,
+      recoveryNotes: policyForm.recoveryNotes.trim() || null,
+      replacementHostLabel: policyForm.replacementHostLabel.trim() || null,
+      recoveryWindowStartsAt: fromDateTimeLocalValue(policyForm.recoveryWindowStartsAt),
+      recoveryWindowEndsAt: fromDateTimeLocalValue(policyForm.recoveryWindowEndsAt),
+    }
+
+    await runAction(`policy-${host.id}`, async () => {
+      await directoryApi.updateOpenClawHostPolicy(host.id, input)
+      await Promise.all([loadOverview(), loadDigest()])
+      await loadHost(host.id)
+    }, `Policy for ${hostTitle(host)} updated.`)
   }
 
   async function handleRevoke(host: OpenClawHostSummary) {
@@ -402,11 +494,14 @@ export default function OpenClawFleetPage() {
         </div>
       ) : null}
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-7">
         <MetricCard label="Hosts" value={!overview ? '—' : formatNumber(overview.summary.totalHosts)} />
         <MetricCard label="Active hosts" value={!overview ? '—' : formatNumber(overview.summary.activeHosts)} tone={(overview?.summary.activeHosts ?? 0) > 0 ? 'success' : 'default'} />
         <MetricCard label="Pending hosts" value={!overview ? '—' : formatNumber(overview.summary.pendingHosts)} tone={(overview?.summary.pendingHosts ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Live routes" value={!overview ? '—' : formatNumber(overview.summary.liveRoutes)} tone={(overview?.summary.liveRoutes ?? 0) > 0 ? 'success' : 'default'} />
+        <MetricCard label="Receipt coverage" value={!overview ? '—' : formatPercent(overview.summary.receiptCoverageRatio)} tone={(overview?.summary.receiptCoverageRatio ?? 1) < 0.8 ? 'warning' : 'success'} />
+        <MetricCard label="Latency watch" value={!overview ? '—' : formatNumber(overview.summary.degradedHosts)} tone={(overview?.summary.degradedHosts ?? 0) > 0 ? 'warning' : 'default'} />
+        <MetricCard label="Rotation due" value={!overview ? '—' : formatNumber(overview.summary.rotationDueHosts)} tone={(overview?.summary.rotationDueHosts ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Duplicate conflicts" value={!overview ? '—' : formatNumber(overview.summary.duplicateIdentityConflicts)} tone={(overview?.summary.duplicateIdentityConflicts ?? 0) > 0 ? 'critical' : 'default'} />
       </section>
 
@@ -428,12 +523,14 @@ export default function OpenClawFleetPage() {
           </button>
         </div>
 
-        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-7">
           <MetricCard label="Action items" value={!digest ? '—' : formatNumber(digest.summary.actionItems)} tone={(digest?.summary.actionItems ?? 0) > 0 ? 'warning' : 'default'} />
           <MetricCard label="Critical items" value={!digest ? '—' : formatNumber(digest.summary.criticalItems)} tone={(digest?.summary.criticalItems ?? 0) > 0 ? 'critical' : 'default'} />
           <MetricCard label="Credential actions" value={!digest ? '—' : formatNumber(digest.summary.pendingCredentialActions)} tone={(digest?.summary.pendingCredentialActions ?? 0) > 0 ? 'warning' : 'default'} />
           <MetricCard label="Failed receipts" value={!digest ? '—' : formatNumber(digest.summary.failedReceipts)} tone={(digest?.summary.failedReceipts ?? 0) > 0 ? 'critical' : 'default'} />
           <MetricCard label="Stale hosts" value={!digest ? '—' : formatNumber(digest.summary.staleHosts)} tone={(digest?.summary.staleHosts ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Missing receipts" value={!digest ? '—' : formatNumber(digest.summary.routesMissingReceipts)} tone={(digest?.summary.routesMissingReceipts ?? 0) > 0 ? 'warning' : 'default'} />
+          <MetricCard label="SLO breaches" value={!digest ? '—' : formatNumber(digest.summary.latencySloBreaches)} tone={(digest?.summary.latencySloBreaches ?? 0) > 0 ? 'warning' : 'default'} />
         </div>
 
         <div className="mt-4 space-y-3">
@@ -526,11 +623,13 @@ export default function OpenClawFleetPage() {
                       <div>{`${formatNumber(host.summary.live)} live · ${formatNumber(host.summary.stale)} stale · ${formatNumber(host.summary.conflict)} conflict`}</div>
                       <div>{`${formatNumber(host.summary.unavailable)} unavailable · ${formatNumber(host.summary.revoked)} revoked`}</div>
                       <div>{host.lastInventoryAt ? `Inventory ${formatRelativeTime(host.lastInventoryAt)}` : 'No inventory yet'}</div>
-                      <div>{host.summary.delivery.receipts > 0 ? `${formatNumber(host.summary.delivery.receipts)} receipts · ${formatNumber(host.summary.delivery.failed)} failed` : 'No delivery receipts yet'}</div>
+                      <div>{host.summary.delivery.receipts > 0 ? `${formatNumber(host.summary.delivery.receipts)} receipts · ${formatNumber(host.summary.delivery.failed)} failed · ${formatPercent(host.summary.delivery.coverage.ratio)} coverage` : 'No delivery receipts yet'}</div>
                       <div>{host.approvedAt ? `Approved ${formatRelativeTime(host.approvedAt)}` : 'Waiting for approval'}</div>
                       <div>{host.revokedAt ? `Revoked ${formatRelativeTime(host.revokedAt)}` : 'Credential active or pending'}</div>
                       <div>{host.credentialIssuedAt ? `Credential age ${host.credentialAgeHours ?? 0}h` : 'No credential issued yet'}</div>
-                      <div>{host.credentialRotatedAt ? `Last rotated ${formatRelativeTime(host.credentialRotatedAt)}` : 'No rotation yet'}</div>
+                      <div>{host.policy.rotation.nextRotationDueAt ? `Rotation ${host.policy.rotation.reviewState === 'overdue' ? 'overdue' : 'due'} ${formatRelativeTime(host.policy.rotation.nextRotationDueAt)}` : 'No rotation schedule yet'}</div>
+                      <div>{host.summary.delivery.latency.samples > 0 ? `p95 ${formatLatency(host.summary.delivery.latency.p95Ms)} · ${formatNumber(host.summary.delivery.latency.overSlo)} breach` : 'No latency samples yet'}</div>
+                      <div>{host.policy.recovery.status !== 'idle' ? `Recovery ${host.policy.recovery.status}${host.policy.recovery.owner ? ` · ${host.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
                     </div>
 
                     <div className="mt-3 flex flex-wrap gap-2">
@@ -778,6 +877,136 @@ export default function OpenClawFleetPage() {
                   <div>{selectedHost.credentialRotatedAt ? `Credential rotated ${formatDateTime(selectedHost.credentialRotatedAt)}` : 'No credential rotation yet'}</div>
                   <div>{`${formatNumber(selectedHost.summary.unavailable)} unavailable · ${formatNumber(selectedHost.summary.revoked)} revoked routes`}</div>
                   <div>{selectedHost.summary.delivery.lastRequestedAt ? `Last receipt ${formatRelativeTime(selectedHost.summary.delivery.lastRequestedAt)} · ${selectedHost.summary.delivery.lastStatus ?? 'unknown'}` : 'No delivery receipts yet'}</div>
+                  <div>{`Receipt coverage ${formatPercent(selectedHost.summary.delivery.coverage.ratio)} · ${formatNumber(selectedHost.summary.delivery.coverage.missingReceipts)} missing`}</div>
+                  <div>{selectedHost.summary.delivery.latency.samples > 0 ? `Latency avg ${formatLatency(selectedHost.summary.delivery.latency.avgMs)} · p95 ${formatLatency(selectedHost.summary.delivery.latency.p95Ms)}` : 'No latency samples yet'}</div>
+                  <div>{selectedHost.policy.rotation.nextRotationWindowStartsAt ? `Rotation window ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowStartsAt)}` : 'No rotation window scheduled'}</div>
+                  <div>{selectedHost.policy.recovery.status !== 'idle' ? `Recovery ${selectedHost.policy.recovery.status}${selectedHost.policy.recovery.owner ? ` · ${selectedHost.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Rotation and recovery</div>
+                    <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      Keep credential policy, rotation windows, and recovery handoff details attached to the host itself.
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusPill label={selectedHost.policy.rotation.reviewState} tone={selectedHost.policy.rotation.reviewState === 'overdue' ? 'critical' : selectedHost.policy.rotation.reviewState === 'due_soon' ? 'warning' : 'default'} />
+                    <StatusPill label={selectedHost.policy.recovery.status} tone={selectedHost.policy.recovery.status === 'cutover_pending' ? 'critical' : selectedHost.policy.recovery.status === 'prepared' ? 'warning' : selectedHost.policy.recovery.status === 'completed' ? 'success' : 'default'} />
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Rotation interval (hours)</span>
+                    <input
+                      className="input-field"
+                      min={1}
+                      step={1}
+                      type="number"
+                      value={policyForm.rotationIntervalHours}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, rotationIntervalHours: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Window start hour (UTC)</span>
+                    <input
+                      className="input-field"
+                      min={0}
+                      max={23}
+                      step={1}
+                      type="number"
+                      value={policyForm.rotationWindowStartHour}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, rotationWindowStartHour: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Window duration (hours)</span>
+                    <input
+                      className="input-field"
+                      min={1}
+                      max={24}
+                      step={1}
+                      type="number"
+                      value={policyForm.rotationWindowDurationHours}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, rotationWindowDurationHours: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Recovery owner</span>
+                    <input
+                      className="input-field"
+                      value={policyForm.recoveryOwner}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, recoveryOwner: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Recovery status</span>
+                    <select
+                      className="input-field"
+                      value={policyForm.recoveryStatus}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, recoveryStatus: event.target.value as OpenClawHostRecoveryRunbookState }))}
+                    >
+                      <option value="idle">idle</option>
+                      <option value="prepared">prepared</option>
+                      <option value="cutover_pending">cutover_pending</option>
+                      <option value="completed">completed</option>
+                    </select>
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Replacement host</span>
+                    <input
+                      className="input-field"
+                      value={policyForm.replacementHostLabel}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, replacementHostLabel: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Recovery window start</span>
+                    <input
+                      className="input-field"
+                      type="datetime-local"
+                      value={policyForm.recoveryWindowStartsAt}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, recoveryWindowStartsAt: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Recovery window end</span>
+                    <input
+                      className="input-field"
+                      type="datetime-local"
+                      value={policyForm.recoveryWindowEndsAt}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, recoveryWindowEndsAt: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400 md:col-span-3">
+                    <span>Recovery notes</span>
+                    <textarea
+                      className="input-field min-h-[96px]"
+                      value={policyForm.recoveryNotes}
+                      onChange={(event) => setPolicyForm((current) => ({ ...current, recoveryNotes: event.target.value }))}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                  <div>{selectedHost.policy.rotation.nextRotationDueAt ? `Next rotation due ${formatDateTime(selectedHost.policy.rotation.nextRotationDueAt)}` : 'No next rotation due yet'}</div>
+                  <div>{selectedHost.policy.rotation.nextRotationWindowEndsAt ? `Window ends ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowEndsAt)}` : 'No rotation window end yet'}</div>
+                  <div>{selectedHost.policy.recovery.windowStartsAt ? `Recovery window starts ${formatDateTime(selectedHost.policy.recovery.windowStartsAt)}` : 'No recovery window start yet'}</div>
+                  <div>{selectedHost.policy.recovery.windowEndsAt ? `Recovery window ends ${formatDateTime(selectedHost.policy.recovery.windowEndsAt)}` : 'No recovery window end yet'}</div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    disabled={actionBusy === `policy-${selectedHost.id}`}
+                    onClick={() => { void handleSavePolicy(selectedHost) }}
+                  >
+                    {actionBusy === `policy-${selectedHost.id}` ? 'Saving…' : 'Save policy'}
+                  </button>
                 </div>
               </div>
 

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -8,12 +8,16 @@ import {
   createDatabase,
   createOpenClawEnrollmentRequest,
   createOpenClawHost,
+  finalizeIntentLog,
   getIntentLogByNonce,
   listOpenClawResolvedRoutesByBeamId,
+  logIntentStart,
   recordOpenClawHostHeartbeat,
   registerAgent,
+  setIntentLifecycleStatus,
   syncOpenClawHostRoutes,
   assignDirectoryRole,
+  updateOpenClawHost,
 } from './db.js'
 import { getLocalDirectoryUrl } from './federation.js'
 import { createApp } from './server.js'
@@ -316,6 +320,12 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
         conflictRoutes: number
         endedRoutes: number
         failedReceipts: number
+        routesMissingReceipts: number
+        receiptCoverageRatio: number | null
+        degradedHosts: number
+        latencySloBreaches: number
+        rotationDueHosts: number
+        recoveryRunbooksOpen: number
         duplicateIdentityConflicts: number
         pendingCredentialActions: number
         actionItems: number
@@ -340,6 +350,12 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
       conflictRoutes: 0,
       endedRoutes: 0,
       failedReceipts: 0,
+      routesMissingReceipts: 1,
+      receiptCoverageRatio: 0,
+      degradedHosts: 1,
+      latencySloBreaches: 0,
+      rotationDueHosts: 0,
+      recoveryRunbooksOpen: 0,
       duplicateIdentityConflicts: 0,
       pendingCredentialActions: 0,
       actionItems: 1,
@@ -627,6 +643,102 @@ test('openclaw host credentials rotate and recover without rebuilding workspace 
   }
 })
 
+test('openclaw host policy patch surfaces rotation windows and recovery runbook state', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const receiver = createFixtureAgent('atlas@openclaw.beam.directory')
+    registerFixtureAgent(db, receiver, 'Atlas')
+
+    const host = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Policy',
+      hostname: 'policy.local',
+      beamId: receiver.beamId,
+      routeKey: 'atlas-policy',
+      workspaceSlug: 'openclaw-local',
+    })
+    updateOpenClawHost(db, {
+      id: host.host.id,
+      credentialIssuedAt: new Date(Date.now() - (4 * 60 * 60 * 1000)).toISOString(),
+    })
+
+    const app = createApp(db)
+    const policyResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}/policy`, {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        rotationIntervalHours: 1,
+        rotationWindowStartHour: 3,
+        rotationWindowDurationHours: 2,
+        recoveryOwner: 'ops@example.com',
+        recoveryStatus: 'prepared',
+        recoveryNotes: 'Replace chassis during the next window',
+        replacementHostLabel: 'policy-replacement',
+        recoveryWindowStartsAt: '2026-04-02T08:00:00.000Z',
+        recoveryWindowEndsAt: '2026-04-02T10:00:00.000Z',
+      }),
+    }))
+    assert.equal(policyResponse.status, 200)
+    const policyBody = await policyResponse.json() as {
+      host: {
+        policy: {
+          rotation: {
+            intervalHours: number
+            windowStartHour: number
+            windowDurationHours: number
+            reviewState: string
+            nextRotationDueAt: string | null
+          }
+          recovery: {
+            owner: string | null
+            status: string
+            notes: string | null
+            replacementHostLabel: string | null
+            windowStartsAt: string | null
+            windowEndsAt: string | null
+          }
+        }
+      }
+    }
+    assert.equal(policyBody.host.policy.rotation.intervalHours, 1)
+    assert.equal(policyBody.host.policy.rotation.windowStartHour, 3)
+    assert.equal(policyBody.host.policy.rotation.windowDurationHours, 2)
+    assert.equal(policyBody.host.policy.rotation.reviewState, 'overdue')
+    assert.ok(policyBody.host.policy.rotation.nextRotationDueAt)
+    assert.equal(policyBody.host.policy.recovery.owner, 'ops@example.com')
+    assert.equal(policyBody.host.policy.recovery.status, 'prepared')
+    assert.equal(policyBody.host.policy.recovery.notes, 'Replace chassis during the next window')
+    assert.equal(policyBody.host.policy.recovery.replacementHostLabel, 'policy-replacement')
+    assert.equal(policyBody.host.policy.recovery.windowStartsAt, '2026-04-02T08:00:00.000Z')
+    assert.equal(policyBody.host.policy.recovery.windowEndsAt, '2026-04-02T10:00:00.000Z')
+
+    const digestResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/digest', {
+      headers: createAdminHeaders(db, 'ops@example.com', 'operator'),
+    }))
+    assert.equal(digestResponse.status, 200)
+    const digestBody = await digestResponse.json() as {
+      summary: {
+        rotationDueHosts: number
+        recoveryRunbooksOpen: number
+      }
+      actionItems: Array<{
+        title: string
+        detail: string
+      }>
+    }
+    assert.equal(digestBody.summary.rotationDueHosts, 1)
+    assert.equal(digestBody.summary.recoveryRunbooksOpen, 1)
+    assert.ok(digestBody.actionItems.some((item) => item.title.includes('due for credential rotation')))
+    assert.ok(digestBody.actionItems.some((item) => item.detail.includes('policy-replacement')))
+  } finally {
+    db.close()
+  }
+})
+
 test('duplicate openclaw conflicts can be resolved by preferring one route owner', async () => {
   const db = createDatabase(':memory:')
 
@@ -694,6 +806,144 @@ test('duplicate openclaw conflicts can be resolved by preferring one route owner
       }
     }
     assert.equal(overviewBody.summary.duplicateIdentityConflicts, 0)
+  } finally {
+    db.close()
+  }
+})
+
+test('openclaw fleet overview surfaces receipt coverage and latency summaries', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const sender = createFixtureAgent('sender@openclaw.beam.directory')
+    const atlas = createFixtureAgent('atlas@openclaw.beam.directory')
+    const beta = createFixtureAgent('beta@openclaw.beam.directory')
+    registerFixtureAgent(db, sender, 'Sender')
+    registerFixtureAgent(db, atlas, 'Atlas')
+    registerFixtureAgent(db, beta, 'Beta')
+
+    const host = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Metrics',
+      hostname: 'metrics.local',
+      beamId: atlas.beamId,
+      routeKey: 'atlas-metrics',
+      workspaceSlug: 'openclaw-local',
+    })
+
+    syncOpenClawHostRoutes(db, {
+      hostId: host.host.id,
+      routes: [
+        {
+          beamId: atlas.beamId,
+          workspaceSlug: 'openclaw-local',
+          routeSource: 'gateway-agent',
+          routeKey: 'atlas-metrics',
+          runtimeType: 'openclaw:gateway',
+          label: 'Atlas',
+          connectionMode: 'websocket',
+          sessionKey: 'session-atlas',
+          reportedState: 'live',
+          lastSeenAt: new Date().toISOString(),
+        },
+        {
+          beamId: beta.beamId,
+          workspaceSlug: 'openclaw-local',
+          routeSource: 'gateway-agent',
+          routeKey: 'beta-metrics',
+          runtimeType: 'openclaw:gateway',
+          label: 'Beta',
+          connectionMode: 'websocket',
+          sessionKey: 'session-beta',
+          reportedState: 'live',
+          lastSeenAt: new Date().toISOString(),
+        },
+      ],
+    })
+    recordOpenClawHostHeartbeat(db, {
+      hostId: host.host.id,
+      routeCount: 2,
+      connectorVersion: '1.4.0-test',
+    })
+
+    for (const latency of [1800, 4200, 7200]) {
+      const frame = createSignedConversationIntent(sender, atlas.beamId, randomUUID())
+      logIntentStart(db, frame)
+      setIntentLifecycleStatus(db, {
+        nonce: frame.nonce,
+        status: 'validated',
+      })
+      setIntentLifecycleStatus(db, {
+        nonce: frame.nonce,
+        status: 'dispatched',
+      })
+      setIntentLifecycleStatus(db, {
+        nonce: frame.nonce,
+        status: 'delivered',
+      })
+      finalizeIntentLog(db, {
+        nonce: frame.nonce,
+        fromBeamId: frame.from,
+        toBeamId: frame.to,
+        status: 'acked',
+        latencyMs: latency,
+      })
+    }
+
+    const app = createApp(db)
+    const hostResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(hostResponse.status, 200)
+    const hostBody = await hostResponse.json() as {
+      host: {
+        summary: {
+          delivery: {
+            coverage: {
+              activeRoutes: number
+              routesWithReceipts: number
+              missingReceipts: number
+              ratio: number | null
+            }
+            latency: {
+              samples: number
+              avgMs: number | null
+              p50Ms: number | null
+              p95Ms: number | null
+              overSlo: number
+              degraded: boolean
+            }
+          }
+        }
+      }
+    }
+    assert.equal(hostBody.host.summary.delivery.coverage.activeRoutes, 2)
+    assert.equal(hostBody.host.summary.delivery.coverage.routesWithReceipts, 1)
+    assert.equal(hostBody.host.summary.delivery.coverage.missingReceipts, 1)
+    assert.equal(hostBody.host.summary.delivery.coverage.ratio, 0.5)
+    assert.equal(hostBody.host.summary.delivery.latency.samples, 3)
+    assert.equal(hostBody.host.summary.delivery.latency.avgMs, 4400)
+    assert.equal(hostBody.host.summary.delivery.latency.p50Ms, 4200)
+    assert.equal(hostBody.host.summary.delivery.latency.p95Ms, 7200)
+    assert.equal(hostBody.host.summary.delivery.latency.overSlo, 1)
+    assert.equal(hostBody.host.summary.delivery.latency.degraded, true)
+
+    const overviewResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewResponse.status, 200)
+    const overviewBody = await overviewResponse.json() as {
+      summary: {
+        routesMissingReceipts: number
+        receiptCoverageRatio: number | null
+        degradedHosts: number
+        latencySloBreaches: number
+      }
+    }
+    assert.equal(overviewBody.summary.routesMissingReceipts, 1)
+    assert.equal(overviewBody.summary.receiptCoverageRatio, 0.5)
+    assert.equal(overviewBody.summary.degradedHosts, 1)
+    assert.equal(overviewBody.summary.latencySloBreaches, 1)
   } finally {
     db.close()
   }
@@ -773,6 +1023,16 @@ test('stale openclaw host routes block Beam delivery before transport dispatch',
             receipts: number
             failed: number
             lastErrorCode: string | null
+            coverage: {
+              activeRoutes: number
+              routesWithReceipts: number
+              missingReceipts: number
+              ratio: number | null
+            }
+            latency: {
+              samples: number
+              degraded: boolean
+            }
           }
         }
       }
@@ -789,6 +1049,12 @@ test('stale openclaw host routes block Beam delivery before transport dispatch',
     assert.equal(routesBody.host.summary.delivery.receipts, 1)
     assert.equal(routesBody.host.summary.delivery.failed, 1)
     assert.equal(routesBody.host.summary.delivery.lastErrorCode, 'HOST_STALE')
+    assert.equal(routesBody.host.summary.delivery.coverage.activeRoutes, 0)
+    assert.equal(routesBody.host.summary.delivery.coverage.routesWithReceipts, 1)
+    assert.equal(routesBody.host.summary.delivery.coverage.missingReceipts, 0)
+    assert.equal(routesBody.host.summary.delivery.coverage.ratio, null)
+    assert.equal(routesBody.host.summary.delivery.latency.samples, 0)
+    assert.equal(routesBody.host.summary.delivery.latency.degraded, true)
     assert.equal(routesBody.routes[0]?.beamId, receiver.beamId)
     assert.equal(routesBody.routes[0]?.lastDelivery?.status, 'failed')
     assert.equal(routesBody.routes[0]?.lastDelivery?.errorCode, 'HOST_STALE')

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -83,6 +83,35 @@ type OpenClawConflictGroup = {
   }>
 }
 
+type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
+
+type OpenClawHostRecoveryRunbookState = 'idle' | 'prepared' | 'cutover_pending' | 'completed'
+
+type OpenClawHostMetadataJson = {
+  credentialPolicy?: {
+    rotationIntervalHours?: number | null
+    rotationWindowStartHour?: number | null
+    rotationWindowDurationHours?: number | null
+  }
+  recoveryRunbook?: {
+    owner?: string | null
+    status?: OpenClawHostRecoveryRunbookState | null
+    notes?: string | null
+    replacementHostLabel?: string | null
+    windowStartsAt?: string | null
+    windowEndsAt?: string | null
+    updatedAt?: string | null
+  }
+}
+
+const DEFAULT_OPENCLAW_ROTATION_INTERVAL_HOURS = 24 * 30
+const DEFAULT_OPENCLAW_ROTATION_WINDOW_START_HOUR = 2
+const DEFAULT_OPENCLAW_ROTATION_WINDOW_DURATION_HOURS = 4
+const OPENCLAW_ROTATION_DUE_SOON_HOURS = 72
+const OPENCLAW_ROUTE_LATENCY_SLO_MS = 5_000
+const OPENCLAW_ROUTE_LATENCY_LOOKBACK_HOURS = 24 * 7
+const OPENCLAW_ROUTE_LATENCY_LOG_LIMIT = 500
+
 function normalizeOptionalString(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null
@@ -95,6 +124,26 @@ function normalizeOptionalString(value: unknown): string | null {
 function normalizePositiveInteger(value: unknown): number | null {
   const parsed = Number.parseInt(String(value ?? ''), 10)
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+function normalizeBoundedInteger(value: unknown, min: number, max: number): number | null {
+  const parsed = Number.parseInt(String(value ?? ''), 10)
+  if (!Number.isFinite(parsed)) {
+    return null
+  }
+  return Math.min(max, Math.max(min, parsed))
+}
+
+function normalizeIsoDateTime(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const normalized = value.trim()
+  if (!normalized) {
+    return null
+  }
+  const parsed = Date.parse(normalized)
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null
 }
 
 function normalizeOpenClawRouteSource(value: unknown): OpenClawRouteSource | null {
@@ -136,6 +185,176 @@ function hoursSince(value: string | null): number | null {
     return null
   }
   return Math.round(((Date.now() - parsed) / 3_600_000) * 10) / 10
+}
+
+function hoursUntil(value: string | null): number | null {
+  if (!value) {
+    return null
+  }
+  const parsed = Date.parse(value)
+  if (!Number.isFinite(parsed)) {
+    return null
+  }
+  return Math.round(((parsed - Date.now()) / 3_600_000) * 10) / 10
+}
+
+function parseOpenClawHostMetadata(raw: string | null): OpenClawHostMetadataJson {
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+    return parsed as OpenClawHostMetadataJson
+  } catch {
+    return {}
+  }
+}
+
+function serializeOpenClawHostMetadata(metadata: OpenClawHostMetadataJson): string | null {
+  const cleaned: OpenClawHostMetadataJson = {}
+  if (metadata.credentialPolicy) {
+    cleaned.credentialPolicy = metadata.credentialPolicy
+  }
+  if (metadata.recoveryRunbook) {
+    cleaned.recoveryRunbook = metadata.recoveryRunbook
+  }
+  if (!cleaned.credentialPolicy && !cleaned.recoveryRunbook) {
+    return null
+  }
+  return JSON.stringify(cleaned)
+}
+
+function computeNextRotationWindow(
+  issuedAt: string | null,
+  intervalHours: number,
+  windowStartHour: number,
+  windowDurationHours: number,
+) {
+  const issuedMs = issuedAt ? Date.parse(issuedAt) : Number.NaN
+  if (!Number.isFinite(issuedMs)) {
+    return {
+      nextRotationDueAt: null as string | null,
+      nextRotationWindowStartsAt: null as string | null,
+      nextRotationWindowEndsAt: null as string | null,
+      dueInHours: null as number | null,
+      reviewState: 'scheduled' as OpenClawHostRotationReviewState,
+    }
+  }
+
+  const dueMs = issuedMs + (intervalHours * 60 * 60 * 1000)
+  const dueAt = new Date(dueMs)
+  const windowStart = new Date(dueMs)
+  windowStart.setUTCMinutes(0, 0, 0)
+  windowStart.setUTCHours(windowStartHour)
+  if (windowStart.getTime() < dueMs) {
+    windowStart.setUTCDate(windowStart.getUTCDate() + 1)
+  }
+  const windowEnd = new Date(windowStart.getTime() + (windowDurationHours * 60 * 60 * 1000))
+  const dueInHours = hoursUntil(dueAt.toISOString())
+  const reviewState: OpenClawHostRotationReviewState =
+    dueMs <= Date.now()
+      ? 'overdue'
+      : dueMs <= (Date.now() + (OPENCLAW_ROTATION_DUE_SOON_HOURS * 60 * 60 * 1000))
+        ? 'due_soon'
+        : 'scheduled'
+
+  return {
+    nextRotationDueAt: dueAt.toISOString(),
+    nextRotationWindowStartsAt: windowStart.toISOString(),
+    nextRotationWindowEndsAt: windowEnd.toISOString(),
+    dueInHours,
+    reviewState,
+  }
+}
+
+function percentile(values: number[], quantile: number): number | null {
+  if (values.length === 0) {
+    return null
+  }
+
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * quantile) - 1))
+  return sorted[index] ?? null
+}
+
+function listRecentIntentLogsByTargets(db: Database, targetBeamIds: string[]) {
+  const uniqueTargetBeamIds = [...new Set(targetBeamIds.filter(Boolean))]
+  if (uniqueTargetBeamIds.length === 0) {
+    return [] as IntentLogRow[]
+  }
+
+  const placeholders = uniqueTargetBeamIds.map(() => '?').join(', ')
+  const cutoffIso = new Date(Date.now() - (OPENCLAW_ROUTE_LATENCY_LOOKBACK_HOURS * 60 * 60 * 1000)).toISOString()
+  return db.prepare(`
+    SELECT *
+    FROM intent_log
+    WHERE to_beam_id IN (${placeholders})
+      AND datetime(requested_at) >= datetime(?)
+    ORDER BY datetime(requested_at) DESC, id DESC
+    LIMIT ?
+  `).all(...uniqueTargetBeamIds, cutoffIso, OPENCLAW_ROUTE_LATENCY_LOG_LIMIT) as IntentLogRow[]
+}
+
+function serializeOpenClawHostPolicy(host: OpenClawHostRow) {
+  const metadata = parseOpenClawHostMetadata(host.metadata_json)
+  const rotationPolicy = metadata.credentialPolicy && typeof metadata.credentialPolicy === 'object'
+    ? metadata.credentialPolicy
+    : {}
+  const recoveryRunbook = metadata.recoveryRunbook && typeof metadata.recoveryRunbook === 'object'
+    ? metadata.recoveryRunbook
+    : {}
+
+  const rotationIntervalHours = normalizeBoundedInteger(rotationPolicy.rotationIntervalHours, 1, 24 * 180)
+    ?? DEFAULT_OPENCLAW_ROTATION_INTERVAL_HOURS
+  const rotationWindowStartHour = normalizeBoundedInteger(rotationPolicy.rotationWindowStartHour, 0, 23)
+    ?? DEFAULT_OPENCLAW_ROTATION_WINDOW_START_HOUR
+  const rotationWindowDurationHours = normalizeBoundedInteger(rotationPolicy.rotationWindowDurationHours, 1, 24)
+    ?? DEFAULT_OPENCLAW_ROTATION_WINDOW_DURATION_HOURS
+  const nextRotation = computeNextRotationWindow(
+    host.credential_issued_at,
+    rotationIntervalHours,
+    rotationWindowStartHour,
+    rotationWindowDurationHours,
+  )
+
+  const rawRecoveryStatus = recoveryRunbook.status === 'prepared'
+    || recoveryRunbook.status === 'cutover_pending'
+    || recoveryRunbook.status === 'completed'
+    || recoveryRunbook.status === 'idle'
+    ? recoveryRunbook.status
+    : null
+  const recoveryStatus: OpenClawHostRecoveryRunbookState =
+    host.credential_state === 'recovery_pending'
+      ? 'cutover_pending'
+      : host.recovery_completed_at
+        ? 'completed'
+        : (rawRecoveryStatus ?? 'idle')
+
+  return {
+    rotation: {
+      intervalHours: rotationIntervalHours,
+      windowStartHour: rotationWindowStartHour,
+      windowDurationHours: rotationWindowDurationHours,
+      nextRotationDueAt: nextRotation.nextRotationDueAt,
+      nextRotationWindowStartsAt: nextRotation.nextRotationWindowStartsAt,
+      nextRotationWindowEndsAt: nextRotation.nextRotationWindowEndsAt,
+      dueInHours: nextRotation.dueInHours,
+      reviewState: nextRotation.reviewState,
+    },
+    recovery: {
+      owner: normalizeOptionalString(recoveryRunbook.owner),
+      status: recoveryStatus,
+      notes: normalizeOptionalString(recoveryRunbook.notes),
+      replacementHostLabel: normalizeOptionalString(recoveryRunbook.replacementHostLabel),
+      windowStartsAt: normalizeIsoDateTime(recoveryRunbook.windowStartsAt),
+      windowEndsAt: normalizeIsoDateTime(recoveryRunbook.windowEndsAt),
+      updatedAt: normalizeIsoDateTime(recoveryRunbook.updatedAt) ?? host.recovery_completed_at,
+    },
+  }
 }
 
 function serializeEnrollment(row: OpenClawHostEnrollmentRequestRow | null) {
@@ -310,8 +529,20 @@ function serializeRoute(db: Database, row: OpenClawResolvedRouteRow) {
 }
 
 function summarizeRoutes(db: Database, routes: OpenClawResolvedRouteRow[]) {
+  const recentLogs = listRecentIntentLogsByTargets(db, routes.map((route) => route.beam_id))
+  const recentLogsByTarget = new Map<string, IntentLogRow[]>()
+  for (const log of recentLogs) {
+    const existing = recentLogsByTarget.get(log.to_beam_id)
+    if (existing) {
+      existing.push(log)
+    } else {
+      recentLogsByTarget.set(log.to_beam_id, [log])
+    }
+  }
+
   const summary = routes.reduce((current, route) => {
-    const latestDelivery = getLatestIntentLogByTarget(db, route.beam_id)
+    const targetLogs = recentLogsByTarget.get(route.beam_id) ?? []
+    const latestDelivery = targetLogs[0] ?? getLatestIntentLogByTarget(db, route.beam_id)
     current.total += 1
     switch (route.runtime_session_state) {
       case 'live':
@@ -345,6 +576,7 @@ function summarizeRoutes(db: Database, routes: OpenClawResolvedRouteRow[]) {
 
     if (latestDelivery) {
       current.delivery.receipts += 1
+      current.delivery.coverage.routesWithReceipts += 1
       if (latestDelivery.status === 'failed' || latestDelivery.error_code) {
         current.delivery.failed += 1
       }
@@ -375,8 +607,50 @@ function summarizeRoutes(db: Database, routes: OpenClawResolvedRouteRow[]) {
       lastStatus: null as IntentLogRow['status'] | null,
       lastErrorCode: null as string | null,
       lastHref: null as string | null,
+      coverage: {
+        activeRoutes: 0,
+        routesWithReceipts: 0,
+        missingReceipts: 0,
+        ratio: null as number | null,
+      },
+      latency: {
+        targetMs: OPENCLAW_ROUTE_LATENCY_SLO_MS,
+        samples: 0,
+        avgMs: null as number | null,
+        p50Ms: null as number | null,
+        p95Ms: null as number | null,
+        overSlo: 0,
+        degraded: false,
+      },
     },
   })
+
+  summary.delivery.coverage.activeRoutes = routes.filter((route) =>
+    route.runtime_session_state === 'live' || route.runtime_session_state === 'idle',
+  ).length
+  summary.delivery.coverage.missingReceipts = Math.max(
+    0,
+    summary.delivery.coverage.activeRoutes - summary.delivery.coverage.routesWithReceipts,
+  )
+  summary.delivery.coverage.ratio = summary.delivery.coverage.activeRoutes > 0
+    ? Number((summary.delivery.coverage.routesWithReceipts / summary.delivery.coverage.activeRoutes).toFixed(3))
+    : null
+
+  const ackLatencies = recentLogs
+    .filter((log) => log.status === 'acked' && typeof log.round_trip_latency_ms === 'number')
+    .map((log) => log.round_trip_latency_ms as number)
+  if (ackLatencies.length > 0) {
+    const total = ackLatencies.reduce((sum, value) => sum + value, 0)
+    summary.delivery.latency.samples = ackLatencies.length
+    summary.delivery.latency.avgMs = Math.round(total / ackLatencies.length)
+    summary.delivery.latency.p50Ms = percentile(ackLatencies, 0.5)
+    summary.delivery.latency.p95Ms = percentile(ackLatencies, 0.95)
+    summary.delivery.latency.overSlo = ackLatencies.filter((value) => value > OPENCLAW_ROUTE_LATENCY_SLO_MS).length
+  }
+  summary.delivery.latency.degraded =
+    summary.delivery.failed > 0
+    || summary.delivery.coverage.missingReceipts > 0
+    || summary.delivery.latency.overSlo > 0
 
   return summary
 }
@@ -387,6 +661,7 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
     : null
   const routes = listOpenClawResolvedRoutesForHost(db, host.id)
   const summary = summarizeRoutes(db, routes)
+  const policy = serializeOpenClawHostPolicy(host)
 
   return {
     id: host.id,
@@ -415,6 +690,7 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
     lastRouteEventAt: host.last_route_event_at,
     createdAt: host.created_at,
     updatedAt: host.updated_at,
+    policy,
     enrollment: serializeEnrollment(enrollment),
     summary,
   }
@@ -484,6 +760,22 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
       })
     }
 
+    if (host.policy.rotation.reviewState === 'overdue' || host.policy.rotation.reviewState === 'due_soon') {
+      actionItems.push({
+        id: `credential-window:${host.id}`,
+        severity: host.policy.rotation.reviewState === 'overdue' ? 'critical' : 'warning',
+        category: 'credential',
+        title: `${hostTitleForDigest(host)} is due for credential rotation`,
+        detail: `${baseDetail} last issued a host credential ${host.credentialAgeHours ?? 0}h ago. The next rotation window starts ${host.policy.rotation.nextRotationWindowStartsAt ? `at ${host.policy.rotation.nextRotationWindowStartsAt}` : 'soon'}.`,
+        nextAction: 'Review the host rotation window, rotate the credential in Beam, then confirm the host returns with a fresh heartbeat and inventory sync.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: null,
+      })
+    }
+
     if (host.credentialState === 'rotation_pending') {
       actionItems.push({
         id: `credential-rotate:${host.id}`,
@@ -508,6 +800,24 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
         title: `${hostTitleForDigest(host)} is waiting for recovery cutover`,
         detail: `${baseDetail} has a recovery credential issued and will stay unavailable until the replacement machine publishes inventory with the recovered host identity.`,
         nextAction: 'Install the recovery credential on the replacement host, then verify heartbeat and inventory before closing the recovery.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: null,
+      })
+    }
+
+    if (host.policy.recovery.status === 'prepared' || host.policy.recovery.status === 'cutover_pending') {
+      actionItems.push({
+        id: `recovery-runbook:${host.id}`,
+        severity: host.policy.recovery.status === 'cutover_pending' ? 'critical' : 'warning',
+        category: 'host',
+        title: `${hostTitleForDigest(host)} has an open recovery runbook`,
+        detail: `${baseDetail} is assigned to ${host.policy.recovery.owner ?? 'an operator'} with recovery state ${host.policy.recovery.status}${host.policy.recovery.replacementHostLabel ? ` on ${host.policy.recovery.replacementHostLabel}` : ''}.`,
+        nextAction: host.policy.recovery.status === 'cutover_pending'
+          ? 'Complete the recovery cutover, confirm fresh routes on the replacement host, then close the runbook state.'
+          : 'Review the recovery notes and schedule the replacement window before the next operator handoff.',
         hostId: host.id,
         hostLabel: host.label,
         workspaceSlug: host.workspaceSlug,
@@ -543,6 +853,24 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
         workspaceSlug: host.workspaceSlug,
         href: hostHref,
         traceHref: null,
+      })
+    }
+
+    if (host.summary.delivery.latency.overSlo > 0) {
+      actionItems.push({
+        id: `delivery-latency:${host.id}`,
+        severity: host.summary.delivery.latency.p95Ms && host.summary.delivery.latency.p95Ms > OPENCLAW_ROUTE_LATENCY_SLO_MS * 2
+          ? 'critical'
+          : 'warning',
+        category: 'delivery',
+        title: `${hostTitleForDigest(host)} is breaching fleet delivery latency`,
+        detail: `${baseDetail} has ${host.summary.delivery.latency.overSlo} receipt(s) above the ${OPENCLAW_ROUTE_LATENCY_SLO_MS}ms target. Recent p95 is ${host.summary.delivery.latency.p95Ms ?? 'unknown'}ms.`,
+        nextAction: 'Open the affected traces, verify route transport and host health, then confirm fresh receipts land within the fleet SLO.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: lastTraceHref,
       })
     }
 
@@ -589,6 +917,16 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
     liveRoutes: hosts.reduce((sum, host) => sum + host.summary.live, 0),
     staleRoutes: hosts.reduce((sum, host) => sum + host.summary.stale, 0),
     failedReceipts: hosts.reduce((sum, host) => sum + host.summary.delivery.failed, 0),
+    routesMissingReceipts: hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.missingReceipts, 0),
+    degradedHosts: hosts.filter((host) => host.summary.delivery.latency.degraded).length,
+    latencySloBreaches: hosts.reduce((sum, host) => sum + host.summary.delivery.latency.overSlo, 0),
+    rotationDueHosts: hosts.filter((host) => host.policy.rotation.reviewState === 'due_soon' || host.policy.rotation.reviewState === 'overdue').length,
+    recoveryRunbooksOpen: hosts.filter((host) => host.policy.recovery.status === 'prepared' || host.policy.recovery.status === 'cutover_pending').length,
+    receiptCoverageRatio: (() => {
+      const activeRoutes = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.activeRoutes, 0)
+      const routesWithReceipts = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.routesWithReceipts, 0)
+      return activeRoutes > 0 ? Number((routesWithReceipts / activeRoutes).toFixed(3)) : null
+    })(),
     duplicateIdentityConflicts: conflicts.length,
     pendingCredentialActions: hosts.filter((host) => host.credentialState === 'rotation_pending' || host.credentialState === 'recovery_pending').length,
     actionItems: actionItems.length,
@@ -604,7 +942,8 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
     `- Hosts: \`${summary.totalHosts}\` total · \`${summary.activeHosts}\` active · \`${summary.pendingHosts}\` pending · \`${summary.revokedHosts}\` revoked`,
     `- Fleet health: \`${summary.staleHosts}\` stale host(s) · \`${summary.pendingCredentialActions}\` credential action(s) pending`,
     `- Routes: \`${summary.liveRoutes}\` live · \`${summary.staleRoutes}\` stale`,
-    `- Delivery: \`${summary.failedReceipts}\` failed receipt(s) · \`${summary.duplicateIdentityConflicts}\` duplicate conflict(s)`,
+    `- Delivery: \`${summary.failedReceipts}\` failed receipt(s) · \`${summary.routesMissingReceipts}\` route(s) without receipts · \`${summary.duplicateIdentityConflicts}\` duplicate conflict(s)`,
+    `- SLO: \`${summary.degradedHosts}\` degraded host(s) · \`${summary.latencySloBreaches}\` latency breach(es) · coverage \`${summary.receiptCoverageRatio === null ? 'n/a' : `${Math.round(summary.receiptCoverageRatio * 100)}%`}\``,
     `- Operator backlog: \`${summary.actionItems}\` action item(s) · \`${summary.criticalItems}\` critical`,
     '',
     '## Action Items',
@@ -741,6 +1080,15 @@ export function openClawAdminRouter(db: Database) {
       acc.conflictRoutes += host.summary.conflict
       acc.endedRoutes += host.summary.ended
       acc.failedReceipts += host.summary.delivery.failed
+      acc.routesMissingReceipts += host.summary.delivery.coverage.missingReceipts
+      acc.degradedHosts += host.summary.delivery.latency.degraded ? 1 : 0
+      acc.latencySloBreaches += host.summary.delivery.latency.overSlo
+      if (host.policy.rotation.reviewState === 'due_soon' || host.policy.rotation.reviewState === 'overdue') {
+        acc.rotationDueHosts += 1
+      }
+      if (host.policy.recovery.status === 'prepared' || host.policy.recovery.status === 'cutover_pending') {
+        acc.recoveryRunbooksOpen += 1
+      }
       return acc
     }, {
       totalHosts: 0,
@@ -753,12 +1101,21 @@ export function openClawAdminRouter(db: Database) {
       conflictRoutes: 0,
       endedRoutes: 0,
       failedReceipts: 0,
+      routesMissingReceipts: 0,
+      degradedHosts: 0,
+      latencySloBreaches: 0,
+      rotationDueHosts: 0,
+      recoveryRunbooksOpen: 0,
     })
+
+    const activeRoutes = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.activeRoutes, 0)
+    const routesWithReceipts = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.routesWithReceipts, 0)
 
     c.header('Cache-Control', 'no-store')
     return c.json({
       summary: {
         ...summary,
+        receiptCoverageRatio: activeRoutes > 0 ? Number((routesWithReceipts / activeRoutes).toFixed(3)) : null,
         duplicateIdentityConflicts: conflicts.length,
         pendingCredentialActions: digest.summary.pendingCredentialActions,
         actionItems: digest.summary.actionItems,
@@ -923,10 +1280,17 @@ export function openClawAdminRouter(db: Database) {
       return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
     }
 
-    const routes = listOpenClawResolvedRoutesForHost(db, host.id).map((route) => serializeRoute(db, route))
+    refreshOpenClawHostHealth(db)
+    recalculateOpenClawRouteStates(db)
+    const refreshedHost = getOpenClawHostById(db, hostId)
+    if (!refreshedHost) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const routes = listOpenClawResolvedRoutesForHost(db, refreshedHost.id).map((route) => serializeRoute(db, route))
     c.header('Cache-Control', 'no-store')
     return c.json({
-      host: serializeHost(db, host),
+      host: serializeHost(db, refreshedHost),
       routes,
       total: routes.length,
     })
@@ -948,7 +1312,14 @@ export function openClawAdminRouter(db: Database) {
       return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
     }
 
-    const routes = listOpenClawResolvedRoutesForHost(db, host.id)
+    refreshOpenClawHostHealth(db)
+    recalculateOpenClawRouteStates(db)
+    const refreshedHost = getOpenClawHostById(db, hostId)
+    if (!refreshedHost) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const routes = listOpenClawResolvedRoutesForHost(db, refreshedHost.id)
     const identities = routes.map((route) => {
       const bindings = listWorkspaceIdentityBindingsByBeamId(db, route.beam_id)
       const agent = getAgent(db, route.beam_id)
@@ -975,7 +1346,7 @@ export function openClawAdminRouter(db: Database) {
 
     c.header('Cache-Control', 'no-store')
     return c.json({
-      host: serializeHost(db, host),
+      host: serializeHost(db, refreshedHost),
       identities,
       total: identities.length,
     })
@@ -1056,6 +1427,99 @@ export function openClawAdminRouter(db: Database) {
     })
   })
 
+  router.patch('/hosts/:id/policy', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const metadata = parseOpenClawHostMetadata(host.metadata_json)
+    const nextMetadata: OpenClawHostMetadataJson = {
+      ...metadata,
+      credentialPolicy: {
+        ...(metadata.credentialPolicy ?? {}),
+        rotationIntervalHours: normalizePositiveInteger(body.rotationIntervalHours)
+          ?? metadata.credentialPolicy?.rotationIntervalHours
+          ?? DEFAULT_OPENCLAW_ROTATION_INTERVAL_HOURS,
+        rotationWindowStartHour: normalizeBoundedInteger(body.rotationWindowStartHour, 0, 23)
+          ?? metadata.credentialPolicy?.rotationWindowStartHour
+          ?? DEFAULT_OPENCLAW_ROTATION_WINDOW_START_HOUR,
+        rotationWindowDurationHours: normalizeBoundedInteger(body.rotationWindowDurationHours, 1, 24)
+          ?? metadata.credentialPolicy?.rotationWindowDurationHours
+          ?? DEFAULT_OPENCLAW_ROTATION_WINDOW_DURATION_HOURS,
+      },
+      recoveryRunbook: {
+        ...(metadata.recoveryRunbook ?? {}),
+        owner: normalizeOptionalString(body.recoveryOwner)
+          ?? metadata.recoveryRunbook?.owner
+          ?? null,
+        status: body.recoveryStatus === 'prepared'
+          || body.recoveryStatus === 'cutover_pending'
+          || body.recoveryStatus === 'completed'
+          || body.recoveryStatus === 'idle'
+          ? body.recoveryStatus
+          : (metadata.recoveryRunbook?.status ?? 'idle'),
+        notes: normalizeOptionalString(body.recoveryNotes)
+          ?? metadata.recoveryRunbook?.notes
+          ?? null,
+        replacementHostLabel: normalizeOptionalString(body.replacementHostLabel)
+          ?? metadata.recoveryRunbook?.replacementHostLabel
+          ?? null,
+        windowStartsAt: normalizeIsoDateTime(body.recoveryWindowStartsAt)
+          ?? metadata.recoveryRunbook?.windowStartsAt
+          ?? null,
+        windowEndsAt: normalizeIsoDateTime(body.recoveryWindowEndsAt)
+          ?? metadata.recoveryRunbook?.windowEndsAt
+          ?? null,
+        updatedAt: new Date().toISOString(),
+      },
+    }
+
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: serializeOpenClawHostMetadata(nextMetadata),
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.policy_updated',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+        rotationIntervalHours: nextMetadata.credentialPolicy?.rotationIntervalHours ?? null,
+        rotationWindowStartHour: nextMetadata.credentialPolicy?.rotationWindowStartHour ?? null,
+        rotationWindowDurationHours: nextMetadata.credentialPolicy?.rotationWindowDurationHours ?? null,
+        recoveryOwner: nextMetadata.recoveryRunbook?.owner ?? null,
+        recoveryStatus: nextMetadata.recoveryRunbook?.status ?? null,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      host: serializeHost(db, updated),
+    })
+  })
+
   router.post('/hosts/:id/recover', async (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'admin')
     if (auth instanceof Response) {
@@ -1075,20 +1539,34 @@ export function openClawAdminRouter(db: Database) {
       return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
     }
 
+    const recoveryMetadata = parseOpenClawHostMetadata(recovered.host.metadata_json)
+    const recoveredHost = updateOpenClawHost(db, {
+      id: recovered.host.id,
+      metadataJson: serializeOpenClawHostMetadata({
+        ...recoveryMetadata,
+        recoveryRunbook: {
+          ...(recoveryMetadata.recoveryRunbook ?? {}),
+          owner: normalizeOptionalString(recoveryMetadata.recoveryRunbook?.owner) ?? auth.session.email,
+          status: 'cutover_pending',
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    }) as OpenClawHostRow
+
     logAuditEvent(db, {
       action: 'admin.openclaw_host.recovered',
       actor: auth.session.email,
-      target: `openclaw-host:${recovered.host.id}`,
+      target: `openclaw-host:${recoveredHost.id}`,
       details: {
         role: auth.session.role,
-        hostname: recovered.host.hostname,
-        label: recovered.host.label,
+        hostname: recoveredHost.hostname,
+        label: recoveredHost.label,
       },
     })
 
     c.header('Cache-Control', 'no-store')
     return c.json({
-      host: serializeHost(db, recovered.host),
+      host: serializeHost(db, recoveredHost),
       credential: recovered.credential,
       installPack: buildCredentialRefreshPack({
         directoryUrl: new URL(c.req.url).origin,
@@ -1290,11 +1768,18 @@ export function openClawAdminRouter(db: Database) {
       return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
     }
 
+    refreshOpenClawHostHealth(db)
+    recalculateOpenClawRouteStates(db)
+    const refreshedHost = getOpenClawHostById(db, hostId)
+    if (!refreshedHost) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
     c.header('Cache-Control', 'no-store')
     return c.json({
-      host: serializeHost(db, host),
-      routes: listOpenClawResolvedRoutesForHost(db, host.id).map((route) => serializeRoute(db, route)),
-      heartbeats: listOpenClawHostHeartbeats(db, host.id, 20).map((row) => ({
+      host: serializeHost(db, refreshedHost),
+      routes: listOpenClawResolvedRoutesForHost(db, refreshedHost.id).map((route) => serializeRoute(db, route)),
+      heartbeats: listOpenClawHostHeartbeats(db, refreshedHost.id, 20).map((row) => ({
         id: row.id,
         routeCount: row.route_count,
         connectorVersion: row.connector_version,


### PR DESCRIPTION
## Summary\n- add host credential policy and recovery runbook controls for the OpenClaw fleet\n- surface receipt coverage and latency SLO summaries in fleet APIs and dashboard\n- document and test the new rotation, recovery, and delivery health flows\n\n## Testing\n- npm test --workspace=packages/directory\n- npm run build\n- npm test\n- npm -C docs run build\n\nCloses #152\nCloses #153