### PR TITLE
Add workspace approval queue automation

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -32,6 +32,7 @@ The current operator-facing surface now covers workspace creation, identity bind
 It also supports direct operator dispatch: a blocked handoff thread can now be approved and sent as a real Beam message from the workspace surface, without waiting for a separate runtime UI.
 Partner channels now also resolve back into the local control plane when the target Beam ID belongs to another Beam-managed workspace identity. That gives operators a real cross-workspace route instead of a raw external address.
 Each local identity card now also exposes the explicit Beam DID, key history, a one-time local credential reissue flow, and a per-agent partner-control override. That makes it practical to bind imported OpenClaw agents, hand them a Beam identity bundle, and keep partner policy close to the specific agent that is allowed to speak externally.
+The workspace page now also exposes an approval queue for manual-review bindings and blocked outbound handoff threads. Operators can approve one binding, pause it, bulk-approve several bindings, or save partner-scoped defaults for known channels without bouncing between the policy, thread, and partner panels.
 
 ## Fast local sync demo
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -677,6 +677,51 @@ export interface WorkspaceOverviewResponse {
   recentExternalHandoffs: WorkspaceOverviewHandoff[]
 }
 
+export interface WorkspaceApprovalQueueBindingItem {
+  id: string
+  kind: 'binding'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
+  binding: WorkspaceIdentityBinding
+  suggestedAllowedPartners: string[]
+}
+
+export interface WorkspaceApprovalQueueThreadItem {
+  id: string
+  kind: 'thread'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
+  thread: WorkspaceThread
+  senderBinding: WorkspaceIdentityBinding | null
+  partnerChannel: WorkspacePartnerChannel | null
+  policyPreview: WorkspacePolicyPreview | null
+  suggestedAllowedPartners: string[]
+  dispatchReady: boolean
+  blockedReason: string | null
+}
+
+export type WorkspaceApprovalQueueItem = WorkspaceApprovalQueueBindingItem | WorkspaceApprovalQueueThreadItem
+
+export interface WorkspaceApprovalQueueResponse {
+  workspace: WorkspaceRecord
+  generatedAt: string
+  summary: {
+    total: number
+    bindingApprovals: number
+    threadApprovals: number
+    critical: number
+  }
+  items: WorkspaceApprovalQueueItem[]
+}
+
 export interface WorkspaceThreadTrace {
   nonce: string
   status: IntentLifecycleStatus
@@ -2242,6 +2287,7 @@ export const directoryApi = {
   }, { admin: true }),
   listWorkspaces: () => request<WorkspaceListResponse>('/admin/workspaces', undefined, { admin: true }),
   getWorkspaceOverview: (slug: string) => request<WorkspaceOverviewResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/overview`, undefined, { admin: true }),
+  getWorkspaceApprovalQueue: (slug: string) => request<WorkspaceApprovalQueueResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/approval-queue`, undefined, { admin: true }),
   listWorkspaceIdentities: (slug: string) => request<WorkspaceIdentitiesResponse>(`/admin/workspaces/${encodeURIComponent(slug)}/identities`, undefined, { admin: true }),
   updateWorkspaceIdentity: (slug: string, id: number, input: WorkspaceIdentityPatchInput) => request<{ binding: WorkspaceIdentityBinding }>(`/admin/workspaces/${encodeURIComponent(slug)}/identities/${id}`, {
     method: 'PATCH',

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -6,6 +6,10 @@ import {
   directoryApi,
   type IntentCatalogItem,
   type IntentLifecycleStatus,
+  type WorkspaceApprovalQueueBindingItem,
+  type WorkspaceApprovalQueueItem,
+  type WorkspaceApprovalQueueResponse,
+  type WorkspaceApprovalQueueThreadItem,
   type WorkspaceBindingStatus,
   type WorkspaceDigestActionItem,
   type WorkspaceDigestResponse,
@@ -157,6 +161,10 @@ function threadStatusTone(status: WorkspaceThreadStatus): 'default' | 'success' 
 }
 
 function digestSeverityTone(severity: WorkspaceDigestActionItem['severity']): 'default' | 'warning' | 'critical' {
+  return severity === 'critical' ? 'critical' : 'warning'
+}
+
+function approvalSeverityTone(severity: WorkspaceApprovalQueueItem['severity']): 'default' | 'warning' | 'critical' {
   return severity === 'critical' ? 'critical' : 'warning'
 }
 
@@ -473,6 +481,14 @@ function sortPartnerChannelsForComposer(channels: WorkspacePartnerChannel[]): Wo
   })
 }
 
+function isBindingApprovalItem(item: WorkspaceApprovalQueueItem): item is WorkspaceApprovalQueueBindingItem {
+  return item.kind === 'binding'
+}
+
+function isThreadApprovalItem(item: WorkspaceApprovalQueueItem): item is WorkspaceApprovalQueueThreadItem {
+  return item.kind === 'thread'
+}
+
 function buildPolicyDefaultsState(policy: WorkspacePolicyResponse | null) {
   return {
     externalInitiation: policy?.policy.defaults.externalInitiation ?? 'binding',
@@ -485,6 +501,7 @@ export default function WorkspacesPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [workspaces, setWorkspaces] = useState<WorkspaceRecord[]>([])
   const [overview, setOverview] = useState<WorkspaceOverviewResponse | null>(null)
+  const [approvalQueue, setApprovalQueue] = useState<WorkspaceApprovalQueueResponse | null>(null)
   const [bindings, setBindings] = useState<WorkspaceIdentityBinding[]>([])
   const [channels, setChannels] = useState<WorkspacePartnerChannel[]>([])
   const [threads, setThreads] = useState<WorkspaceThread[]>([])
@@ -534,6 +551,7 @@ export default function WorkspacesPage() {
     bindingId: number
     bundle: WorkspaceIdentityCredentialBundle
   } | null>(null)
+  const [selectedApprovalBindingIds, setSelectedApprovalBindingIds] = useState<number[]>([])
 
   const selectedSlug = searchParams.get('workspace') ?? ''
   const selectedThreadId = useMemo(() => {
@@ -609,6 +627,14 @@ export default function WorkspacesPage() {
     () => channels.find((channel) => channel.id === Number.parseInt(threadForm.partnerChannelId, 10)) ?? null,
     [channels, threadForm.partnerChannelId],
   )
+  const approvalBindingItems = useMemo(
+    () => approvalQueue?.items.filter(isBindingApprovalItem) ?? [],
+    [approvalQueue],
+  )
+  const selectedApprovalBindingItems = useMemo(
+    () => approvalBindingItems.filter((item) => selectedApprovalBindingIds.includes(item.binding.id)),
+    [approvalBindingItems, selectedApprovalBindingIds],
+  )
   const threadDetailWorkspaceRoute = useMemo(() => {
     if (!threadDetail) {
       return null
@@ -646,6 +672,7 @@ export default function WorkspacesPage() {
   async function loadWorkspaceSurface(slug: string) {
     const [
       overviewResponse,
+      approvalQueueResponse,
       identitiesResponse,
       partnerChannelsResponse,
       threadsResponse,
@@ -654,6 +681,7 @@ export default function WorkspacesPage() {
       digestResponse,
     ] = await Promise.all([
       directoryApi.getWorkspaceOverview(slug),
+      directoryApi.getWorkspaceApprovalQueue(slug),
       directoryApi.listWorkspaceIdentities(slug),
       directoryApi.listWorkspacePartnerChannels(slug),
       directoryApi.listWorkspaceThreads(slug),
@@ -663,6 +691,7 @@ export default function WorkspacesPage() {
     ])
 
     setOverview(overviewResponse)
+    setApprovalQueue(approvalQueueResponse)
     setBindings(identitiesResponse.bindings)
     setChannels(partnerChannelsResponse.channels)
     setThreads(threadsResponse.threads)
@@ -761,6 +790,7 @@ export default function WorkspacesPage() {
   useEffect(() => {
     if (!selectedWorkspace) {
       setOverview(null)
+      setApprovalQueue(null)
       setBindings([])
       setChannels([])
       setThreads([])
@@ -768,6 +798,7 @@ export default function WorkspacesPage() {
       setPolicy(null)
       setTimeline([])
       setDigest(null)
+      setSelectedApprovalBindingIds([])
       return
     }
 
@@ -782,6 +813,10 @@ export default function WorkspacesPage() {
         setSurfaceLoading(false)
       }
     })()
+  }, [selectedWorkspace?.slug])
+
+  useEffect(() => {
+    setSelectedApprovalBindingIds([])
   }, [selectedWorkspace?.slug])
 
   useEffect(() => {
@@ -1158,6 +1193,115 @@ export default function WorkspacesPage() {
     }
   }
 
+  function toggleApprovalBindingSelection(bindingId: number) {
+    setSelectedApprovalBindingIds((current) => (
+      current.includes(bindingId)
+        ? current.filter((value) => value !== bindingId)
+        : [...current, bindingId]
+    ))
+  }
+
+  async function approveBindingExternalMotion(
+    item: WorkspaceApprovalQueueBindingItem,
+    options: {
+      saveDefault?: boolean
+      pauseInstead?: boolean
+    } = {},
+  ) {
+    if (!selectedWorkspace) return
+
+    const allowPartners = options.saveDefault ? item.suggestedAllowedPartners : []
+    await runAction(`approval-binding-${item.binding.id}`, async () => {
+      await directoryApi.updateWorkspaceIdentity(selectedWorkspace.slug, item.binding.id, {
+        status: options.pauseInstead ? 'paused' : 'active',
+        canInitiateExternal: options.pauseInstead ? false : true,
+      })
+
+      if (!options.pauseInstead && options.saveDefault) {
+        await directoryApi.updateWorkspaceIdentityPolicy(selectedWorkspace.slug, item.binding.id, {
+          externalInitiation: 'allow',
+          allowedPartners: allowPartners,
+        })
+      }
+
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      setSelectedApprovalBindingIds((current) => current.filter((value) => value !== item.binding.id))
+    }, options.pauseInstead
+      ? `${item.binding.beamId} paused and removed from outbound approval.`
+      : options.saveDefault
+        ? `${item.binding.beamId} approved with partner-scoped defaults.`
+        : `${item.binding.beamId} approved for outbound motion.`)
+  }
+
+  async function handleBulkBindingApproval(options: {
+    saveDefault?: boolean
+    pauseInstead?: boolean
+  } = {}) {
+    if (!selectedWorkspace || selectedApprovalBindingItems.length === 0) {
+      return
+    }
+
+    await runAction(
+      options.pauseInstead ? 'approval-bulk-pause' : options.saveDefault ? 'approval-bulk-default' : 'approval-bulk-approve',
+      async () => {
+        for (const item of selectedApprovalBindingItems) {
+          await directoryApi.updateWorkspaceIdentity(selectedWorkspace.slug, item.binding.id, {
+            status: options.pauseInstead ? 'paused' : 'active',
+            canInitiateExternal: options.pauseInstead ? false : true,
+          })
+          if (!options.pauseInstead && options.saveDefault) {
+            await directoryApi.updateWorkspaceIdentityPolicy(selectedWorkspace.slug, item.binding.id, {
+              externalInitiation: 'allow',
+              allowedPartners: item.suggestedAllowedPartners,
+            })
+          }
+        }
+        await loadWorkspaceSurface(selectedWorkspace.slug)
+        setSelectedApprovalBindingIds([])
+      },
+      options.pauseInstead
+        ? `${selectedApprovalBindingItems.length} bindings paused.`
+        : options.saveDefault
+          ? `${selectedApprovalBindingItems.length} bindings approved with known-channel defaults.`
+          : `${selectedApprovalBindingItems.length} bindings approved for outbound motion.`,
+    )
+  }
+
+  async function handleApprovalThreadDispatch(
+    item: WorkspaceApprovalQueueThreadItem,
+    options: {
+      saveDefault?: boolean
+    } = {},
+  ) {
+    if (!selectedWorkspace) return
+
+    await runAction(`approval-thread-${item.thread.id}-${options.saveDefault ? 'default' : 'dispatch'}`, async () => {
+      if (item.senderBinding) {
+        await directoryApi.updateWorkspaceIdentity(selectedWorkspace.slug, item.senderBinding.id, {
+          status: 'active',
+          canInitiateExternal: true,
+        })
+        if (options.saveDefault) {
+          await directoryApi.updateWorkspaceIdentityPolicy(selectedWorkspace.slug, item.senderBinding.id, {
+            externalInitiation: 'allow',
+            allowedPartners: item.suggestedAllowedPartners,
+          })
+        }
+      }
+
+      const response = await directoryApi.dispatchWorkspaceThread(selectedWorkspace.slug, item.thread.id, {})
+      await loadWorkspaceSurface(selectedWorkspace.slug)
+      await loadThreadDetail(selectedWorkspace.slug, item.thread.id)
+      setNotice(
+        response.workspaceSync
+          ? `Workspace handoff dispatched and synced to ${response.workspaceSync.workspaceName}.`
+          : 'Workspace handoff dispatched through Beam.',
+      )
+    }, options.saveDefault
+      ? `${item.thread.title} approved, default saved, and dispatched.`
+      : `${item.thread.title} approved and dispatched.`)
+  }
+
   async function handleDeliverDigest() {
     if (!selectedWorkspace) return
 
@@ -1244,6 +1388,200 @@ export default function WorkspacesPage() {
             <MetricCard label="Manual review" value={!overview ? '—' : formatNumber(overview.summary.pendingApprovals)} tone={(overview?.summary.pendingApprovals ?? 0) > 0 ? 'warning' : 'default'} />
             <MetricCard label="Partner channels" value={formatNumber(channels.length)} tone={channels.some((channel) => channel.healthStatus === 'critical') ? 'critical' : channels.some((channel) => channel.healthStatus === 'watch') ? 'warning' : 'success'} />
             <MetricCard label="Digest escalations" value={!digest ? '—' : formatNumber(digest.summary.escalations)} tone={(digest?.summary.escalations ?? 0) > 0 ? 'critical' : 'default'} />
+          </section>
+
+          <section className="panel">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <div className="panel-title">Approval queue</div>
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  Manual-review identities and blocked handoff threads in one place, with direct approve, dispatch, and save-default actions.
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                  type="button"
+                  disabled={selectedApprovalBindingItems.length === 0 || actionBusy === 'approval-bulk-approve'}
+                  onClick={() => { void handleBulkBindingApproval() }}
+                >
+                  {actionBusy === 'approval-bulk-approve' ? 'Approving…' : 'Approve selected'}
+                </button>
+                <button
+                  className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                  type="button"
+                  disabled={selectedApprovalBindingItems.length === 0 || actionBusy === 'approval-bulk-default'}
+                  onClick={() => { void handleBulkBindingApproval({ saveDefault: true }) }}
+                >
+                  {actionBusy === 'approval-bulk-default' ? 'Saving…' : 'Approve for known channels'}
+                </button>
+                <button
+                  className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                  type="button"
+                  disabled={selectedApprovalBindingItems.length === 0 || actionBusy === 'approval-bulk-pause'}
+                  onClick={() => { void handleBulkBindingApproval({ pauseInstead: true }) }}
+                >
+                  {actionBusy === 'approval-bulk-pause' ? 'Pausing…' : 'Pause selected'}
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-4">
+              <MetricCard label="Queue items" value={!approvalQueue ? '—' : formatNumber(approvalQueue.summary.total)} tone={(approvalQueue?.summary.total ?? 0) > 0 ? 'warning' : 'default'} />
+              <MetricCard label="Binding approvals" value={!approvalQueue ? '—' : formatNumber(approvalQueue.summary.bindingApprovals)} tone={(approvalQueue?.summary.bindingApprovals ?? 0) > 0 ? 'warning' : 'default'} />
+              <MetricCard label="Thread approvals" value={!approvalQueue ? '—' : formatNumber(approvalQueue.summary.threadApprovals)} tone={(approvalQueue?.summary.threadApprovals ?? 0) > 0 ? 'critical' : 'default'} />
+              <MetricCard label="Critical blockers" value={!approvalQueue ? '—' : formatNumber(approvalQueue.summary.critical)} tone={(approvalQueue?.summary.critical ?? 0) > 0 ? 'critical' : 'default'} />
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {!approvalQueue || approvalQueue.items.length === 0 ? (
+                <EmptyPanel label="No approval work is waiting right now." />
+              ) : (
+                approvalQueue.items.map((item) => (
+                  <div key={item.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</div>
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                          {item.owner ? `Owner ${item.owner}` : 'No owner'} · {item.nextAction}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <StatusPill label={item.kind} />
+                        <StatusPill label={item.severity} tone={approvalSeverityTone(item.severity)} />
+                        {isThreadApprovalItem(item) ? (
+                          <StatusPill
+                            label={item.dispatchReady ? 'Dispatch ready' : 'Needs unblock'}
+                            tone={item.dispatchReady ? 'success' : 'warning'}
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+
+                    <div className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.detail}</div>
+
+                    {isBindingApprovalItem(item) ? (
+                      <>
+                        <div className="mt-3 grid gap-2 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Binding</div>
+                            <div>{displayName(item.binding.identity.displayName, item.binding.beamId)}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Lifecycle</div>
+                            <div>{item.binding.lifecycleStatus}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Runtime</div>
+                            <div>{renderBindingRuntime(item.binding)}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Suggested partners</div>
+                            <div>{summarizeList(item.suggestedAllowedPartners, 'No known channels yet')}</div>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 flex flex-wrap items-center gap-2">
+                          <label className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 dark:border-slate-800 dark:text-slate-200">
+                            <input
+                              checked={selectedApprovalBindingIds.includes(item.binding.id)}
+                              onChange={() => { toggleApprovalBindingSelection(item.binding.id) }}
+                              type="checkbox"
+                            />
+                            Select for bulk actions
+                          </label>
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `approval-binding-${item.binding.id}`}
+                            onClick={() => { void approveBindingExternalMotion(item) }}
+                          >
+                            {actionBusy === `approval-binding-${item.binding.id}` ? 'Approving…' : 'Approve binding'}
+                          </button>
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={item.suggestedAllowedPartners.length === 0 || actionBusy === `approval-binding-${item.binding.id}`}
+                            onClick={() => { void approveBindingExternalMotion(item, { saveDefault: true }) }}
+                          >
+                            Save default
+                          </button>
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={actionBusy === `approval-binding-${item.binding.id}`}
+                            onClick={() => { void approveBindingExternalMotion(item, { pauseInstead: true }) }}
+                          >
+                            Pause binding
+                          </button>
+                          {item.href ? (
+                            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={item.href}>
+                              Open workspace
+                            </Link>
+                          ) : null}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="mt-3 grid gap-2 text-sm text-slate-600 dark:text-slate-300 md:grid-cols-2 xl:grid-cols-4">
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Sender</div>
+                            <div>{item.senderBinding ? displayName(item.senderBinding.identity.displayName, item.senderBinding.beamId) : 'Missing local sender'}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Partner lane</div>
+                            <div>{item.partnerChannel ? renderPartnerChannelOptionLabel(item.partnerChannel) : 'No partner channel'}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Workflow</div>
+                            <div>{item.thread.workflowType || item.thread.draftIntentType || 'Unspecified'}</div>
+                          </div>
+                          <div>
+                            <div className="text-xs uppercase tracking-wide text-slate-400">Policy</div>
+                            <div>{item.policyPreview ? `${item.policyPreview.externalInitiation} · ${item.policyPreview.approvalRequired ? 'approval path' : 'direct path'}` : 'No preview available'}</div>
+                          </div>
+                        </div>
+
+                        {item.blockedReason ? (
+                          <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                            {item.blockedReason}
+                          </div>
+                        ) : null}
+
+                        <div className="mt-4 flex flex-wrap items-center gap-2">
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={!item.senderBinding || !item.partnerChannel || item.partnerChannel.status === 'blocked' || actionBusy === `approval-thread-${item.thread.id}-dispatch`}
+                            onClick={() => { void handleApprovalThreadDispatch(item) }}
+                          >
+                            {actionBusy === `approval-thread-${item.thread.id}-dispatch` ? 'Sending…' : 'Approve and send'}
+                          </button>
+                          <button
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            type="button"
+                            disabled={!item.senderBinding || item.suggestedAllowedPartners.length === 0 || actionBusy === `approval-thread-${item.thread.id}-default`}
+                            onClick={() => { void handleApprovalThreadDispatch(item, { saveDefault: true }) }}
+                          >
+                            {actionBusy === `approval-thread-${item.thread.id}-default` ? 'Saving…' : 'Save default and send'}
+                          </button>
+                          {item.href ? (
+                            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={item.href}>
+                              Open thread
+                            </Link>
+                          ) : null}
+                          {item.thread.trace?.href ? (
+                            <Link className="text-sm text-orange-600 hover:text-orange-700 dark:text-orange-300" to={item.thread.trace.href}>
+                              Open trace
+                            </Link>
+                          ) : null}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
           </section>
 
           <section className="grid gap-6 xl:grid-cols-[0.74fr,1.26fr]">

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -282,6 +282,39 @@ type WorkspaceDigestActionItem = {
   nextAction: string
 }
 
+type WorkspaceApprovalQueueBindingItem = {
+  id: string
+  kind: 'binding'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
+  binding: SerializedWorkspaceIdentityBinding
+  suggestedAllowedPartners: string[]
+}
+
+type WorkspaceApprovalQueueThreadItem = {
+  id: string
+  kind: 'thread'
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  owner: string | null
+  href: string | null
+  nextAction: string
+  thread: SerializedWorkspaceThread
+  senderBinding: SerializedWorkspaceIdentityBinding | null
+  partnerChannel: SerializedWorkspacePartnerChannel | null
+  policyPreview: SerializedWorkspacePolicyPreview | null
+  suggestedAllowedPartners: string[]
+  dispatchReady: boolean
+  blockedReason: string | null
+}
+
+type WorkspaceApprovalQueueItem = WorkspaceApprovalQueueBindingItem | WorkspaceApprovalQueueThreadItem
+
 type WorkspaceOverviewAttentionCode =
   | 'identity_missing'
   | 'stale_check_in'
@@ -1780,6 +1813,139 @@ function buildWorkspaceOverview(db: Database, workspace: WorkspaceRow) {
   }
 }
 
+function buildWorkspaceApprovalQueue(db: Database, workspace: WorkspaceRow) {
+  const generatedAt = new Date().toISOString()
+  const overview = buildWorkspaceOverview(db, workspace)
+  const bindings = listWorkspaceIdentityBindings(db, workspace.id)
+  const localBeamIds = bindings
+    .filter((binding) => binding.binding_type !== 'partner')
+    .map((binding) => binding.beam_id)
+  const channels = listWorkspacePartnerChannels(db, workspace.id).map((row) => serializeWorkspacePartnerChannel(db, row, localBeamIds))
+  const channelByBeamId = new Map(channels.map((channel) => [channel.partnerBeamId, channel]))
+  const policy = getWorkspacePolicyDocument(db, workspace.id).policy
+  const threads = listWorkspaceThreads(db, workspace.id)
+  const items: WorkspaceApprovalQueueItem[] = []
+  const knownPartnerBeamIds = channels
+    .filter((channel) => channel.status !== 'blocked')
+    .map((channel) => channel.partnerBeamId)
+
+  for (const item of overview.blockedExternalMotion) {
+    if (item.reasonCode !== 'manual_review_required') {
+      continue
+    }
+
+    items.push({
+      id: `binding-${item.binding.id}`,
+      kind: 'binding',
+      severity: 'warning',
+      title: `${item.binding.beamId} is waiting for outbound approval`,
+      detail: item.reason,
+      owner: item.binding.owner,
+      href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`,
+      nextAction: knownPartnerBeamIds.length > 0
+        ? 'Approve outbound motion directly or save a partner-scoped default for the current fleet lanes.'
+        : 'Approve outbound motion directly or attach a partner channel before enabling external sends.',
+      binding: item.binding,
+      suggestedAllowedPartners: knownPartnerBeamIds,
+    })
+  }
+
+  for (const row of threads) {
+    if (row.kind !== 'handoff' || row.status !== 'blocked') {
+      continue
+    }
+
+    const participants = listWorkspaceThreadParticipants(db, row.id)
+    const thread = serializeWorkspaceThread(db, row, participants)
+    const senderParticipant = participants.find((participant) => (
+      participant.workspace_binding_id != null
+      && participant.principal_type !== 'partner'
+      && typeof participant.beam_id === 'string'
+      && participant.beam_id.length > 0
+    ))
+    const partnerParticipant = participants.find((participant) => (
+      participant.principal_type === 'partner'
+      && typeof participant.beam_id === 'string'
+      && participant.beam_id.length > 0
+    ))
+
+    const senderBindingRow = senderParticipant?.workspace_binding_id
+      ? getWorkspaceIdentityBindingById(db, senderParticipant.workspace_binding_id)
+      : null
+    const senderBinding = senderBindingRow && senderBindingRow.workspace_id === workspace.id
+      ? serializeWorkspaceIdentityBinding(db, senderBindingRow)
+      : null
+
+    const partnerChannel = partnerParticipant?.beam_id
+      ? channelByBeamId.get(partnerParticipant.beam_id) ?? null
+      : null
+    const policyPreview = senderBindingRow && senderBindingRow.workspace_id === workspace.id
+      ? buildWorkspacePolicyPreview(policy, senderBindingRow, row.workflow_type)
+      : null
+
+    let blockedReason: string | null = null
+    if (workspace.external_handoffs_enabled !== 1) {
+      blockedReason = 'Workspace external handoffs are disabled.'
+    } else if (!senderBindingRow || senderBindingRow.workspace_id !== workspace.id) {
+      blockedReason = 'The thread is missing a local sender binding.'
+    } else if (!partnerChannel) {
+      blockedReason = 'No partner channel is attached to the partner participant yet.'
+    } else if (partnerChannel.status === 'blocked') {
+      blockedReason = 'The attached partner channel is blocked.'
+    } else if (policyPreview?.externalInitiation !== 'allow') {
+      blockedReason = 'The current outbound policy still denies this handoff.'
+    }
+
+    items.push({
+      id: `thread-${thread.id}`,
+      kind: 'thread',
+      severity: blockedReason ? 'critical' : 'warning',
+      title: `${thread.title} is waiting for approval`,
+      detail: blockedReason
+        ?? 'This blocked handoff already has enough context to be approved and sent directly from Beam.',
+      owner: thread.owner,
+      href: `/workspaces?workspace=${encodeURIComponent(workspace.slug)}&thread=${encodeURIComponent(String(thread.id))}`,
+      nextAction: blockedReason
+        ? 'Review the sender, partner channel, and policy preview, then approve and send or keep the thread blocked.'
+        : 'Approve and send now, or save the partner-scoped default before dispatching.',
+      thread,
+      senderBinding,
+      partnerChannel,
+      policyPreview,
+      suggestedAllowedPartners: partnerChannel ? [partnerChannel.partnerBeamId] : [],
+      dispatchReady: blockedReason === null,
+      blockedReason,
+    })
+  }
+
+  items.sort((left, right) => {
+    const severityRank = (value: WorkspaceApprovalQueueItem['severity']) => value === 'critical' ? 0 : 1
+    const leftSeverity = severityRank(left.severity)
+    const rightSeverity = severityRank(right.severity)
+    if (leftSeverity !== rightSeverity) {
+      return leftSeverity - rightSeverity
+    }
+
+    if (left.kind !== right.kind) {
+      return left.kind === 'thread' ? -1 : 1
+    }
+
+    return left.title.localeCompare(right.title)
+  })
+
+  return {
+    workspace: serializeWorkspace(db, workspace),
+    generatedAt,
+    summary: {
+      total: items.length,
+      bindingApprovals: items.filter((item) => item.kind === 'binding').length,
+      threadApprovals: items.filter((item) => item.kind === 'thread').length,
+      critical: items.filter((item) => item.severity === 'critical').length,
+    },
+    items,
+  }
+}
+
 function isUniqueConstraintError(err: unknown, target: string): boolean {
   return err instanceof Error && err.message.includes(`UNIQUE constraint failed: ${target}`)
 }
@@ -1920,6 +2086,21 @@ export function workspacesRouter(db: Database): Hono {
       workspace: serializeWorkspace(db, workspace),
       ...buildWorkspaceOverview(db, workspace),
     })
+  })
+
+  router.get('/:slug/approval-queue', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const workspace = getWorkspaceBySlug(db, c.req.param('slug'))
+    if (!workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json(buildWorkspaceApprovalQueue(db, workspace))
   })
 
   router.get('/:slug/partner-channels', (c) => {

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -588,6 +588,181 @@ test('workspace overview surfaces stale identities, blocked external motion, and
   }
 })
 
+test('workspace approval queue surfaces manual review bindings and blocked handoff threads with automation hints', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    registerAgent(db, {
+      beamId: 'ops-bot@beam.directory',
+      displayName: 'Ops Bot',
+      capabilities: ['handoff'],
+      publicKey: 'MCowBQYDK2VwAyEAw2QJY0YH7e1L2+2VQ1bH4TqL6wCnC8n9v8m8z4vPsxM=',
+      personal: true,
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'Acme Approval Workspace',
+        slug: 'acme-approval',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+
+    const bindingResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-approval/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: 'ops-bot@beam.directory',
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'codex:operator',
+        policyProfile: 'ops-default',
+        canInitiateExternal: false,
+      }),
+    }))
+    const bindingBody = await bindingResponse.json() as { binding: { id: number } }
+
+    await app.request(new Request('http://localhost/admin/workspaces/acme-approval/policy', {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        workflowRules: [{
+          workflowType: 'partner.review',
+          requireApproval: true,
+          allowedPartners: ['echo@beam.directory'],
+          approvers: ['ops@example.com'],
+        }],
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces/acme-approval/partner-channels', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        partnerBeamId: 'echo@beam.directory',
+        label: 'Beam Echo',
+        owner: 'ops@example.com',
+        status: 'active',
+      }),
+    }))
+
+    await app.request(new Request('http://localhost/admin/workspaces/acme-approval/threads', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        kind: 'handoff',
+        title: 'Approval queue thread',
+        summary: 'Blocked until the sender gets outbound approval.',
+        owner: 'ops@example.com',
+        workflowType: 'partner.review',
+        status: 'blocked',
+        draftIntentType: 'conversation.message',
+        draftPayload: {
+          message: 'Please confirm the approval queue path.',
+          language: 'en',
+        },
+        participants: [
+          {
+            principalId: 'ops-bot@beam.directory',
+            principalType: 'agent',
+            beamId: 'ops-bot@beam.directory',
+            workspaceBindingId: bindingBody.binding.id,
+            role: 'owner',
+          },
+          {
+            principalId: 'echo@beam.directory',
+            principalType: 'partner',
+            beamId: 'echo@beam.directory',
+            role: 'participant',
+          },
+        ],
+      }),
+    }))
+
+    const queueResponse = await app.request(new Request('http://localhost/admin/workspaces/acme-approval/approval-queue', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(queueResponse.status, 200)
+
+    const queueBody = await queueResponse.json() as {
+      summary: {
+        total: number
+        bindingApprovals: number
+        threadApprovals: number
+        critical: number
+      }
+      items: Array<{
+        id: string
+        kind: 'binding' | 'thread'
+        severity: 'warning' | 'critical'
+        title: string
+        suggestedAllowedPartners: string[]
+        binding?: {
+          id: number
+          beamId: string
+        }
+        thread?: {
+          id: number
+          workflowType: string | null
+        }
+        senderBinding?: {
+          beamId: string
+        } | null
+        partnerChannel?: {
+          partnerBeamId: string
+        } | null
+        policyPreview?: {
+          externalInitiation: string
+          approvalRequired: boolean
+        } | null
+        dispatchReady?: boolean
+        blockedReason?: string | null
+      }>
+    }
+
+    assert.deepEqual(queueBody.summary, {
+      total: 2,
+      bindingApprovals: 1,
+      threadApprovals: 1,
+      critical: 1,
+    })
+
+    const bindingItem = queueBody.items.find((item) => item.kind === 'binding')
+    assert.equal(bindingItem?.binding?.beamId, 'ops-bot@beam.directory')
+    assert.deepEqual(bindingItem?.suggestedAllowedPartners, ['echo@beam.directory'])
+    assert.equal(bindingItem?.severity, 'warning')
+
+    const threadItem = queueBody.items.find((item) => item.kind === 'thread')
+    assert.equal(threadItem?.thread?.workflowType, 'partner.review')
+    assert.equal(threadItem?.senderBinding?.beamId, 'ops-bot@beam.directory')
+    assert.equal(threadItem?.partnerChannel?.partnerBeamId, 'echo@beam.directory')
+    assert.equal(threadItem?.policyPreview?.externalInitiation, 'deny')
+    assert.equal(threadItem?.policyPreview?.approvalRequired, true)
+    assert.equal(threadItem?.dispatchReady, false)
+    assert.match(threadItem?.blockedReason ?? '', /policy still denies/i)
+  } finally {
+    db.close()
+  }
+})
+
 test('workspace threads model internal discussion and external handoffs in one timeline', async () => {
   const db = createDatabase(':memory:')
 


### PR DESCRIPTION
## Summary
- add a workspace approval queue API for manual-review bindings and blocked outbound handoff threads
- expose direct approve, save-default, pause, and dispatch automation from the workspace dashboard
- cover the new queue with directory tests and update workspace docs

## Testing
- npm test --workspace=packages/directory
- npm run build
- npm test
- npm -C docs run build