### PR TITLE
Add guided OpenClaw conflict remediation

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -184,6 +184,7 @@ The fleet surface also gives operators explicit day-2 actions:
 - rotate host credentials without reinstalling the whole host
 - recover or replace a revoked or lost host with a new credential cutover
 - prefer, disable, or reset route ownership when duplicate Beam identities appear
+- open a guided remediation view for one duplicated Beam ID, keep the recommended owner route, and optionally disable the competing routes in one step
 - deliver a fleet digest that calls out stale hosts, pending credential work, duplicate conflicts, and missing receipts
 
 The host detail and fleet summary now also expose the operational thresholds behind those actions:

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -392,6 +392,9 @@ export interface OpenClawHostSummary {
 export interface OpenClawConflictGroup {
   beamId: string
   routeCount: number
+  selectedOwnerRouteId: number | null
+  recommendedRouteId: number | null
+  recommendedReason: string | null
   routes: Array<{
     routeId: number
     hostId: number
@@ -401,7 +404,39 @@ export interface OpenClawConflictGroup {
     routeKey: string
     routeSource: OpenClawRouteSource
     ownerResolutionState: OpenClawRouteOwnerResolutionState
+    ownerResolutionActor: string | null
+    ownerResolutionAt: string | null
+    ownerResolutionNote: string | null
+    runtimeSessionState: OpenClawRouteRuntimeState
+    hostHealth: OpenClawHostHealth
+    lastSeenAt: string | null
+    lastDeliveryStatus: IntentLifecycleStatus | null
+    lastDeliveryHref: string | null
   }>
+}
+
+export interface OpenClawConflictHistoryItem {
+  id: string
+  source: 'route' | 'host'
+  action: string
+  actor: string | null
+  timestamp: string
+  note: string | null
+  routeId: number | null
+  hostId: number | null
+  href: string | null
+}
+
+export interface OpenClawConflictDetailResponse {
+  beamId: string
+  routeCount: number
+  activeConflictRouteCount: number
+  resolutionState: 'unresolved' | 'owner_selected'
+  selectedOwnerRouteId: number | null
+  recommendedRouteId: number | null
+  recommendedReason: string | null
+  routes: OpenClawHostRoute[]
+  history: OpenClawConflictHistoryItem[]
 }
 
 export interface OpenClawFleetOverviewResponse {
@@ -566,6 +601,18 @@ export interface OpenClawHostPolicyActionResponse {
 
 export interface OpenClawRouteActionResponse {
   route: OpenClawHostRoute | null
+}
+
+export interface OpenClawConflictResolveInput {
+  preferredRouteId: number
+  disableCompetingRoutes?: boolean
+  note?: string | null
+}
+
+export interface OpenClawConflictResolveResponse {
+  conflict: OpenClawConflictDetailResponse | null
+  preferredRouteId: number
+  disabledRouteIds: number[]
 }
 
 export interface OpenClawFleetDigestDeliveryResponse {
@@ -2318,6 +2365,7 @@ export const directoryApi = {
     method: 'POST',
     body: JSON.stringify(input ?? {}),
   }, { admin: true }),
+  getOpenClawConflict: (beamId: string) => request<OpenClawConflictDetailResponse>(`/admin/openclaw/conflicts/${encodeURIComponent(beamId)}`, undefined, { admin: true }),
   listOpenClawHosts: () => request<OpenClawHostsResponse>('/admin/openclaw/hosts', undefined, { admin: true }),
   getOpenClawHost: (id: number) => request<OpenClawHostDetailResponse>(`/admin/openclaw/hosts/${id}`, undefined, { admin: true }),
   getOpenClawHostRoutes: (id: number) => request<OpenClawHostRoutesResponse>(`/admin/openclaw/hosts/${id}/routes`, undefined, { admin: true }),
@@ -2342,6 +2390,10 @@ export const directoryApi = {
   revokeOpenClawHost: (id: number, input?: { reason?: string | null }) => request<OpenClawHostRevokeResponse>(`/admin/openclaw/hosts/${id}/revoke`, {
     method: 'POST',
     body: JSON.stringify(input ?? {}),
+  }, { admin: true }),
+  resolveOpenClawConflict: (beamId: string, input: OpenClawConflictResolveInput) => request<OpenClawConflictResolveResponse>(`/admin/openclaw/conflicts/${encodeURIComponent(beamId)}/resolve`, {
+    method: 'POST',
+    body: JSON.stringify(input),
   }, { admin: true }),
   preferOpenClawRoute: (id: number, input?: { note?: string | null }) => request<OpenClawRouteActionResponse>(`/admin/openclaw/routes/${id}/prefer`, {
     method: 'POST',

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { EmptyPanel, MetricCard, PageHeader, StatusPill } from '../components/Observability'
 import {
   ApiError,
+  type OpenClawConflictDetailResponse,
   directoryApi,
   type OpenClawConflictGroup,
   type OpenClawFleetDigestResponse,
@@ -131,6 +132,10 @@ function digestSeverityTone(severity: 'warning' | 'critical'): 'warning' | 'crit
   return severity === 'critical' ? 'critical' : 'warning'
 }
 
+function conflictResolutionTone(state: OpenClawConflictDetailResponse['resolutionState']): 'warning' | 'success' {
+  return state === 'owner_selected' ? 'success' : 'warning'
+}
+
 function formatPercent(value: number | null): string {
   return value === null ? '—' : `${Math.round(value * 100)}%`
 }
@@ -176,6 +181,7 @@ export default function OpenClawFleetPage() {
   const [searchParams, setSearchParams] = useSearchParams()
   const [overview, setOverview] = useState<OpenClawFleetOverviewResponse | null>(null)
   const [digest, setDigest] = useState<OpenClawFleetDigestResponse | null>(null)
+  const [conflictDetail, setConflictDetail] = useState<OpenClawConflictDetailResponse | null>(null)
   const [hostDetail, setHostDetail] = useState<OpenClawHostDetailResponse | null>(null)
   const [hostIdentities, setHostIdentities] = useState<OpenClawHostIdentitiesResponse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -215,6 +221,7 @@ export default function OpenClawFleetPage() {
     recoveryWindowStartsAt: '',
     recoveryWindowEndsAt: '',
   })
+  const [selectedConflictRouteId, setSelectedConflictRouteId] = useState<number | null>(null)
 
   const selectedHostId = useMemo(() => {
     const raw = searchParams.get('host')
@@ -223,9 +230,19 @@ export default function OpenClawFleetPage() {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null
   }, [searchParams])
 
+  const selectedConflictBeamId = useMemo(() => {
+    const raw = searchParams.get('conflict')
+    return raw ? raw.trim() || null : null
+  }, [searchParams])
+
   const selectedHost = useMemo(
     () => overview?.hosts.find((host) => host.id === selectedHostId) ?? overview?.hosts[0] ?? null,
     [overview, selectedHostId],
+  )
+
+  const selectedConflictRoute = useMemo(
+    () => conflictDetail?.routes.find((route) => route.id === selectedConflictRouteId) ?? null,
+    [conflictDetail, selectedConflictRouteId],
   )
 
   async function loadOverview() {
@@ -238,6 +255,11 @@ export default function OpenClawFleetPage() {
     setDigest(response)
   }
 
+  async function loadConflict(beamId: string) {
+    const response = await directoryApi.getOpenClawConflict(beamId)
+    setConflictDetail(response)
+  }
+
   async function loadHost(id: number) {
     const [detailResponse, identitiesResponse] = await Promise.all([
       directoryApi.getOpenClawHost(id),
@@ -247,14 +269,20 @@ export default function OpenClawFleetPage() {
     setHostIdentities(identitiesResponse)
   }
 
-  async function refreshAll(nextHostId?: number | null) {
+  async function refreshAll(nextHostId?: number | null, nextConflictBeamId?: string | null) {
     try {
       setLoading(true)
       setError(null)
       await Promise.all([loadOverview(), loadDigest()])
       const hostId = nextHostId ?? selectedHostId
+      const conflictBeamId = nextConflictBeamId ?? selectedConflictBeamId
       if (hostId) {
         await loadHost(hostId)
+      }
+      if (conflictBeamId) {
+        await loadConflict(conflictBeamId)
+      } else {
+        setConflictDetail(null)
       }
     } catch (err) {
       setError(err instanceof ApiError ? err.message : 'Failed to load OpenClaw fleet')
@@ -298,6 +326,34 @@ export default function OpenClawFleetPage() {
       }
     })()
   }, [overview, searchParams, selectedHostId, setSearchParams])
+
+  useEffect(() => {
+    if (!selectedConflictBeamId) {
+      setConflictDetail(null)
+      setSelectedConflictRouteId(null)
+      return
+    }
+
+    void (async () => {
+      try {
+        setDetailLoading(true)
+        setError(null)
+        await loadConflict(selectedConflictBeamId)
+      } catch (err) {
+        setError(err instanceof ApiError ? err.message : 'Failed to load conflict detail')
+      } finally {
+        setDetailLoading(false)
+      }
+    })()
+  }, [selectedConflictBeamId])
+
+  useEffect(() => {
+    if (!conflictDetail) {
+      setSelectedConflictRouteId(null)
+      return
+    }
+    setSelectedConflictRouteId(conflictDetail.selectedOwnerRouteId ?? conflictDetail.recommendedRouteId ?? conflictDetail.routes[0]?.id ?? null)
+  }, [conflictDetail?.beamId, conflictDetail?.selectedOwnerRouteId, conflictDetail?.recommendedRouteId, conflictDetail?.routes.length])
 
   useEffect(() => {
     if (!selectedHost) {
@@ -413,9 +469,31 @@ export default function OpenClawFleetPage() {
       : `Revoked by operator on ${new Date().toISOString()}`
     await runAction(`revoke-${host.id}`, async () => {
       await directoryApi.revokeOpenClawHost(host.id, { reason })
-      await Promise.all([loadOverview(), loadDigest()])
-      await loadHost(host.id)
+      await refreshAll(host.id, selectedConflictBeamId)
     }, `Host ${hostTitle(host)} revoked.`)
+  }
+
+  function focusConflict(beamId: string) {
+    const nextParams = new URLSearchParams(searchParams)
+    nextParams.set('conflict', beamId)
+    setSearchParams(nextParams, { replace: true })
+  }
+
+  async function handleResolveConflict(options: {
+    beamId: string
+    preferredRouteId: number
+    disableCompetingRoutes?: boolean
+    note?: string | null
+  }) {
+    await runAction(`resolve-conflict-${options.beamId}`, async () => {
+      const response = await directoryApi.resolveOpenClawConflict(options.beamId, {
+        preferredRouteId: options.preferredRouteId,
+        disableCompetingRoutes: options.disableCompetingRoutes,
+        note: options.note,
+      })
+      setConflictDetail(response.conflict)
+      await refreshAll(selectedHostId, options.beamId)
+    }, `Conflict route owner updated for ${options.beamId}.`)
   }
 
   async function handlePreferRoute(route: Pick<OpenClawHostRoute, 'id' | 'beamId'>) {
@@ -423,7 +501,7 @@ export default function OpenClawFleetPage() {
       await directoryApi.preferOpenClawRoute(route.id, {
         note: `Preferred by operator for ${route.beamId}`,
       })
-      await refreshAll(selectedHostId)
+      await refreshAll(selectedHostId, selectedConflictBeamId)
     }, `Preferred route set for ${route.beamId}.`)
   }
 
@@ -432,7 +510,7 @@ export default function OpenClawFleetPage() {
       await directoryApi.disableOpenClawRoute(route.id, {
         note: `Disabled by operator for ${route.beamId}`,
       })
-      await refreshAll(selectedHostId)
+      await refreshAll(selectedHostId, selectedConflictBeamId)
     }, `Route disabled for ${route.beamId}.`)
   }
 
@@ -441,7 +519,7 @@ export default function OpenClawFleetPage() {
       await directoryApi.clearOpenClawRouteOwner(route.id, {
         note: `Ownership reset by operator for ${route.beamId}`,
       })
-      await refreshAll(selectedHostId)
+      await refreshAll(selectedHostId, selectedConflictBeamId)
     }, `Route ownership reset for ${route.beamId}.`)
   }
 
@@ -786,13 +864,26 @@ export default function OpenClawFleetPage() {
         <div className="mt-4 space-y-3">
           {overview && overview.conflicts.length > 0 ? (
             overview.conflicts.map((group) => (
-              <div key={group.beamId} className="rounded-2xl border border-red-200 bg-red-50/60 p-4 dark:border-red-500/30 dark:bg-red-500/10">
+              <div
+                key={group.beamId}
+                className={`rounded-2xl border p-4 ${selectedConflictBeamId === group.beamId ? 'border-orange-300 bg-orange-50/60 dark:border-orange-500/40 dark:bg-orange-500/10' : 'border-red-200 bg-red-50/60 dark:border-red-500/30 dark:bg-red-500/10'}`}
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <div className="text-sm font-medium text-red-700 dark:text-red-200">{group.beamId}</div>
                     <div className="text-xs text-red-600/80 dark:text-red-200/80">{conflictSummary(group)}</div>
+                    {group.recommendedReason ? (
+                      <div className="mt-1 text-[11px] text-red-600/80 dark:text-red-200/80">
+                        Recommended owner: route {group.recommendedRouteId ?? '—'} · {group.recommendedReason}
+                      </div>
+                    ) : null}
                   </div>
-                  <StatusPill label={`${group.routeCount} conflicting routes`} tone="critical" />
+                  <div className="flex flex-wrap gap-2">
+                    {group.selectedOwnerRouteId ? (
+                      <StatusPill label={`Owner ${group.selectedOwnerRouteId}`} tone="success" />
+                    ) : null}
+                    <StatusPill label={`${group.routeCount} conflicting routes`} tone="critical" />
+                  </div>
                 </div>
                 <div className="mt-3 grid gap-2 text-xs text-red-700/80 dark:text-red-200/80 md:grid-cols-2">
                   {group.routes.map((route) => (
@@ -803,6 +894,13 @@ export default function OpenClawFleetPage() {
                           route.workspaceSlug ? `Workspace ${route.workspaceSlug}` : 'No workspace',
                           routeSourceLabel(route.routeSource),
                         ].join(' · ')}
+                      </div>
+                      <div className="mt-1 text-[11px] opacity-80">
+                        {[
+                          route.hostHealth,
+                          route.lastSeenAt ? `Seen ${formatRelativeTime(route.lastSeenAt)}` : null,
+                          route.lastDeliveryStatus ? `Last ${route.lastDeliveryStatus}` : null,
+                        ].filter(Boolean).join(' · ')}
                       </div>
                       <div className="mt-2 flex flex-wrap gap-2">
                         <StatusPill label={route.ownerResolutionState} tone={ownerResolutionTone(route.ownerResolutionState)} />
@@ -830,14 +928,267 @@ export default function OpenClawFleetPage() {
                         >
                           {actionBusy === `clear-route-${route.routeId}` ? 'Resetting…' : 'Reset owner'}
                         </button>
+                        {route.lastDeliveryHref ? (
+                          <Link className="rounded-xl border border-red-200 px-3 py-2 text-[11px] font-medium text-red-700 transition hover:bg-red-100 dark:border-red-500/30 dark:text-red-100 dark:hover:bg-red-500/10" to={route.lastDeliveryHref}>
+                            Open trace
+                          </Link>
+                        ) : null}
                       </div>
                     </div>
                   ))}
+                </div>
+                <div className="mt-3 flex flex-wrap gap-3 text-xs">
+                  <button
+                    type="button"
+                    className="text-orange-600 hover:text-orange-700 dark:text-orange-300"
+                    onClick={() => focusConflict(group.beamId)}
+                  >
+                    Review conflict
+                  </button>
+                  <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/openclaw-fleet?conflict=${encodeURIComponent(group.beamId)}`}>
+                    Open remediation view
+                  </Link>
                 </div>
               </div>
             ))
           ) : (
             <EmptyPanel label="No duplicate identity conflicts are active." />
+          )}
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="panel-title">Conflict remediation</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Guided route-owner resolution for one Beam identity, with a recommended owner, shadow-route cleanup, and audit history.
+            </p>
+          </div>
+          {conflictDetail ? (
+            <div className="flex flex-wrap gap-2">
+              <StatusPill label={conflictDetail.resolutionState} tone={conflictResolutionTone(conflictDetail.resolutionState)} />
+              <StatusPill label={`${conflictDetail.activeConflictRouteCount} active conflicts`} tone={conflictDetail.activeConflictRouteCount > 0 ? 'critical' : 'default'} />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {!selectedConflictBeamId ? (
+            <EmptyPanel label="Pick a duplicate conflict above to open the guided remediation flow." />
+          ) : detailLoading && !conflictDetail ? (
+            <EmptyPanel label="Loading conflict detail…" />
+          ) : !conflictDetail ? (
+            <EmptyPanel label="The selected conflict no longer exists." />
+          ) : (
+            <>
+              <div className="rounded-2xl border border-slate-200 px-4 py-4 text-sm dark:border-slate-800">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="text-base font-medium text-slate-900 dark:text-slate-100">{conflictDetail.beamId}</div>
+                    <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      {`${formatNumber(conflictDetail.routeCount)} total route(s) · ${formatNumber(conflictDetail.activeConflictRouteCount)} active conflicting route(s)`}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {conflictDetail.selectedOwnerRouteId ? (
+                      <StatusPill label={`Owner route ${conflictDetail.selectedOwnerRouteId}`} tone="success" />
+                    ) : null}
+                    {conflictDetail.recommendedRouteId ? (
+                      <StatusPill label={`Recommended ${conflictDetail.recommendedRouteId}`} tone="warning" />
+                    ) : null}
+                  </div>
+                </div>
+                <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                  <div>{conflictDetail.recommendedReason ? `Recommendation: ${conflictDetail.recommendedReason}` : 'No route recommendation available yet.'}</div>
+                  <div>{selectedConflictRoute ? `Selected route ${selectedConflictRoute.id}${selectedConflictRoute.hostLabel ? ` · ${selectedConflictRoute.hostLabel}` : ''}` : 'No route selected yet.'}</div>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    disabled={!selectedConflictRoute || actionBusy === `resolve-conflict-${conflictDetail.beamId}`}
+                    onClick={() => {
+                      if (!selectedConflictRoute) return
+                      void handleResolveConflict({
+                        beamId: conflictDetail.beamId,
+                        preferredRouteId: selectedConflictRoute.id,
+                        disableCompetingRoutes: false,
+                        note: `Guided remediation selected route ${selectedConflictRoute.id} for ${conflictDetail.beamId}.`,
+                      })
+                    }}
+                  >
+                    {actionBusy === `resolve-conflict-${conflictDetail.beamId}` ? 'Resolving…' : 'Prefer selected route'}
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    disabled={!selectedConflictRoute || actionBusy === `resolve-conflict-${conflictDetail.beamId}`}
+                    onClick={() => {
+                      if (!selectedConflictRoute) return
+                      void handleResolveConflict({
+                        beamId: conflictDetail.beamId,
+                        preferredRouteId: selectedConflictRoute.id,
+                        disableCompetingRoutes: true,
+                        note: `Guided remediation preferred route ${selectedConflictRoute.id} and disabled competing routes for ${conflictDetail.beamId}.`,
+                      })
+                    }}
+                  >
+                    {actionBusy === `resolve-conflict-${conflictDetail.beamId}` ? 'Resolving…' : 'Prefer and disable others'}
+                  </button>
+                  {conflictDetail.recommendedRouteId && conflictDetail.recommendedRouteId !== selectedConflictRouteId ? (
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => setSelectedConflictRouteId(conflictDetail.recommendedRouteId)}
+                    >
+                      Pick recommended route
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="grid gap-4 xl:grid-cols-[1.25fr,0.75fr]">
+                <div className="space-y-3">
+                  {conflictDetail.routes.map((route) => {
+                    const selected = selectedConflictRouteId === route.id
+                    const recommended = conflictDetail.recommendedRouteId === route.id
+                    return (
+                      <button
+                        key={route.id}
+                        type="button"
+                        className={`w-full rounded-2xl border p-4 text-left transition ${selected ? 'border-orange-300 bg-orange-50/50 dark:border-orange-500/40 dark:bg-orange-500/10' : 'border-slate-200 hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-900/60'}`}
+                        onClick={() => setSelectedConflictRouteId(route.id)}
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                              {route.hostLabel || `Host ${route.hostId}`} · {route.routeKey}
+                            </div>
+                            <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+                              {[
+                                route.workspace?.slug ? `Workspace ${route.workspace.slug}` : 'No workspace',
+                                routeSourceLabel(route.routeSource),
+                                route.connectionMode ?? 'No receiver',
+                              ].join(' · ')}
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            {recommended ? <StatusPill label="recommended" tone="warning" /> : null}
+                            {selected ? <StatusPill label="selected" tone="success" /> : null}
+                            <StatusPill label={route.runtimeSessionState} tone={routeStateTone(route.runtimeSessionState)} />
+                            <StatusPill label={route.ownerResolutionState} tone={ownerResolutionTone(route.ownerResolutionState)} />
+                          </div>
+                        </div>
+                        <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                          <div>{`Host health ${route.hostHealth} · credential ${route.hostCredentialState}`}</div>
+                          <div>{route.lastSeenAt ? `Last seen ${formatRelativeTime(route.lastSeenAt)}` : 'No last-seen timestamp'}</div>
+                          <div>{route.lastDelivery ? `Last delivery ${formatRelativeTime(route.lastDelivery.requestedAt)} · ${route.lastDelivery.status}${route.lastDelivery.errorCode ? ` · ${route.lastDelivery.errorCode}` : ''}` : 'No delivery receipt yet'}</div>
+                          <div>{route.ownerResolutionAt ? `Owner action ${formatRelativeTime(route.ownerResolutionAt)}${route.ownerResolutionActor ? ` · ${route.ownerResolutionActor}` : ''}` : 'No owner action recorded'}</div>
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+                          <button
+                            type="button"
+                            className="text-orange-600 hover:text-orange-700 disabled:opacity-60 dark:text-orange-300"
+                            disabled={actionBusy === `prefer-route-${route.id}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handlePreferRoute(route)
+                            }}
+                          >
+                            {actionBusy === `prefer-route-${route.id}` ? 'Preferring…' : 'Prefer route'}
+                          </button>
+                          <button
+                            type="button"
+                            className="text-orange-600 hover:text-orange-700 disabled:opacity-60 dark:text-orange-300"
+                            disabled={actionBusy === `disable-route-${route.id}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleDisableRoute(route)
+                            }}
+                          >
+                            {actionBusy === `disable-route-${route.id}` ? 'Disabling…' : 'Disable route'}
+                          </button>
+                          <button
+                            type="button"
+                            className="text-orange-600 hover:text-orange-700 disabled:opacity-60 dark:text-orange-300"
+                            disabled={actionBusy === `clear-route-${route.id}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleClearRouteOwner(route)
+                            }}
+                          >
+                            {actionBusy === `clear-route-${route.id}` ? 'Resetting…' : 'Reset owner'}
+                          </button>
+                          <button
+                            type="button"
+                            className="text-orange-600 hover:text-orange-700 disabled:opacity-60 dark:text-orange-300"
+                            disabled={actionBusy === `revoke-${route.hostId}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              const host = overview?.hosts.find((entry) => entry.id === route.hostId)
+                              if (host) {
+                                void handleRevoke(host)
+                              }
+                            }}
+                          >
+                            {actionBusy === `revoke-${route.hostId}` ? 'Revoking…' : 'Revoke host'}
+                          </button>
+                          {route.workspace ? (
+                            <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={`/workspaces?workspace=${encodeURIComponent(route.workspace.slug)}`}>
+                              Open workspace
+                            </Link>
+                          ) : null}
+                          {route.lastDelivery ? (
+                            <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={route.lastDelivery.href}>
+                              Open trace
+                            </Link>
+                          ) : null}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Resolution history</div>
+                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                    Route-owner and host actions attached to this Beam identity.
+                  </div>
+                  <div className="mt-4 space-y-3">
+                    {conflictDetail.history.length > 0 ? (
+                      conflictDetail.history.map((entry) => (
+                        <div key={entry.id} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <div className="font-medium text-slate-900 dark:text-slate-100">{entry.action}</div>
+                            <div>{formatRelativeTime(entry.timestamp)}</div>
+                          </div>
+                          <div className="mt-1">
+                            {[
+                              entry.actor ? `Actor ${entry.actor}` : null,
+                              entry.routeId ? `Route ${entry.routeId}` : null,
+                              entry.hostId ? `Host ${entry.hostId}` : null,
+                            ].filter(Boolean).join(' · ')}
+                          </div>
+                          {entry.note ? (
+                            <div className="mt-2">{entry.note}</div>
+                          ) : null}
+                          {entry.href ? (
+                            <div className="mt-2">
+                              <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={entry.href}>
+                                Open related view
+                              </Link>
+                            </div>
+                          ) : null}
+                        </div>
+                      ))
+                    ) : (
+                      <EmptyPanel label="No conflict history recorded yet." />
+                    )}
+                  </div>
+                </div>
+              </div>
+            </>
           )}
         </div>
       </section>

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -1817,6 +1817,11 @@ export default function WorkspacesPage() {
                             Open agent
                           </Link>
                         ) : null}
+                        {binding.runtimeSessionState === 'conflict' ? (
+                          <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-orange-600 transition hover:bg-slate-100 dark:border-slate-800 dark:text-orange-300 dark:hover:bg-slate-800" to={`/openclaw-fleet?conflict=${encodeURIComponent(binding.beamId)}`}>
+                            Resolve in fleet
+                          </Link>
+                        ) : null}
                         {binding.bindingType !== 'partner' && binding.identity.existsLocally ? (
                           <button
                             className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -811,6 +811,97 @@ test('duplicate openclaw conflicts can be resolved by preferring one route owner
   }
 })
 
+test('conflict detail recommends an owner route and guided resolve can disable competing routes', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const receiver = createFixtureAgent('fleet-conflict@openclaw.beam.directory')
+    registerFixtureAgent(db, receiver, 'Fleet Conflict')
+
+    const app = createApp(db)
+
+    createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Alpha',
+      hostname: 'alpha.local',
+      beamId: receiver.beamId,
+      routeKey: 'fleet-conflict-alpha',
+      workspaceSlug: 'openclaw-local',
+    })
+    createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Bravo',
+      hostname: 'bravo.local',
+      beamId: receiver.beamId,
+      routeKey: 'fleet-conflict-bravo',
+      workspaceSlug: 'openclaw-local',
+    })
+
+    const detailResponse = await app.request(new Request(`http://localhost/admin/openclaw/conflicts/${encodeURIComponent(receiver.beamId)}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(detailResponse.status, 200)
+    const detailBody = await detailResponse.json() as {
+      beamId: string
+      routeCount: number
+      activeConflictRouteCount: number
+      recommendedRouteId: number | null
+      routes: Array<{
+        id: number
+        runtimeSessionState: string
+      }>
+      history: unknown[]
+    }
+    assert.equal(detailBody.beamId, receiver.beamId)
+    assert.equal(detailBody.routeCount, 2)
+    assert.equal(detailBody.activeConflictRouteCount, 2)
+    assert.ok(typeof detailBody.recommendedRouteId === 'number')
+    assert.equal(detailBody.history.length, 0)
+    assert.deepEqual(detailBody.routes.map((route) => route.runtimeSessionState), ['conflict', 'conflict'])
+
+    const resolveResponse = await app.request(new Request(`http://localhost/admin/openclaw/conflicts/${encodeURIComponent(receiver.beamId)}/resolve`, {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        preferredRouteId: detailBody.recommendedRouteId,
+        disableCompetingRoutes: true,
+        note: 'Guided remediation smoke test',
+      }),
+    }))
+    assert.equal(resolveResponse.status, 200)
+    const resolveBody = await resolveResponse.json() as {
+      preferredRouteId: number
+      disabledRouteIds: number[]
+      conflict: {
+        resolutionState: string
+        activeConflictRouteCount: number
+        selectedOwnerRouteId: number | null
+        routes: Array<{
+          id: number
+          runtimeSessionState: string
+          ownerResolutionState: string
+        }>
+        history: Array<{
+          action: string
+          note: string | null
+        }>
+      } | null
+    }
+    assert.equal(resolveBody.preferredRouteId, detailBody.recommendedRouteId)
+    assert.equal(resolveBody.disabledRouteIds.length, 1)
+    assert.equal(resolveBody.conflict?.resolutionState, 'owner_selected')
+    assert.equal(resolveBody.conflict?.activeConflictRouteCount, 0)
+    assert.equal(resolveBody.conflict?.selectedOwnerRouteId, detailBody.recommendedRouteId)
+    assert.ok(resolveBody.conflict?.routes.some((route) => route.id === detailBody.recommendedRouteId && route.runtimeSessionState === 'live'))
+    assert.ok(resolveBody.conflict?.routes.some((route) => route.id !== detailBody.recommendedRouteId && route.ownerResolutionState === 'disabled'))
+    assert.ok(resolveBody.conflict?.history.some((entry) => entry.action === 'admin.openclaw_conflict.resolved' && entry.note === 'Guided remediation smoke test'))
+  } finally {
+    db.close()
+  }
+})
+
 test('openclaw fleet overview surfaces receipt coverage and latency summaries', async () => {
   const db = createDatabase(':memory:')
 

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -22,6 +22,7 @@ import {
   listOpenClawHosts,
   listOpenClawResolvedRoutesByBeamId,
   listOpenClawResolvedRoutesForHost,
+  listAuditLog,
   listWorkspaceIdentityBindingsByBeamId,
   logAuditEvent,
   recordOpenClawHostHeartbeat,
@@ -47,6 +48,7 @@ import type {
   OpenClawRouteOwnerResolutionState,
   OpenClawResolvedRouteRow,
   OpenClawRouteReportedState,
+  OpenClawRouteRuntimeState,
   OpenClawRouteSource,
 } from '../types.js'
 
@@ -71,6 +73,9 @@ type OpenClawFleetDigestItem = {
 type OpenClawConflictGroup = {
   beamId: string
   routeCount: number
+  selectedOwnerRouteId: number | null
+  recommendedRouteId: number | null
+  recommendedReason: string | null
   routes: Array<{
     routeId: number
     hostId: number
@@ -80,7 +85,27 @@ type OpenClawConflictGroup = {
     routeKey: string
     routeSource: string
     ownerResolutionState: OpenClawRouteOwnerResolutionState
+    ownerResolutionActor: string | null
+    ownerResolutionAt: string | null
+    ownerResolutionNote: string | null
+    runtimeSessionState: OpenClawRouteRuntimeState
+    hostHealth: OpenClawHostHealth
+    lastSeenAt: string | null
+    lastDeliveryStatus: IntentLogRow['status'] | null
+    lastDeliveryHref: string | null
   }>
+}
+
+type OpenClawConflictHistoryItem = {
+  id: string
+  source: 'route' | 'host'
+  action: string
+  actor: string | null
+  timestamp: string
+  note: string | null
+  routeId: number | null
+  hostId: number | null
+  href: string | null
 }
 
 type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
@@ -429,6 +454,10 @@ function buildOpenClawFleetHref(hostId: number | null = null): string {
   return '/openclaw-fleet'
 }
 
+function buildOpenClawConflictHref(beamId: string): string {
+  return `/openclaw-fleet?conflict=${encodeURIComponent(beamId)}`
+}
+
 function buildWorkspaceHref(workspaceSlug: string | null): string | null {
   if (!workspaceSlug) {
     return null
@@ -525,6 +554,255 @@ function serializeRoute(db: Database, row: OpenClawResolvedRouteRow) {
       owner: binding.owner,
       runtimeType: binding.runtime_type,
     })),
+  }
+}
+
+function rankConflictRoute(route: ReturnType<typeof serializeRoute>) {
+  let score = 0
+  const reasons: string[] = []
+
+  switch (route.hostHealth) {
+    case 'healthy':
+      score += 50
+      reasons.push('healthy host heartbeat')
+      break
+    case 'watch':
+      score += 25
+      reasons.push('host is still connected')
+      break
+    case 'pending':
+      score += 5
+      break
+    case 'stale':
+    case 'revoked':
+      score -= 50
+      break
+  }
+
+  switch (route.connectionMode) {
+    case 'websocket':
+      score += 20
+      reasons.push('live websocket receiver')
+      break
+    case 'hybrid':
+      score += 16
+      reasons.push('hybrid receiver path')
+      break
+    case 'http':
+      score += 10
+      reasons.push('HTTP receiver path')
+      break
+    default:
+      break
+  }
+
+  switch (route.routeSource) {
+    case 'gateway-agent':
+      score += 12
+      reasons.push('gateway route')
+      break
+    case 'workspace-agent':
+      score += 8
+      break
+    case 'agent-folder':
+      score += 6
+      break
+    case 'subagent-run':
+      score += 2
+      break
+  }
+
+  if (route.lastDelivery?.status === 'acked') {
+    score += 12
+    reasons.push('recent successful delivery')
+  } else if (route.lastDelivery?.status === 'failed') {
+    score -= 12
+  }
+
+  if (route.ownerResolutionState === 'preferred') {
+    score += 10
+    reasons.push('already preferred previously')
+  }
+
+  const lastSeenMs = route.lastSeenAt ? Date.parse(route.lastSeenAt) : Number.NaN
+  if (Number.isFinite(lastSeenMs)) {
+    const ageMinutes = (Date.now() - lastSeenMs) / 60_000
+    if (ageMinutes <= 5) {
+      score += 15
+      reasons.push('very recent heartbeat')
+    } else if (ageMinutes <= 30) {
+      score += 8
+    } else if (ageMinutes > 180) {
+      score -= 8
+    }
+  }
+
+  if (route.runtimeSessionState === 'conflict') {
+    score += 4
+  } else if (route.runtimeSessionState === 'stale' || route.runtimeSessionState === 'revoked') {
+    score -= 20
+  }
+
+  return {
+    score,
+    reason: reasons.slice(0, 3).join(' · ') || 'best available route based on health and delivery signals',
+  }
+}
+
+function summarizeConflictResolution(routes: Array<ReturnType<typeof serializeRoute>>) {
+  const selectedOwnerRouteId = routes.find((route) => route.ownerResolutionState === 'preferred')?.id ?? null
+  const ranked = [...routes]
+    .map((route) => ({
+      route,
+      ranking: rankConflictRoute(route),
+    }))
+    .sort((left, right) => {
+      if (right.ranking.score !== left.ranking.score) {
+        return right.ranking.score - left.ranking.score
+      }
+      return (Date.parse(right.route.lastSeenAt ?? '') || 0) - (Date.parse(left.route.lastSeenAt ?? '') || 0)
+    })
+
+  const recommended = ranked[0] ?? null
+  return {
+    selectedOwnerRouteId,
+    recommendedRouteId: recommended?.route.id ?? null,
+    recommendedReason: recommended?.ranking.reason ?? null,
+  }
+}
+
+function buildConflictHistory(
+  db: Database,
+  beamId: string,
+  routes: Array<ReturnType<typeof serializeRoute>>,
+): OpenClawConflictHistoryItem[] {
+  const historyItems: OpenClawConflictHistoryItem[] = []
+
+  for (const entry of listAuditLog(db, {
+    limit: 5,
+    target: `openclaw-conflict:${beamId}`,
+  })) {
+    let note: string | null = null
+    try {
+      const parsed = entry.details ? JSON.parse(entry.details) as Record<string, unknown> : null
+      note = normalizeOptionalString(parsed?.note)
+    } catch {
+      note = null
+    }
+    historyItems.push({
+      id: `audit-conflict:${entry.id}`,
+      source: 'route',
+      action: entry.action,
+      actor: entry.actor,
+      timestamp: entry.timestamp,
+      note,
+      routeId: null,
+      hostId: null,
+      href: buildOpenClawConflictHref(beamId),
+    })
+  }
+
+  for (const route of routes) {
+    if (route.ownerResolutionAt) {
+      historyItems.push({
+        id: `route-resolution:${route.id}:${route.ownerResolutionAt}`,
+        source: 'route',
+        action: route.ownerResolutionState,
+        actor: route.ownerResolutionActor,
+        timestamp: route.ownerResolutionAt,
+        note: route.ownerResolutionNote,
+        routeId: route.id,
+        hostId: route.hostId,
+        href: route.lastDelivery?.href ?? null,
+      })
+    }
+
+    const auditEntries = listAuditLog(db, {
+      limit: 5,
+      target: `openclaw-route:${route.id}`,
+    })
+    for (const entry of auditEntries) {
+      let note: string | null = null
+      try {
+        const parsed = entry.details ? JSON.parse(entry.details) as Record<string, unknown> : null
+        note = normalizeOptionalString(parsed?.note)
+      } catch {
+        note = null
+      }
+      historyItems.push({
+        id: `audit-route:${entry.id}`,
+        source: 'route',
+        action: entry.action,
+        actor: entry.actor,
+        timestamp: entry.timestamp,
+        note,
+        routeId: route.id,
+        hostId: route.hostId,
+        href: null,
+      })
+    }
+  }
+
+  const seenHostIds = new Set<number>()
+  for (const route of routes) {
+    if (seenHostIds.has(route.hostId)) {
+      continue
+    }
+    seenHostIds.add(route.hostId)
+    const auditEntries = listAuditLog(db, {
+      limit: 5,
+      target: `openclaw-host:${route.hostId}`,
+    }).filter((entry) => entry.action === 'admin.openclaw_host.revoked')
+    for (const entry of auditEntries) {
+      let note: string | null = null
+      try {
+        const parsed = entry.details ? JSON.parse(entry.details) as Record<string, unknown> : null
+        note = normalizeOptionalString(parsed?.reason)
+      } catch {
+        note = null
+      }
+      historyItems.push({
+        id: `audit-host:${entry.id}`,
+        source: 'host',
+        action: entry.action,
+        actor: entry.actor,
+        timestamp: entry.timestamp,
+        note,
+        routeId: null,
+        hostId: route.hostId,
+        href: buildOpenClawFleetHref(route.hostId),
+      })
+    }
+  }
+
+  return historyItems
+    .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp))
+    .filter((entry, index, items) => items.findIndex((candidate) => candidate.id === entry.id) === index)
+    .slice(0, 12)
+}
+
+function buildConflictDetail(db: Database, beamId: string) {
+  const resolvedRoutes = listOpenClawResolvedRoutesByBeamId(db, beamId)
+  if (resolvedRoutes.length === 0) {
+    return null
+  }
+
+  const routes = resolvedRoutes.map((route) => serializeRoute(db, route))
+  const summary = summarizeConflictResolution(routes)
+  const activeConflictRoutes = summary.selectedOwnerRouteId
+    ? []
+    : routes.filter((route) => route.runtimeSessionState === 'conflict')
+
+  return {
+    beamId,
+    routeCount: routes.length,
+    activeConflictRouteCount: activeConflictRoutes.length,
+    resolutionState: summary.selectedOwnerRouteId ? 'owner_selected' : 'unresolved',
+    selectedOwnerRouteId: summary.selectedOwnerRouteId,
+    recommendedRouteId: summary.recommendedRouteId,
+    recommendedReason: summary.recommendedReason,
+    routes,
+    history: buildConflictHistory(db, beamId, routes),
   }
 }
 
@@ -903,7 +1181,7 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
       hostId: primaryRoute?.hostId ?? null,
       hostLabel: primaryRoute?.hostLabel ?? primaryRoute?.hostname ?? null,
       workspaceSlug: primaryRoute?.workspaceSlug ?? null,
-      href: buildOpenClawFleetHref(primaryRoute?.hostId ?? null),
+      href: buildOpenClawConflictHref(conflict.beamId),
       traceHref: null,
     })
   }
@@ -994,34 +1272,37 @@ function listConflictGroups(db: Database): OpenClawConflictGroup[] {
   `).all() as Array<{ beam_id: string }>
 
   return rows.flatMap((row): OpenClawConflictGroup[] => {
-    const resolvedRoutes = listOpenClawResolvedRoutesByBeamId(db, row.beam_id)
-    const hasActivePreferredRoute = resolvedRoutes.some((route) =>
-      route.owner_resolution_state === 'preferred'
-      && route.runtime_session_state !== 'conflict'
-      && route.runtime_session_state !== 'revoked'
-      && route.runtime_session_state !== 'ended',
-    )
-    if (hasActivePreferredRoute) {
+    const detail = buildConflictDetail(db, row.beam_id)
+    if (!detail || detail.activeConflictRouteCount === 0) {
       return []
     }
 
-    const routes = resolvedRoutes
-      .filter((route) => route.runtime_session_state === 'conflict')
-      .map((route) => ({
-        routeId: route.id,
-        hostId: route.host_id,
-        hostLabel: route.host_label,
-        hostname: route.hostname,
-        workspaceSlug: route.workspace_slug,
-        routeKey: route.route_key,
-        routeSource: route.route_source,
-        ownerResolutionState: route.owner_resolution_state,
-      }))
-
     return [{
       beamId: row.beam_id,
-      routeCount: routes.length,
-      routes,
+      routeCount: detail.activeConflictRouteCount,
+      selectedOwnerRouteId: detail.selectedOwnerRouteId,
+      recommendedRouteId: detail.recommendedRouteId,
+      recommendedReason: detail.recommendedReason,
+      routes: detail.routes
+        .filter((route) => route.runtimeSessionState === 'conflict')
+        .map((route) => ({
+          routeId: route.id,
+          hostId: route.hostId,
+          hostLabel: route.hostLabel,
+          hostname: route.hostLabel ?? `host-${route.hostId}`,
+          workspaceSlug: route.workspaceSlug,
+          routeKey: route.routeKey,
+          routeSource: route.routeSource,
+          ownerResolutionState: route.ownerResolutionState,
+          ownerResolutionActor: route.ownerResolutionActor,
+          ownerResolutionAt: route.ownerResolutionAt,
+          ownerResolutionNote: route.ownerResolutionNote,
+          runtimeSessionState: route.runtimeSessionState,
+          hostHealth: route.hostHealth,
+          lastSeenAt: route.lastSeenAt,
+          lastDeliveryStatus: route.lastDelivery?.status ?? null,
+          lastDeliveryHref: route.lastDelivery?.href ?? null,
+        })),
     }]
   })
 }
@@ -1123,6 +1404,112 @@ export function openClawAdminRouter(db: Database) {
       },
       hosts,
       conflicts,
+    })
+  })
+
+  router.get('/conflicts/:beamId', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const beamId = normalizeOptionalString(c.req.param('beamId'))
+    if (!beamId) {
+      return c.json({ error: 'Invalid Beam ID', errorCode: 'INVALID_BEAM_ID' }, 400)
+    }
+
+    const conflict = buildConflictDetail(db, beamId)
+    if (!conflict) {
+      return c.json({ error: 'Conflict not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json(conflict)
+  })
+
+  router.post('/conflicts/:beamId/resolve', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const beamId = normalizeOptionalString(c.req.param('beamId'))
+    if (!beamId) {
+      return c.json({ error: 'Invalid Beam ID', errorCode: 'INVALID_BEAM_ID' }, 400)
+    }
+
+    const conflict = buildConflictDetail(db, beamId)
+    if (!conflict) {
+      return c.json({ error: 'Conflict not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+    if (conflict.routes.length < 2) {
+      return c.json({ error: 'Route ownership conflict is no longer active', errorCode: 'NO_ACTIVE_CONFLICT' }, 409)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const preferredRouteId = normalizePositiveInteger(body.preferredRouteId)
+    if (!preferredRouteId) {
+      return c.json({ error: 'Preferred route is required', errorCode: 'PREFERRED_ROUTE_REQUIRED' }, 400)
+    }
+
+    const preferredRoute = conflict.routes.find((route) => route.id === preferredRouteId)
+    if (!preferredRoute) {
+      return c.json({ error: 'Preferred route does not belong to this Beam ID', errorCode: 'PREFERRED_ROUTE_INVALID' }, 400)
+    }
+
+    const note = normalizeOptionalString(body.note)
+    const disableCompetingRoutes = body.disableCompetingRoutes === true
+
+    setOpenClawRouteOwnerResolution(db, {
+      routeId: preferredRouteId,
+      resolutionState: 'preferred',
+      actor: auth.session.email,
+      note: note ?? `Preferred during guided remediation for ${beamId}.`,
+    })
+
+    const disabledRouteIds: number[] = []
+    if (disableCompetingRoutes) {
+      for (const route of conflict.routes) {
+        if (route.id === preferredRouteId || route.ownerResolutionState === 'disabled') {
+          continue
+        }
+        const updated = setOpenClawRouteOwnerResolution(db, {
+          routeId: route.id,
+          resolutionState: 'disabled',
+          actor: auth.session.email,
+          note: note ?? `Disabled during guided remediation for ${beamId}.`,
+        })
+        if (updated) {
+          disabledRouteIds.push(updated.id)
+        }
+      }
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_conflict.resolved',
+      actor: auth.session.email,
+      target: `openclaw-conflict:${beamId}`,
+      details: {
+        role: auth.session.role,
+        preferredRouteId,
+        disableCompetingRoutes,
+        disabledRouteIds,
+        note: note ?? null,
+      },
+    })
+
+    const updatedConflict = buildConflictDetail(db, beamId)
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      conflict: updatedConflict,
+      preferredRouteId,
+      disabledRouteIds,
     })
   })
 


### PR DESCRIPTION
## Summary\n- add guided conflict detail and remediation APIs for duplicate OpenClaw identities\n- surface remediation controls and conflict history in the fleet and workspace UI\n- update docs and tests so preferred-owner conflicts stop blocking fleet operations\n\n## Testing\n- npm test --workspace=packages/directory\n- npm run build\n- npm test\n- npm -C docs run build\n\nCloses #155