### PR TITLE
Add fleet digest scheduling and delivery history

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -151,6 +151,14 @@ For a repo-owned fleet digest and escalation summary, use:
 npm run workspace:fleet-digest
 ```
 
+To run the scheduled digest engine against an already running local Beam stack, use:
+
+```bash
+npm run workspace:fleet-digest:tick
+```
+
+That command hits the canonical scheduled run path, respects the configured digest schedule by default, and records persistent digest runs plus delivery history.
+
 The fleet enrollment response now also includes a copy-paste install pack with:
 
 - managed macOS install command
@@ -186,6 +194,8 @@ The fleet surface also gives operators explicit day-2 actions:
 - prefer, disable, or reset route ownership when duplicate Beam identities appear
 - open a guided remediation view for one duplicated Beam ID, keep the recommended owner route, and optionally disable the competing routes in one step
 - deliver a fleet digest that calls out stale hosts, pending credential work, duplicate conflicts, and missing receipts
+- configure one daily digest schedule with a separate escalation mailbox for critical fleet items
+- inspect persistent digest run history and delivery history directly in the fleet surface
 - label hosts with environment and group metadata such as `prod`, `staging`, `lab`, `edge`, or team ownership
 - stage guarded bulk actions across multiple hosts before a real revoke, with an explicit confirm phrase
 - clear staged revoke reviews again when a maintenance plan changes

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "workspace:buyer-dry-run": "node scripts/workspace/buyer-dry-run.mjs",
     "workspace:digest": "node scripts/workspace/operator-digest.mjs",
     "workspace:fleet-digest": "node scripts/workspace/fleet-digest.mjs",
+    "workspace:fleet-digest:tick": "node scripts/workspace/fleet-digest-tick.mjs",
     "workspace:fleet-drill": "node scripts/workspace/fleet-smoke.mjs",
     "workspace:fleet-smoke": "node scripts/workspace/fleet-smoke.mjs",
     "workspace:import-openclaw": "node scripts/workspace/import-openclaw.mjs",

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -36,6 +36,10 @@ export type OpenClawRouteOwnerResolutionState = 'implicit' | 'preferred' | 'disa
 export type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
 export type OpenClawHostRecoveryRunbookState = 'idle' | 'prepared' | 'cutover_pending' | 'completed'
 export type OpenClawFleetBulkAction = 'apply_labels' | 'stage_revoke_review' | 'clear_revoke_review'
+export type OpenClawFleetDigestRunTriggerKind = 'manual' | 'scheduled'
+export type OpenClawFleetDigestDeliveryKind = 'digest' | 'escalation'
+export type OpenClawFleetDigestDeliveryStatus = 'delivered' | 'failed' | 'unavailable' | 'skipped'
+export type OpenClawFleetDigestRunDeliveryState = 'pending' | 'delivered' | 'partial' | 'failed' | 'unavailable'
 export type WorkspaceOverviewAttentionCode =
   | 'identity_missing'
   | 'stale_check_in'
@@ -510,6 +514,54 @@ export interface OpenClawFleetDigestItem {
   traceHref: string | null
 }
 
+export interface OpenClawFleetDigestSchedule {
+  enabled: boolean
+  deliveryEmail: string | null
+  escalationEmail: string | null
+  runHourUtc: number
+  runMinuteUtc: number
+  escalateOnCritical: boolean
+  lastScheduledForAt: string | null
+  lastRunAt: string | null
+  lastDeliveryAt: string | null
+  lastEscalationDeliveryAt: string | null
+  nextRunAt: string | null
+}
+
+export interface OpenClawFleetDigestRun {
+  id: number
+  triggerKind: OpenClawFleetDigestRunTriggerKind
+  actor: string | null
+  generatedAt: string
+  deliveryState: OpenClawFleetDigestRunDeliveryState
+  lastDeliveryErrorCode: string | null
+  summary: {
+    actionItems: number
+    criticalItems: number
+    staleHosts: number
+    failedReceipts: number
+    duplicateIdentityConflicts: number
+    escalations: number
+  }
+}
+
+export interface OpenClawFleetDigestDelivery {
+  id: number
+  runId: number | null
+  runGeneratedAt: string | null
+  kind: OpenClawFleetDigestDeliveryKind
+  status: OpenClawFleetDigestDeliveryStatus
+  recipientEmail: string
+  errorCode: string | null
+  errorMessage: string | null
+  deliveredAt: string
+  summary: {
+    actionItems: number
+    criticalItems: number
+    escalations: number
+  } | null
+}
+
 export interface OpenClawFleetDigestResponse {
   generatedAt: string
   summary: {
@@ -531,10 +583,34 @@ export interface OpenClawFleetDigestResponse {
     pendingCredentialActions: number
     actionItems: number
     criticalItems: number
+    escalations: number
     warningItems: number
   }
   actionItems: OpenClawFleetDigestItem[]
+  escalations: OpenClawFleetDigestItem[]
+  schedule: OpenClawFleetDigestSchedule
+  history: {
+    runs: OpenClawFleetDigestRun[]
+    deliveries: OpenClawFleetDigestDelivery[]
+  }
   markdown: string
+}
+
+export interface OpenClawFleetDigestRunResponse {
+  ok: boolean
+  skipped: boolean
+  reason?: 'disabled' | 'not_due'
+  nextRunAt?: string | null
+  schedule?: OpenClawFleetDigestSchedule
+  run?: OpenClawFleetDigestRun
+  digest?: OpenClawFleetDigestResponse
+  deliveries?: Array<{
+    ok: boolean
+    status: OpenClawFleetDigestDeliveryStatus
+    errorCode: string | null
+    errorMessage: string | null
+    delivery: OpenClawFleetDigestDelivery
+  }>
 }
 
 export interface OpenClawHostsResponse {
@@ -636,6 +712,19 @@ export interface OpenClawFleetBulkActionResponse {
   hosts: OpenClawHostSummary[]
 }
 
+export interface OpenClawFleetDigestSchedulePatchInput {
+  enabled?: boolean
+  deliveryEmail?: string | null
+  escalationEmail?: string | null
+  runHourUtc?: number
+  runMinuteUtc?: number
+  escalateOnCritical?: boolean
+}
+
+export interface OpenClawFleetDigestSchedulePatchResponse {
+  schedule: OpenClawFleetDigestSchedule
+}
+
 export interface OpenClawHostPolicyPatchInput {
   rotationIntervalHours?: number | null
   rotationWindowStartHour?: number | null
@@ -671,6 +760,7 @@ export interface OpenClawConflictResolveResponse {
 export interface OpenClawFleetDigestDeliveryResponse {
   ok: boolean
   email: string
+  kind: OpenClawFleetDigestDeliveryKind
   deliveredAt: string
   summary: OpenClawFleetDigestResponse['summary']
 }
@@ -2414,7 +2504,15 @@ export const directoryApi = {
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
   getOpenClawFleetOverview: () => request<OpenClawFleetOverviewResponse>('/admin/openclaw/fleet/overview', undefined, { admin: true }),
   getOpenClawFleetDigest: (params?: { format?: 'json' | 'markdown' }) => request<OpenClawFleetDigestResponse>(`/admin/openclaw/fleet/digest${buildQuery({ format: params?.format })}`, undefined, { admin: true }),
-  deliverOpenClawFleetDigest: (input?: { email?: string | null }) => request<OpenClawFleetDigestDeliveryResponse>('/admin/openclaw/fleet/digest/deliver', {
+  updateOpenClawFleetDigestSchedule: (input: OpenClawFleetDigestSchedulePatchInput) => request<OpenClawFleetDigestSchedulePatchResponse>('/admin/openclaw/fleet/digest/schedule', {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  runOpenClawFleetDigest: (input?: { triggerKind?: OpenClawFleetDigestRunTriggerKind; deliver?: boolean; respectSchedule?: boolean }) => request<OpenClawFleetDigestRunResponse>('/admin/openclaw/fleet/digest/run', {
+    method: 'POST',
+    body: JSON.stringify(input ?? {}),
+  }, { admin: true }),
+  deliverOpenClawFleetDigest: (input?: { email?: string | null; kind?: OpenClawFleetDigestDeliveryKind; runId?: number | null }) => request<OpenClawFleetDigestDeliveryResponse>('/admin/openclaw/fleet/digest/deliver', {
     method: 'POST',
     body: JSON.stringify(input ?? {}),
   }, { admin: true }),

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -209,6 +209,15 @@ type HostPlacementFormState = {
   owner: string
 }
 
+type DigestScheduleFormState = {
+  enabled: boolean
+  deliveryEmail: string
+  escalationEmail: string
+  runHourUtc: string
+  runMinuteUtc: string
+  escalateOnCritical: boolean
+}
+
 type FleetBulkMode = 'labels' | 'stage_revoke_review' | 'clear_revoke_review' | null
 
 export default function OpenClawFleetPage() {
@@ -259,6 +268,14 @@ export default function OpenClawFleetPage() {
     environmentLabel: '',
     groupLabels: '',
     owner: '',
+  })
+  const [digestScheduleForm, setDigestScheduleForm] = useState<DigestScheduleFormState>({
+    enabled: true,
+    deliveryEmail: '',
+    escalationEmail: '',
+    runHourUtc: '8',
+    runMinuteUtc: '0',
+    escalateOnCritical: true,
   })
   const [selectedHostIds, setSelectedHostIds] = useState<number[]>([])
   const [bulkMode, setBulkMode] = useState<FleetBulkMode>(null)
@@ -463,6 +480,21 @@ export default function OpenClawFleetPage() {
     })
   }, [selectedHost?.id, selectedHost?.updatedAt])
 
+  useEffect(() => {
+    if (!digest) {
+      return
+    }
+
+    setDigestScheduleForm({
+      enabled: digest.schedule.enabled,
+      deliveryEmail: digest.schedule.deliveryEmail ?? '',
+      escalationEmail: digest.schedule.escalationEmail ?? '',
+      runHourUtc: String(digest.schedule.runHourUtc),
+      runMinuteUtc: String(digest.schedule.runMinuteUtc),
+      escalateOnCritical: digest.schedule.escalateOnCritical,
+    })
+  }, [digest?.schedule.enabled, digest?.schedule.deliveryEmail, digest?.schedule.escalationEmail, digest?.schedule.runHourUtc, digest?.schedule.runMinuteUtc, digest?.schedule.escalateOnCritical])
+
   async function runAction(actionKey: string, fn: () => Promise<void>, successMessage: string) {
     try {
       setActionBusy(actionKey)
@@ -665,12 +697,60 @@ export default function OpenClawFleetPage() {
     }, `Route ownership reset for ${route.beamId}.`)
   }
 
-  async function handleDeliverDigest() {
-    await runAction('deliver-digest', async () => {
-      const response = await directoryApi.deliverOpenClawFleetDigest()
+  async function handleSaveDigestSchedule() {
+    await runAction('digest-schedule', async () => {
+      await directoryApi.updateOpenClawFleetDigestSchedule({
+        enabled: digestScheduleForm.enabled,
+        deliveryEmail: digestScheduleForm.deliveryEmail.trim() || null,
+        escalationEmail: digestScheduleForm.escalationEmail.trim() || null,
+        runHourUtc: Math.max(0, Math.min(23, Number.parseInt(digestScheduleForm.runHourUtc, 10) || 0)),
+        runMinuteUtc: Math.max(0, Math.min(59, Number.parseInt(digestScheduleForm.runMinuteUtc, 10) || 0)),
+        escalateOnCritical: digestScheduleForm.escalateOnCritical,
+      })
       await loadDigest()
-      setNotice(`Fleet digest delivered to ${response.email}.`)
-    }, 'Fleet digest delivered.')
+    }, 'Fleet digest schedule updated.')
+  }
+
+  async function handleRunDigest(options?: {
+    triggerKind?: 'manual' | 'scheduled'
+    deliver?: boolean
+    respectSchedule?: boolean
+  }) {
+    const triggerKind = options?.triggerKind ?? 'manual'
+    const actionKey = `run-digest-${triggerKind}${options?.deliver ? '-deliver' : ''}${options?.respectSchedule ? '-respect' : ''}`
+    let nextNotice: string | null = null
+    await runAction(actionKey, async () => {
+      const response = await directoryApi.runOpenClawFleetDigest({
+        triggerKind,
+        deliver: options?.deliver ?? false,
+        respectSchedule: options?.respectSchedule ?? false,
+      })
+      if (response.skipped) {
+        nextNotice = response.reason === 'disabled'
+          ? 'Fleet digest schedule is disabled.'
+          : `Fleet digest is not due yet. Next run ${response.nextRunAt ? formatRelativeTime(response.nextRunAt) : 'is not scheduled'}.`
+      }
+      await loadDigest()
+    }, triggerKind === 'scheduled' ? 'Scheduled fleet digest processed.' : 'Fleet digest generated.')
+    if (nextNotice) {
+      setNotice(nextNotice)
+    }
+  }
+
+  async function handleDeliverDigest(input?: { kind?: 'digest' | 'escalation'; runId?: number | null }) {
+    const deliveryKind = input?.kind ?? 'digest'
+    let nextNotice: string | null = null
+    await runAction(`deliver-${deliveryKind}`, async () => {
+      const response = await directoryApi.deliverOpenClawFleetDigest({
+        kind: deliveryKind,
+        runId: input?.runId ?? null,
+      })
+      await loadDigest()
+      nextNotice = `${deliveryKind === 'escalation' ? 'Fleet escalation' : 'Fleet digest'} delivered to ${response.email}.`
+    }, deliveryKind === 'escalation' ? 'Fleet escalation delivered.' : 'Fleet digest delivered.')
+    if (nextNotice) {
+      setNotice(nextNotice)
+    }
   }
 
   const hostRoutes = hostDetail?.routes ?? []
@@ -714,7 +794,7 @@ export default function OpenClawFleetPage() {
         </div>
       ) : null}
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-7">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-8">
         <MetricCard label="Hosts" value={!overview ? '—' : formatNumber(overview.summary.totalHosts)} />
         <MetricCard label="Active hosts" value={!overview ? '—' : formatNumber(overview.summary.activeHosts)} tone={(overview?.summary.activeHosts ?? 0) > 0 ? 'success' : 'default'} />
         <MetricCard label="Pending hosts" value={!overview ? '—' : formatNumber(overview.summary.pendingHosts)} tone={(overview?.summary.pendingHosts ?? 0) > 0 ? 'warning' : 'default'} />
@@ -733,25 +813,257 @@ export default function OpenClawFleetPage() {
               One recurring summary for stale hosts, pending credential actions, duplicate conflicts, and failed deliveries.
             </p>
           </div>
-          <button
-            type="button"
-            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
-            disabled={actionBusy === 'deliver-digest'}
-            onClick={() => { void handleDeliverDigest() }}
-          >
-            {actionBusy === 'deliver-digest' ? 'Delivering…' : 'Deliver digest'}
-          </button>
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            {digest?.schedule.nextRunAt ? `Next run ${formatRelativeTime(digest.schedule.nextRunAt)}` : 'No digest schedule loaded yet'}
+          </div>
         </div>
 
         <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-7">
           <MetricCard label="Action items" value={!digest ? '—' : formatNumber(digest.summary.actionItems)} tone={(digest?.summary.actionItems ?? 0) > 0 ? 'warning' : 'default'} />
           <MetricCard label="Critical items" value={!digest ? '—' : formatNumber(digest.summary.criticalItems)} tone={(digest?.summary.criticalItems ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Escalations" value={!digest ? '—' : formatNumber(digest.summary.escalations)} tone={(digest?.summary.escalations ?? 0) > 0 ? 'critical' : 'default'} />
           <MetricCard label="Credential actions" value={!digest ? '—' : formatNumber(digest.summary.pendingCredentialActions)} tone={(digest?.summary.pendingCredentialActions ?? 0) > 0 ? 'warning' : 'default'} />
           <MetricCard label="Failed receipts" value={!digest ? '—' : formatNumber(digest.summary.failedReceipts)} tone={(digest?.summary.failedReceipts ?? 0) > 0 ? 'critical' : 'default'} />
           <MetricCard label="Stale hosts" value={!digest ? '—' : formatNumber(digest.summary.staleHosts)} tone={(digest?.summary.staleHosts ?? 0) > 0 ? 'critical' : 'default'} />
           <MetricCard label="Missing receipts" value={!digest ? '—' : formatNumber(digest.summary.routesMissingReceipts)} tone={(digest?.summary.routesMissingReceipts ?? 0) > 0 ? 'warning' : 'default'} />
           <MetricCard label="SLO breaches" value={!digest ? '—' : formatNumber(digest.summary.latencySloBreaches)} tone={(digest?.summary.latencySloBreaches ?? 0) > 0 ? 'warning' : 'default'} />
         </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-[1.05fr,0.95fr]">
+          <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+            <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Digest schedule</div>
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                <span>Delivery email</span>
+                <input
+                  className="input-field"
+                  placeholder="ops@example.com"
+                  value={digestScheduleForm.deliveryEmail}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, deliveryEmail: event.target.value }))}
+                />
+              </label>
+              <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                <span>Escalation email</span>
+                <input
+                  className="input-field"
+                  placeholder="critical@example.com"
+                  value={digestScheduleForm.escalationEmail}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, escalationEmail: event.target.value }))}
+                />
+              </label>
+              <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                <span>Run hour (UTC)</span>
+                <input
+                  className="input-field"
+                  inputMode="numeric"
+                  value={digestScheduleForm.runHourUtc}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, runHourUtc: event.target.value }))}
+                />
+              </label>
+              <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                <span>Run minute (UTC)</span>
+                <input
+                  className="input-field"
+                  inputMode="numeric"
+                  value={digestScheduleForm.runMinuteUtc}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, runMinuteUtc: event.target.value }))}
+                />
+              </label>
+            </div>
+
+            <div className="mt-3 flex flex-wrap gap-4 text-xs text-slate-500 dark:text-slate-400">
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={digestScheduleForm.enabled}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, enabled: event.target.checked }))}
+                />
+                <span>Schedule enabled</span>
+              </label>
+              <label className="inline-flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={digestScheduleForm.escalateOnCritical}
+                  onChange={(event) => setDigestScheduleForm((current) => ({ ...current, escalateOnCritical: event.target.checked }))}
+                />
+                <span>Escalate on critical items</span>
+              </label>
+            </div>
+
+            <div className="mt-4 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+              <div>Last scheduled slot: {digest?.schedule.lastScheduledForAt ? formatDateTime(digest.schedule.lastScheduledForAt) : '—'}</div>
+              <div>Last run: {digest?.schedule.lastRunAt ? formatRelativeTime(digest.schedule.lastRunAt) : '—'}</div>
+              <div>Last digest delivery: {digest?.schedule.lastDeliveryAt ? formatRelativeTime(digest.schedule.lastDeliveryAt) : '—'}</div>
+              <div>Last escalation: {digest?.schedule.lastEscalationDeliveryAt ? formatRelativeTime(digest.schedule.lastEscalationDeliveryAt) : '—'}</div>
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <button
+                type="button"
+                className="rounded-xl bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-orange-500 dark:text-slate-950 dark:hover:bg-orange-400"
+                disabled={actionBusy === 'digest-schedule'}
+                onClick={() => { void handleSaveDigestSchedule() }}
+              >
+                {actionBusy === 'digest-schedule' ? 'Saving…' : 'Save schedule'}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === 'run-digest-manual'}
+                onClick={() => { void handleRunDigest({ triggerKind: 'manual' }) }}
+              >
+                {actionBusy === 'run-digest-manual' ? 'Running…' : 'Run now'}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === 'run-digest-manual-deliver'}
+                onClick={() => { void handleRunDigest({ triggerKind: 'manual', deliver: true }) }}
+              >
+                {actionBusy === 'run-digest-manual-deliver' ? 'Running…' : 'Run + deliver'}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === 'run-digest-scheduled-deliver-respect'}
+                onClick={() => { void handleRunDigest({ triggerKind: 'scheduled', deliver: true, respectSchedule: true }) }}
+              >
+                {actionBusy === 'run-digest-scheduled-deliver-respect' ? 'Running due…' : 'Run if due'}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === 'deliver-digest'}
+                onClick={() => { void handleDeliverDigest({ kind: 'digest' }) }}
+              >
+                {actionBusy === 'deliver-digest' ? 'Delivering…' : 'Deliver digest'}
+              </button>
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === 'deliver-escalation'}
+                onClick={() => { void handleDeliverDigest({ kind: 'escalation' }) }}
+              >
+                {actionBusy === 'deliver-escalation' ? 'Delivering…' : 'Deliver escalation'}
+              </button>
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Recent runs</div>
+                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">Persistent run history for scheduled and manual digests.</div>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">
+                  {digest ? `${formatNumber(digest.history.runs.length)} runs` : '—'}
+                </div>
+              </div>
+              <div className="mt-3 space-y-2">
+                {digest && digest.history.runs.length > 0 ? (
+                  digest.history.runs.map((run) => (
+                    <div key={run.id} className="rounded-xl border border-slate-200 px-3 py-3 text-xs dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div className="font-medium text-slate-900 dark:text-slate-100">Run #{run.id}</div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={run.triggerKind} />
+                          <StatusPill label={run.deliveryState} tone={run.deliveryState === 'delivered' ? 'success' : run.deliveryState === 'partial' ? 'warning' : run.deliveryState === 'failed' || run.deliveryState === 'unavailable' ? 'critical' : 'default'} />
+                        </div>
+                      </div>
+                      <div className="mt-2 grid gap-2 text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                        <div>Generated {formatRelativeTime(run.generatedAt)}</div>
+                        <div>{run.actor ? `Actor ${run.actor}` : 'System generated'}</div>
+                        <div>{formatNumber(run.summary.actionItems)} action items · {formatNumber(run.summary.criticalItems)} critical</div>
+                        <div>{formatNumber(run.summary.escalations)} escalations · {formatNumber(run.summary.failedReceipts)} failed receipts</div>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <EmptyPanel label="No digest runs recorded yet." />
+                )}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-medium uppercase tracking-wide text-slate-400">Recent deliveries</div>
+                  <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">Digest and escalation delivery history with delivery-state evidence.</div>
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400">
+                  {digest ? `${formatNumber(digest.history.deliveries.length)} deliveries` : '—'}
+                </div>
+              </div>
+              <div className="mt-3 space-y-2">
+                {digest && digest.history.deliveries.length > 0 ? (
+                  digest.history.deliveries.map((delivery) => (
+                    <div key={delivery.id} className="rounded-xl border border-slate-200 px-3 py-3 text-xs dark:border-slate-800">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <div className="font-medium text-slate-900 dark:text-slate-100">{delivery.kind === 'escalation' ? 'Escalation' : 'Digest'} delivery</div>
+                        <div className="flex flex-wrap gap-2">
+                          <StatusPill label={delivery.kind} />
+                          <StatusPill label={delivery.status} tone={delivery.status === 'delivered' ? 'success' : delivery.status === 'skipped' ? 'warning' : 'critical'} />
+                        </div>
+                      </div>
+                      <div className="mt-2 grid gap-2 text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                        <div>{delivery.recipientEmail}</div>
+                        <div>{delivery.runGeneratedAt ? `Run ${formatRelativeTime(delivery.runGeneratedAt)}` : 'Manual delivery without persisted run'}</div>
+                        <div>{formatRelativeTime(delivery.deliveredAt)}</div>
+                        <div>{delivery.summary ? `${formatNumber(delivery.summary.actionItems)} items · ${formatNumber(delivery.summary.criticalItems)} critical` : 'No summary'}</div>
+                      </div>
+                      {delivery.errorCode ? (
+                        <div className="mt-2 text-[11px] text-red-600 dark:text-red-300">
+                          {delivery.errorCode}: {delivery.errorMessage ?? 'Delivery failed'}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))
+                ) : (
+                  <EmptyPanel label="No digest deliveries recorded yet." />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {digest && digest.escalations.length > 0 ? (
+          <div className="mt-4 rounded-2xl border border-red-200 bg-red-50/70 p-4 dark:border-red-500/30 dark:bg-red-500/10">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="panel-title">Escalations</div>
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  Critical fleet items that should trigger the explicit escalation path.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="rounded-xl border border-red-200 px-3 py-2 text-sm text-red-700 transition hover:bg-red-100 disabled:opacity-60 dark:border-red-500/30 dark:text-red-200 dark:hover:bg-red-500/10"
+                disabled={actionBusy === 'deliver-escalation'}
+                onClick={() => { void handleDeliverDigest({ kind: 'escalation' }) }}
+              >
+                {actionBusy === 'deliver-escalation' ? 'Delivering…' : 'Deliver escalations'}
+              </button>
+            </div>
+            <div className="mt-4 space-y-3">
+              {digest.escalations.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-red-200 bg-white/80 p-4 dark:border-red-500/20 dark:bg-slate-950/40">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <div className="text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.detail}</div>
+                    </div>
+                    <StatusPill label={item.severity} tone={digestSeverityTone(item.severity)} />
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                    <div>{item.nextAction}</div>
+                    <div>{item.hostLabel ? `${item.hostLabel}${item.workspaceSlug ? ` · ${item.workspaceSlug}` : ''}` : item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'Global fleet item'}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         <div className="mt-4 space-y-3">
           {digest && digest.actionItems.length > 0 ? (

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -18,6 +18,13 @@ import type {
   IntentLogRow,
   IntentTraceEventRow,
   OperatorNotificationRow,
+  OpenClawFleetDigestDeliveryKind,
+  OpenClawFleetDigestDeliveryRow,
+  OpenClawFleetDigestDeliveryStatus,
+  OpenClawFleetDigestRunDeliveryState,
+  OpenClawFleetDigestRunRow,
+  OpenClawFleetDigestRunTriggerKind,
+  OpenClawFleetDigestScheduleRow,
   OpenClawHostEnrollmentRequestRow,
   OpenClawHostEnrollmentStatus,
   OpenClawHostCredentialState,
@@ -433,6 +440,56 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_openclaw_host_heartbeats_host
       ON openclaw_host_heartbeats(host_id, heartbeat_at DESC);
+
+    CREATE TABLE IF NOT EXISTS openclaw_fleet_digest_schedules (
+      id INTEGER PRIMARY KEY CHECK(id = 1),
+      enabled INTEGER NOT NULL DEFAULT 1,
+      delivery_email TEXT,
+      escalation_email TEXT,
+      run_hour_utc INTEGER NOT NULL DEFAULT 8,
+      run_minute_utc INTEGER NOT NULL DEFAULT 0,
+      escalate_on_critical INTEGER NOT NULL DEFAULT 1,
+      last_scheduled_for_at TEXT,
+      last_run_id INTEGER,
+      last_delivery_at TEXT,
+      last_escalation_delivery_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      FOREIGN KEY (last_run_id) REFERENCES openclaw_fleet_digest_runs(id) ON DELETE SET NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS openclaw_fleet_digest_runs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      trigger_kind TEXT NOT NULL CHECK(trigger_kind IN ('manual', 'scheduled')),
+      actor TEXT,
+      generated_at TEXT NOT NULL,
+      summary_json TEXT NOT NULL,
+      action_items_json TEXT NOT NULL,
+      escalation_items_json TEXT NOT NULL,
+      markdown TEXT NOT NULL,
+      delivery_state TEXT NOT NULL DEFAULT 'pending' CHECK(delivery_state IN ('pending', 'delivered', 'partial', 'failed', 'unavailable')),
+      last_delivery_error_code TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_openclaw_fleet_digest_runs_generated
+      ON openclaw_fleet_digest_runs(generated_at DESC, id DESC);
+
+    CREATE TABLE IF NOT EXISTS openclaw_fleet_digest_deliveries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_id INTEGER,
+      delivery_kind TEXT NOT NULL CHECK(delivery_kind IN ('digest', 'escalation')),
+      recipient_email TEXT NOT NULL,
+      status TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'unavailable', 'skipped')),
+      error_code TEXT,
+      error_message TEXT,
+      delivered_at TEXT NOT NULL,
+      details_json TEXT,
+      FOREIGN KEY (run_id) REFERENCES openclaw_fleet_digest_runs(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_openclaw_fleet_digest_deliveries_run
+      ON openclaw_fleet_digest_deliveries(run_id, delivered_at DESC, id DESC);
 
     CREATE TABLE IF NOT EXISTS operator_notifications (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -866,6 +923,24 @@ function initSchema(db: DB): void {
     UPDATE openclaw_host_routes
     SET owner_resolution_state = COALESCE(NULLIF(owner_resolution_state, ''), 'implicit')
   `).run()
+
+  db.prepare(`
+    INSERT OR IGNORE INTO openclaw_fleet_digest_schedules (
+      id,
+      enabled,
+      delivery_email,
+      escalation_email,
+      run_hour_utc,
+      run_minute_utc,
+      escalate_on_critical,
+      last_scheduled_for_at,
+      last_run_id,
+      last_delivery_at,
+      last_escalation_delivery_at,
+      created_at,
+      updated_at
+    ) VALUES (1, 1, NULL, NULL, 8, 0, 1, NULL, NULL, NULL, NULL, ?, ?)
+  `).run(nowIso(), nowIso())
 
   db.prepare(`
     UPDATE agents
@@ -4170,6 +4245,261 @@ export function listOpenClawHostHeartbeats(db: DB, hostId: number, limit = 20): 
     ORDER BY datetime(heartbeat_at) DESC, id DESC
     LIMIT ?
   `).all(hostId, Math.max(1, Math.trunc(limit))) as OpenClawHostHeartbeatRow[]
+}
+
+export function getOpenClawFleetDigestSchedule(db: DB): OpenClawFleetDigestScheduleRow {
+  const row = db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_schedules
+    WHERE id = 1
+    LIMIT 1
+  `).get() as OpenClawFleetDigestScheduleRow | undefined
+
+  if (row) {
+    return row
+  }
+
+  const now = nowIso()
+  db.prepare(`
+    INSERT INTO openclaw_fleet_digest_schedules (
+      id,
+      enabled,
+      delivery_email,
+      escalation_email,
+      run_hour_utc,
+      run_minute_utc,
+      escalate_on_critical,
+      last_scheduled_for_at,
+      last_run_id,
+      last_delivery_at,
+      last_escalation_delivery_at,
+      created_at,
+      updated_at
+    ) VALUES (1, 1, NULL, NULL, 8, 0, 1, NULL, NULL, NULL, NULL, ?, ?)
+  `).run(now, now)
+
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_schedules
+    WHERE id = 1
+    LIMIT 1
+  `).get() as OpenClawFleetDigestScheduleRow
+}
+
+export function updateOpenClawFleetDigestSchedule(
+  db: DB,
+  input: {
+    enabled?: boolean
+    deliveryEmail?: string | null
+    escalationEmail?: string | null
+    runHourUtc?: number
+    runMinuteUtc?: number
+    escalateOnCritical?: boolean
+    lastScheduledForAt?: string | null
+    lastRunId?: number | null
+    lastDeliveryAt?: string | null
+    lastEscalationDeliveryAt?: string | null
+  },
+): OpenClawFleetDigestScheduleRow {
+  const existing = getOpenClawFleetDigestSchedule(db)
+  db.prepare(`
+    UPDATE openclaw_fleet_digest_schedules
+    SET enabled = ?,
+        delivery_email = ?,
+        escalation_email = ?,
+        run_hour_utc = ?,
+        run_minute_utc = ?,
+        escalate_on_critical = ?,
+        last_scheduled_for_at = ?,
+        last_run_id = ?,
+        last_delivery_at = ?,
+        last_escalation_delivery_at = ?,
+        updated_at = ?
+    WHERE id = 1
+  `).run(
+    input.enabled === undefined ? existing.enabled : (input.enabled ? 1 : 0),
+    input.deliveryEmail === undefined ? existing.delivery_email : input.deliveryEmail,
+    input.escalationEmail === undefined ? existing.escalation_email : input.escalationEmail,
+    input.runHourUtc === undefined ? existing.run_hour_utc : input.runHourUtc,
+    input.runMinuteUtc === undefined ? existing.run_minute_utc : input.runMinuteUtc,
+    input.escalateOnCritical === undefined ? existing.escalate_on_critical : (input.escalateOnCritical ? 1 : 0),
+    input.lastScheduledForAt === undefined ? existing.last_scheduled_for_at : input.lastScheduledForAt,
+    input.lastRunId === undefined ? existing.last_run_id : input.lastRunId,
+    input.lastDeliveryAt === undefined ? existing.last_delivery_at : input.lastDeliveryAt,
+    input.lastEscalationDeliveryAt === undefined ? existing.last_escalation_delivery_at : input.lastEscalationDeliveryAt,
+    nowIso(),
+  )
+  return getOpenClawFleetDigestSchedule(db)
+}
+
+export function createOpenClawFleetDigestRun(
+  db: DB,
+  input: {
+    triggerKind: OpenClawFleetDigestRunTriggerKind
+    actor?: string | null
+    generatedAt?: string
+    summaryJson: string
+    actionItemsJson: string
+    escalationItemsJson: string
+    markdown: string
+  },
+): OpenClawFleetDigestRunRow {
+  const generatedAt = input.generatedAt ?? nowIso()
+  const result = db.prepare(`
+    INSERT INTO openclaw_fleet_digest_runs (
+      trigger_kind,
+      actor,
+      generated_at,
+      summary_json,
+      action_items_json,
+      escalation_items_json,
+      markdown,
+      delivery_state,
+      last_delivery_error_code,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', NULL, ?)
+  `).run(
+    input.triggerKind,
+    input.actor ?? null,
+    generatedAt,
+    input.summaryJson,
+    input.actionItemsJson,
+    input.escalationItemsJson,
+    input.markdown,
+    generatedAt,
+  )
+  const run = getOpenClawFleetDigestRunById(db, Number(result.lastInsertRowid))
+  updateOpenClawFleetDigestSchedule(db, { lastRunId: run?.id ?? null })
+  return run as OpenClawFleetDigestRunRow
+}
+
+export function getOpenClawFleetDigestRunById(db: DB, id: number): OpenClawFleetDigestRunRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_runs
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as OpenClawFleetDigestRunRow | undefined
+
+  return row ?? null
+}
+
+export function listOpenClawFleetDigestRuns(db: DB, limit = 20): OpenClawFleetDigestRunRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_runs
+    ORDER BY datetime(generated_at) DESC, id DESC
+    LIMIT ?
+  `).all(Math.max(1, Math.trunc(limit))) as OpenClawFleetDigestRunRow[]
+}
+
+function computeOpenClawFleetDigestRunDeliveryState(
+  deliveries: OpenClawFleetDigestDeliveryRow[],
+): OpenClawFleetDigestRunDeliveryState {
+  if (deliveries.length === 0) {
+    return 'pending'
+  }
+
+  const deliveredCount = deliveries.filter((delivery) => delivery.status === 'delivered').length
+  const unavailableOnly = deliveries.every((delivery) => delivery.status === 'unavailable' || delivery.status === 'skipped')
+
+  if (deliveredCount === deliveries.length) {
+    return 'delivered'
+  }
+  if (deliveredCount > 0) {
+    return 'partial'
+  }
+  if (unavailableOnly) {
+    return 'unavailable'
+  }
+  return 'failed'
+}
+
+function refreshOpenClawFleetDigestRunDeliveryState(db: DB, runId: number): OpenClawFleetDigestRunRow | null {
+  const run = getOpenClawFleetDigestRunById(db, runId)
+  if (!run) {
+    return null
+  }
+
+  const deliveries = db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_deliveries
+    WHERE run_id = ?
+    ORDER BY datetime(delivered_at) DESC, id DESC
+  `).all(runId) as OpenClawFleetDigestDeliveryRow[]
+
+  const nextState = computeOpenClawFleetDigestRunDeliveryState(deliveries)
+  const lastDeliveryError = deliveries.find((delivery) => delivery.error_code)?.error_code ?? null
+  db.prepare(`
+    UPDATE openclaw_fleet_digest_runs
+    SET delivery_state = ?,
+        last_delivery_error_code = ?
+    WHERE id = ?
+  `).run(nextState, lastDeliveryError, runId)
+
+  return getOpenClawFleetDigestRunById(db, runId)
+}
+
+export function recordOpenClawFleetDigestDelivery(
+  db: DB,
+  input: {
+    runId?: number | null
+    deliveryKind: OpenClawFleetDigestDeliveryKind
+    recipientEmail: string
+    status: OpenClawFleetDigestDeliveryStatus
+    errorCode?: string | null
+    errorMessage?: string | null
+    deliveredAt?: string
+    detailsJson?: string | null
+  },
+): OpenClawFleetDigestDeliveryRow {
+  const deliveredAt = input.deliveredAt ?? nowIso()
+  const result = db.prepare(`
+    INSERT INTO openclaw_fleet_digest_deliveries (
+      run_id,
+      delivery_kind,
+      recipient_email,
+      status,
+      error_code,
+      error_message,
+      delivered_at,
+      details_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    input.runId ?? null,
+    input.deliveryKind,
+    input.recipientEmail,
+    input.status,
+    input.errorCode ?? null,
+    input.errorMessage ?? null,
+    deliveredAt,
+    input.detailsJson ?? null,
+  )
+
+  if (input.runId) {
+    refreshOpenClawFleetDigestRunDeliveryState(db, input.runId)
+  }
+
+  updateOpenClawFleetDigestSchedule(db, {
+    lastDeliveryAt: input.deliveryKind === 'digest' ? deliveredAt : undefined,
+    lastEscalationDeliveryAt: input.deliveryKind === 'escalation' ? deliveredAt : undefined,
+  })
+
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_deliveries
+    WHERE id = ?
+    LIMIT 1
+  `).get(Number(result.lastInsertRowid)) as OpenClawFleetDigestDeliveryRow
+}
+
+export function listOpenClawFleetDigestDeliveries(db: DB, limit = 20): OpenClawFleetDigestDeliveryRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_fleet_digest_deliveries
+    ORDER BY datetime(delivered_at) DESC, id DESC
+    LIMIT ?
+  `).all(Math.max(1, Math.trunc(limit))) as OpenClawFleetDigestDeliveryRow[]
 }
 
 function updateOpenClawHostRouteCount(db: DB, hostId: number): void {

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -739,6 +739,156 @@ test('openclaw host policy patch surfaces rotation windows and recovery runbook 
   }
 })
 
+test('fleet digest schedule persists scheduled runs and delivery history', async () => {
+  const db = createDatabase(':memory:')
+  const originalSmtpHost = process.env['SMTP_HOST']
+  const originalSmtpPort = process.env['SMTP_PORT']
+  const originalSmtpUser = process.env['SMTP_USER']
+  const originalSmtpPass = process.env['SMTP_PASS']
+  const originalSmtpPassword = process.env['SMTP_PASSWORD']
+  const originalSmtpFrom = process.env['SMTP_FROM']
+  const originalResendApiKey = process.env['RESEND_API_KEY']
+
+  delete process.env['SMTP_HOST']
+  delete process.env['SMTP_PORT']
+  delete process.env['SMTP_USER']
+  delete process.env['SMTP_PASS']
+  delete process.env['SMTP_PASSWORD']
+  delete process.env['SMTP_FROM']
+  delete process.env['RESEND_API_KEY']
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const receiver = createFixtureAgent('atlas@openclaw.beam.directory')
+    registerFixtureAgent(db, receiver, 'Atlas')
+    const staleAt = new Date(Date.now() - (20 * 60 * 1000)).toISOString()
+    createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Digest',
+      hostname: 'digest.local',
+      beamId: receiver.beamId,
+      routeKey: 'atlas-digest',
+      workspaceSlug: 'openclaw-local',
+      heartbeatAt: staleAt,
+    })
+
+    const app = createApp(db)
+    const now = new Date()
+    const scheduleResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/digest/schedule', {
+      method: 'PATCH',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        enabled: true,
+        deliveryEmail: 'ops@example.com',
+        escalationEmail: 'critical@example.com',
+        runHourUtc: now.getUTCHours(),
+        runMinuteUtc: now.getUTCMinutes(),
+        escalateOnCritical: true,
+      }),
+    }))
+    assert.equal(scheduleResponse.status, 200)
+
+    const runResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/digest/run', {
+      method: 'POST',
+      headers: {
+        ...createAdminHeaders(db, 'ops@example.com', 'operator'),
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        triggerKind: 'scheduled',
+        deliver: true,
+        respectSchedule: true,
+      }),
+    }))
+    assert.equal(runResponse.status, 200)
+    const runBody = await runResponse.json() as {
+      ok: boolean
+      skipped: boolean
+      run: {
+        id: number
+        triggerKind: string
+        deliveryState: string
+      }
+      deliveries: Array<{
+        status: string
+        errorCode: string | null
+        delivery: {
+          kind: string
+          recipientEmail: string
+        }
+      }>
+    }
+    assert.equal(runBody.ok, true)
+    assert.equal(runBody.skipped, false)
+    assert.equal(runBody.run.triggerKind, 'scheduled')
+    assert.equal(runBody.run.deliveryState, 'unavailable')
+    assert.ok(runBody.deliveries.some((delivery) => delivery.delivery.kind === 'digest' && delivery.status === 'unavailable'))
+    assert.ok(runBody.deliveries.some((delivery) => delivery.delivery.kind === 'escalation' && delivery.status === 'unavailable'))
+    assert.ok(runBody.deliveries.some((delivery) => delivery.errorCode === 'EMAIL_DELIVERY_UNAVAILABLE'))
+
+    const digestResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/digest', {
+      headers: createAdminHeaders(db, 'ops@example.com', 'operator'),
+    }))
+    assert.equal(digestResponse.status, 200)
+    const digestBody = await digestResponse.json() as {
+      summary: {
+        staleHosts: number
+        escalations: number
+      }
+      schedule: {
+        enabled: boolean
+        deliveryEmail: string | null
+        escalationEmail: string | null
+        lastRunAt: string | null
+        lastDeliveryAt: string | null
+        lastEscalationDeliveryAt: string | null
+      }
+      history: {
+        runs: Array<{
+          id: number
+          deliveryState: string
+        }>
+        deliveries: Array<{
+          kind: string
+          status: string
+        }>
+      }
+      markdown: string
+    }
+    assert.equal(digestBody.summary.staleHosts, 1)
+    assert.ok(digestBody.summary.escalations >= 1)
+    assert.equal(digestBody.schedule.enabled, true)
+    assert.equal(digestBody.schedule.deliveryEmail, 'ops@example.com')
+    assert.equal(digestBody.schedule.escalationEmail, 'critical@example.com')
+    assert.ok(digestBody.schedule.lastRunAt)
+    assert.ok(digestBody.schedule.lastDeliveryAt)
+    assert.ok(digestBody.schedule.lastEscalationDeliveryAt)
+    assert.ok(digestBody.history.runs.length >= 1)
+    assert.equal(digestBody.history.runs[0]?.deliveryState, 'unavailable')
+    assert.ok(digestBody.history.deliveries.some((delivery) => delivery.kind === 'digest' && delivery.status === 'unavailable'))
+    assert.ok(digestBody.history.deliveries.some((delivery) => delivery.kind === 'escalation' && delivery.status === 'unavailable'))
+    assert.match(digestBody.markdown, /## Escalations/)
+  } finally {
+    if (originalSmtpHost === undefined) delete process.env['SMTP_HOST']
+    else process.env['SMTP_HOST'] = originalSmtpHost
+    if (originalSmtpPort === undefined) delete process.env['SMTP_PORT']
+    else process.env['SMTP_PORT'] = originalSmtpPort
+    if (originalSmtpUser === undefined) delete process.env['SMTP_USER']
+    else process.env['SMTP_USER'] = originalSmtpUser
+    if (originalSmtpPass === undefined) delete process.env['SMTP_PASS']
+    else process.env['SMTP_PASS'] = originalSmtpPass
+    if (originalSmtpPassword === undefined) delete process.env['SMTP_PASSWORD']
+    else process.env['SMTP_PASSWORD'] = originalSmtpPassword
+    if (originalSmtpFrom === undefined) delete process.env['SMTP_FROM']
+    else process.env['SMTP_FROM'] = originalSmtpFrom
+    if (originalResendApiKey === undefined) delete process.env['RESEND_API_KEY']
+    else process.env['RESEND_API_KEY'] = originalResendApiKey
+    db.close()
+  }
+})
+
 test('duplicate openclaw conflicts can be resolved by preferring one route owner', async () => {
   const db = createDatabase(':memory:')
 

--- a/packages/directory/src/public-surface.test.ts
+++ b/packages/directory/src/public-surface.test.ts
@@ -732,9 +732,10 @@ test('hosted beta requests can be created publicly, reviewed by operators, and e
       details: { route: 'direct-http' },
     })
 
-    const contactTimestamp = '2026-03-30T20:15:00.000Z'
-    const meetingTimestamp = '2026-04-02T14:00:00.000Z'
-    const reminderTimestamp = '2026-03-30T21:00:00.000Z'
+    const now = Date.now()
+    const contactTimestamp = new Date(now - 60 * 60 * 1000).toISOString()
+    const meetingTimestamp = new Date(now + 60 * 60 * 1000).toISOString()
+    const reminderTimestamp = new Date(now - 30 * 60 * 1000).toISOString()
     const contactResponse = await app.request(new Request(`http://localhost/admin/beta-requests/${created.request.id}`, {
       method: 'PATCH',
       headers: {

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -6,9 +6,12 @@ import {
   applyOpenClawHostRouteEvents,
   approveOpenClawHost,
   createOpenClawEnrollmentRequest,
+  createOpenClawFleetDigestRun,
   createOpenClawHost,
   getAgent,
   getLatestIntentLogByTarget,
+  getOpenClawFleetDigestRunById,
+  getOpenClawFleetDigestSchedule,
   getOpenClawEnrollmentRequestById,
   getOpenClawEnrollmentRequestByKey,
   getOpenClawHostByEnrollmentRequestId,
@@ -18,6 +21,8 @@ import {
   getWorkspaceById,
   getWorkspaceBySlug,
   listOpenClawEnrollmentRequests,
+  listOpenClawFleetDigestDeliveries,
+  listOpenClawFleetDigestRuns,
   listOpenClawHostHeartbeats,
   listOpenClawHosts,
   listOpenClawResolvedRoutesByBeamId,
@@ -32,14 +37,23 @@ import {
   revokeOpenClawHost,
   resolveOpenClawHostCredential,
   rotateOpenClawHostCredential,
+  recordOpenClawFleetDigestDelivery,
   setOpenClawRouteOwnerResolution,
   syncOpenClawHostRoutes,
   updateOpenClawEnrollmentRequest,
+  updateOpenClawFleetDigestSchedule,
   updateOpenClawHost,
 } from '../db.js'
 import { getSuppliedApiKey, hostApiKeyMatches, hostKeyFromApiKey } from '../api-key.js'
 import type {
   IntentLogRow,
+  OpenClawFleetDigestDeliveryKind,
+  OpenClawFleetDigestDeliveryRow,
+  OpenClawFleetDigestDeliveryStatus,
+  OpenClawFleetDigestRunDeliveryState,
+  OpenClawFleetDigestRunRow,
+  OpenClawFleetDigestRunTriggerKind,
+  OpenClawFleetDigestScheduleRow,
   OpenClawHostCredentialState,
   OpenClawHostEnrollmentRequestRow,
   OpenClawHostHealth,
@@ -68,6 +82,56 @@ type OpenClawFleetDigestItem = {
   workspaceSlug: string | null
   href: string | null
   traceHref: string | null
+}
+
+type OpenClawFleetEscalation = OpenClawFleetDigestItem
+
+type SerializedOpenClawFleetDigestSchedule = {
+  enabled: boolean
+  deliveryEmail: string | null
+  escalationEmail: string | null
+  runHourUtc: number
+  runMinuteUtc: number
+  escalateOnCritical: boolean
+  lastScheduledForAt: string | null
+  lastRunAt: string | null
+  lastDeliveryAt: string | null
+  lastEscalationDeliveryAt: string | null
+  nextRunAt: string | null
+}
+
+type SerializedOpenClawFleetDigestRun = {
+  id: number
+  triggerKind: OpenClawFleetDigestRunTriggerKind
+  actor: string | null
+  generatedAt: string
+  deliveryState: OpenClawFleetDigestRunDeliveryState
+  lastDeliveryErrorCode: string | null
+  summary: {
+    actionItems: number
+    criticalItems: number
+    staleHosts: number
+    failedReceipts: number
+    duplicateIdentityConflicts: number
+    escalations: number
+  }
+}
+
+type SerializedOpenClawFleetDigestDelivery = {
+  id: number
+  runId: number | null
+  runGeneratedAt: string | null
+  kind: OpenClawFleetDigestDeliveryKind
+  status: OpenClawFleetDigestDeliveryStatus
+  recipientEmail: string
+  errorCode: string | null
+  errorMessage: string | null
+  deliveredAt: string
+  summary: {
+    actionItems: number
+    criticalItems: number
+    escalations: number
+  } | null
 }
 
 type OpenClawConflictGroup = {
@@ -279,6 +343,18 @@ function parseOpenClawHostMetadata(raw: string | null): OpenClawHostMetadataJson
     return parsed as OpenClawHostMetadataJson
   } catch {
     return {}
+  }
+}
+
+function parseJson<T>(raw: string | null, fallback: T): T {
+  if (!raw) {
+    return fallback
+  }
+
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
   }
 }
 
@@ -1153,6 +1229,123 @@ function summarizeOpenClawFleetGroups(hosts: Array<ReturnType<typeof serializeHo
     .sort((left, right) => left.label.localeCompare(right.label))
 }
 
+function buildOpenClawFleetEscalations(actionItems: OpenClawFleetDigestItem[]): OpenClawFleetEscalation[] {
+  return actionItems.filter((item) => item.severity === 'critical')
+}
+
+function computeOpenClawFleetDigestCurrentScheduleSlot(
+  runHourUtc: number,
+  runMinuteUtc: number,
+  now = new Date(),
+): string {
+  const slot = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    runHourUtc,
+    runMinuteUtc,
+    0,
+    0,
+  ))
+  if (now.getTime() < slot.getTime()) {
+    slot.setUTCDate(slot.getUTCDate() - 1)
+  }
+  return slot.toISOString()
+}
+
+function computeOpenClawFleetDigestNextRunAt(
+  schedule: OpenClawFleetDigestScheduleRow,
+  now = new Date(),
+): string | null {
+  if (!schedule.enabled) {
+    return null
+  }
+
+  const next = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    schedule.run_hour_utc,
+    schedule.run_minute_utc,
+    0,
+    0,
+  ))
+  if (now.getTime() >= next.getTime()) {
+    next.setUTCDate(next.getUTCDate() + 1)
+  }
+  return next.toISOString()
+}
+
+function serializeOpenClawFleetDigestSchedule(
+  schedule: OpenClawFleetDigestScheduleRow,
+  runsById: Map<number, OpenClawFleetDigestRunRow>,
+): SerializedOpenClawFleetDigestSchedule {
+  const lastRun = schedule.last_run_id ? runsById.get(schedule.last_run_id) ?? null : null
+
+  return {
+    enabled: schedule.enabled === 1,
+    deliveryEmail: schedule.delivery_email,
+    escalationEmail: schedule.escalation_email,
+    runHourUtc: schedule.run_hour_utc,
+    runMinuteUtc: schedule.run_minute_utc,
+    escalateOnCritical: schedule.escalate_on_critical === 1,
+    lastScheduledForAt: schedule.last_scheduled_for_at,
+    lastRunAt: lastRun?.generated_at ?? null,
+    lastDeliveryAt: schedule.last_delivery_at,
+    lastEscalationDeliveryAt: schedule.last_escalation_delivery_at,
+    nextRunAt: computeOpenClawFleetDigestNextRunAt(schedule),
+  }
+}
+
+function serializeOpenClawFleetDigestRun(row: OpenClawFleetDigestRunRow): SerializedOpenClawFleetDigestRun {
+  const summary = parseJson<Record<string, unknown>>(row.summary_json, {})
+  const escalationItems = parseJson<unknown[]>(row.escalation_items_json, [])
+  return {
+    id: row.id,
+    triggerKind: row.trigger_kind,
+    actor: row.actor,
+    generatedAt: row.generated_at,
+    deliveryState: row.delivery_state,
+    lastDeliveryErrorCode: row.last_delivery_error_code,
+    summary: {
+      actionItems: Number(summary['actionItems'] ?? 0),
+      criticalItems: Number(summary['criticalItems'] ?? 0),
+      staleHosts: Number(summary['staleHosts'] ?? 0),
+      failedReceipts: Number(summary['failedReceipts'] ?? 0),
+      duplicateIdentityConflicts: Number(summary['duplicateIdentityConflicts'] ?? 0),
+      escalations: escalationItems.length,
+    },
+  }
+}
+
+function serializeOpenClawFleetDigestDelivery(
+  row: OpenClawFleetDigestDeliveryRow,
+  runsById: Map<number, OpenClawFleetDigestRunRow>,
+): SerializedOpenClawFleetDigestDelivery {
+  const run = row.run_id ? runsById.get(row.run_id) ?? null : null
+  const summary = run ? parseJson<Record<string, unknown>>(run.summary_json, {}) : null
+  const escalationItems = run ? parseJson<unknown[]>(run.escalation_items_json, []) : []
+
+  return {
+    id: row.id,
+    runId: row.run_id,
+    runGeneratedAt: run?.generated_at ?? null,
+    kind: row.delivery_kind,
+    status: row.status,
+    recipientEmail: row.recipient_email,
+    errorCode: row.error_code,
+    errorMessage: row.error_message,
+    deliveredAt: row.delivered_at,
+    summary: summary
+      ? {
+          actionItems: Number(summary['actionItems'] ?? 0),
+          criticalItems: Number(summary['criticalItems'] ?? 0),
+          escalations: escalationItems.length,
+        }
+      : null,
+  }
+}
+
 function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
   refreshOpenClawHostHealth(db)
   recalculateOpenClawRouteStates(db)
@@ -1404,6 +1597,7 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
     pendingCredentialActions: hosts.filter((host) => host.credentialState === 'rotation_pending' || host.credentialState === 'recovery_pending').length,
     actionItems: actionItems.length,
     criticalItems: actionItems.filter((item) => item.severity === 'critical').length,
+    escalations: buildOpenClawFleetEscalations(actionItems).length,
     warningItems: actionItems.filter((item) => item.severity === 'warning').length,
   }
 
@@ -1443,11 +1637,190 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
     }
   }
 
+  const escalationItems = buildOpenClawFleetEscalations(actionItems)
+  markdownLines.push('', '## Escalations', '')
+  if (escalationItems.length === 0) {
+    markdownLines.push('- No critical fleet escalations are currently open.')
+  } else {
+    for (const item of escalationItems) {
+      markdownLines.push(`- ${item.title}`)
+      markdownLines.push(`  - Detail: ${item.detail}`)
+      markdownLines.push(`  - Next action: ${item.nextAction}`)
+    }
+  }
+
   return {
     generatedAt: new Date().toISOString(),
     summary,
     actionItems,
+    escalations: escalationItems,
     markdown: `${markdownLines.join('\n')}\n`,
+  }
+}
+
+type BuiltOpenClawFleetDigest = ReturnType<typeof buildOpenClawFleetDigest>
+
+function buildPersistedOpenClawFleetDigestRun(
+  db: Database,
+  baseUrl: string,
+  input: {
+    triggerKind: OpenClawFleetDigestRunTriggerKind
+    actor?: string | null
+    scheduledForAt?: string | null
+  },
+): { digest: BuiltOpenClawFleetDigest; run: OpenClawFleetDigestRunRow } {
+  const digest = buildOpenClawFleetDigest(db, baseUrl)
+  const run = createOpenClawFleetDigestRun(db, {
+    triggerKind: input.triggerKind,
+    actor: input.actor ?? null,
+    generatedAt: digest.generatedAt,
+    summaryJson: JSON.stringify(digest.summary),
+    actionItemsJson: JSON.stringify(digest.actionItems),
+    escalationItemsJson: JSON.stringify(digest.escalations),
+    markdown: digest.markdown,
+  })
+
+  if (input.scheduledForAt !== undefined) {
+    updateOpenClawFleetDigestSchedule(db, {
+      lastRunId: run.id,
+      lastScheduledForAt: input.scheduledForAt,
+    })
+  }
+
+  return { digest, run }
+}
+
+function buildOpenClawFleetEscalationMarkdown(run: OpenClawFleetDigestRunRow): string {
+  const escalations = parseJson<OpenClawFleetEscalation[]>(run.escalation_items_json, [])
+  const summary = parseJson<Record<string, unknown>>(run.summary_json, {})
+  const lines = [
+    `# Beam OpenClaw fleet escalation · ${run.generated_at.slice(0, 10)}`,
+    '',
+    '## Summary',
+    '',
+    `- Trigger: \`${run.trigger_kind}\``,
+    `- Critical items: \`${Number(summary['criticalItems'] ?? escalations.length)}\``,
+    `- Action items: \`${Number(summary['actionItems'] ?? 0)}\``,
+    '',
+    '## Escalations',
+    '',
+  ]
+
+  if (escalations.length === 0) {
+    lines.push('- No critical fleet escalations are currently open.')
+  } else {
+    for (const item of escalations) {
+      lines.push(`- ${item.title}`)
+      lines.push(`  - Detail: ${item.detail}`)
+      lines.push(`  - Next action: ${item.nextAction}`)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+async function deliverOpenClawFleetDigestRun(
+  db: Database,
+  run: OpenClawFleetDigestRunRow,
+  input: {
+    actor: string
+    recipientEmail: string
+    deliveryKind: OpenClawFleetDigestDeliveryKind
+  },
+): Promise<{
+  ok: boolean
+  status: OpenClawFleetDigestDeliveryStatus
+  errorCode: string | null
+  errorMessage: string | null
+  delivery: OpenClawFleetDigestDeliveryRow
+}> {
+  const markdown = input.deliveryKind === 'escalation'
+    ? buildOpenClawFleetEscalationMarkdown(run)
+    : run.markdown
+  const subject = input.deliveryKind === 'escalation'
+    ? `Beam OpenClaw fleet escalation · ${run.generated_at.slice(0, 10)}`
+    : `Beam OpenClaw fleet digest · ${run.generated_at.slice(0, 10)}`
+
+  if (!isEmailDeliveryConfigured()) {
+    const delivery = recordOpenClawFleetDigestDelivery(db, {
+      runId: run.id,
+      deliveryKind: input.deliveryKind,
+      recipientEmail: input.recipientEmail,
+      status: 'unavailable',
+      errorCode: 'EMAIL_DELIVERY_UNAVAILABLE',
+      errorMessage: 'Email delivery is not configured for fleet digests.',
+      detailsJson: JSON.stringify({ actor: input.actor }),
+    })
+    return {
+      ok: false,
+      status: 'unavailable',
+      errorCode: 'EMAIL_DELIVERY_UNAVAILABLE',
+      errorMessage: 'Email delivery is not configured for fleet digests.',
+      delivery,
+    }
+  }
+
+  const delivered = await sendOperatorDigestEmail({
+    email: input.recipientEmail,
+    subject,
+    markdown,
+  })
+
+  const delivery = recordOpenClawFleetDigestDelivery(db, {
+    runId: run.id,
+    deliveryKind: input.deliveryKind,
+    recipientEmail: input.recipientEmail,
+    status: delivered ? 'delivered' : 'failed',
+    errorCode: delivered ? null : 'EMAIL_DELIVERY_FAILED',
+    errorMessage: delivered ? null : 'Failed to deliver fleet digest email.',
+    detailsJson: JSON.stringify({ actor: input.actor }),
+  })
+
+  return {
+    ok: delivered,
+    status: delivered ? 'delivered' : 'failed',
+    errorCode: delivered ? null : 'EMAIL_DELIVERY_FAILED',
+    errorMessage: delivered ? null : 'Failed to deliver fleet digest email.',
+    delivery,
+  }
+}
+
+function buildOpenClawFleetDigestEnvelope(db: Database, baseUrl: string) {
+  const digest = buildOpenClawFleetDigest(db, baseUrl)
+  const schedule = getOpenClawFleetDigestSchedule(db)
+  const runs = listOpenClawFleetDigestRuns(db, 10)
+  const runsById = new Map(runs.map((run) => [run.id, run]))
+  const deliveries = listOpenClawFleetDigestDeliveries(db, 20)
+
+  return {
+    ...digest,
+    schedule: serializeOpenClawFleetDigestSchedule(schedule, runsById),
+    history: {
+      runs: runs.map((run) => serializeOpenClawFleetDigestRun(run)),
+      deliveries: deliveries.map((delivery) => serializeOpenClawFleetDigestDelivery(delivery, runsById)),
+    },
+  }
+}
+
+function isOpenClawFleetDigestDue(schedule: OpenClawFleetDigestScheduleRow, now = new Date()) {
+  if (!schedule.enabled) {
+    return {
+      due: false,
+      scheduledForAt: null,
+      nextRunAt: computeOpenClawFleetDigestNextRunAt(schedule, now),
+    }
+  }
+
+  const scheduledForAt = computeOpenClawFleetDigestCurrentScheduleSlot(
+    schedule.run_hour_utc,
+    schedule.run_minute_utc,
+    now,
+  )
+
+  return {
+    due: schedule.last_scheduled_for_at !== scheduledForAt,
+    scheduledForAt,
+    nextRunAt: computeOpenClawFleetDigestNextRunAt(schedule, now),
   }
 }
 
@@ -1718,7 +2091,7 @@ export function openClawAdminRouter(db: Database) {
       return auth
     }
 
-    const digest = buildOpenClawFleetDigest(db, new URL(c.req.url).origin)
+    const digest = buildOpenClawFleetDigestEnvelope(db, new URL(c.req.url).origin)
     const format = c.req.query('format')
     if (format === 'markdown') {
       c.header('Cache-Control', 'no-store')
@@ -1730,6 +2103,246 @@ export function openClawAdminRouter(db: Database) {
 
     c.header('Cache-Control', 'no-store')
     return c.json(digest)
+  })
+
+  router.patch('/fleet/digest/schedule', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const enabled = body.enabled === undefined ? undefined : body.enabled === true
+    const deliveryEmail = body.deliveryEmail === undefined ? undefined : normalizeOptionalString(body.deliveryEmail)
+    const escalationEmail = body.escalationEmail === undefined ? undefined : normalizeOptionalString(body.escalationEmail)
+    const runHourUtc = body.runHourUtc === undefined ? undefined : normalizeBoundedInteger(body.runHourUtc, 0, 23)
+    const runMinuteUtc = body.runMinuteUtc === undefined ? undefined : normalizeBoundedInteger(body.runMinuteUtc, 0, 59)
+    const escalateOnCritical = body.escalateOnCritical === undefined ? undefined : body.escalateOnCritical === true
+
+    const schedule = updateOpenClawFleetDigestSchedule(db, {
+      enabled,
+      deliveryEmail,
+      escalationEmail,
+      runHourUtc: runHourUtc ?? undefined,
+      runMinuteUtc: runMinuteUtc ?? undefined,
+      escalateOnCritical,
+    })
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_fleet_digest.schedule_updated',
+      actor: auth.session.email,
+      target: 'openclaw-fleet:digest-schedule',
+      details: {
+        role: auth.session.role,
+        enabled: schedule.enabled === 1,
+        deliveryEmail: schedule.delivery_email,
+        escalationEmail: schedule.escalation_email,
+        runHourUtc: schedule.run_hour_utc,
+        runMinuteUtc: schedule.run_minute_utc,
+        escalateOnCritical: schedule.escalate_on_critical === 1,
+      },
+    })
+
+    const runs = listOpenClawFleetDigestRuns(db, 10)
+    const runsById = new Map(runs.map((run) => [run.id, run]))
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      schedule: serializeOpenClawFleetDigestSchedule(schedule, runsById),
+    })
+  })
+
+  router.post('/fleet/digest/run', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'operator')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const triggerKind: OpenClawFleetDigestRunTriggerKind = body.triggerKind === 'scheduled' ? 'scheduled' : 'manual'
+    const deliver = body.deliver === true
+    const respectSchedule = body.respectSchedule === true
+    const schedule = getOpenClawFleetDigestSchedule(db)
+    if (triggerKind === 'scheduled' && respectSchedule) {
+      const dueState = isOpenClawFleetDigestDue(schedule)
+      if (!dueState.due) {
+        c.header('Cache-Control', 'no-store')
+        return c.json({
+          ok: true,
+          skipped: true,
+          reason: schedule.enabled ? 'not_due' : 'disabled',
+          schedule: serializeOpenClawFleetDigestSchedule(schedule, new Map(listOpenClawFleetDigestRuns(db, 10).map((run) => [run.id, run]))),
+          nextRunAt: dueState.nextRunAt,
+        })
+      }
+
+      const { digest, run } = buildPersistedOpenClawFleetDigestRun(db, new URL(c.req.url).origin, {
+        triggerKind,
+        actor: auth.session.email,
+        scheduledForAt: dueState.scheduledForAt,
+      })
+
+      const deliveries: Array<{
+        ok: boolean
+        status: OpenClawFleetDigestDeliveryStatus
+        errorCode: string | null
+        errorMessage: string | null
+        delivery: SerializedOpenClawFleetDigestDelivery
+      }> = []
+
+      if (deliver) {
+        if (schedule.delivery_email) {
+          const digestDelivery = await deliverOpenClawFleetDigestRun(db, run, {
+            actor: auth.session.email,
+            recipientEmail: schedule.delivery_email,
+            deliveryKind: 'digest',
+          })
+          deliveries.push({
+            ...digestDelivery,
+            delivery: serializeOpenClawFleetDigestDelivery(digestDelivery.delivery, new Map([[run.id, run]])),
+          })
+        } else {
+          const missingDigestDelivery = recordOpenClawFleetDigestDelivery(db, {
+            runId: run.id,
+            deliveryKind: 'digest',
+            recipientEmail: 'unconfigured',
+            status: 'skipped',
+            errorCode: 'NO_DIGEST_RECIPIENT',
+            errorMessage: 'No default fleet digest recipient is configured.',
+            detailsJson: JSON.stringify({ actor: auth.session.email }),
+          })
+          deliveries.push({
+            ok: false,
+            status: 'skipped',
+            errorCode: 'NO_DIGEST_RECIPIENT',
+            errorMessage: 'No default fleet digest recipient is configured.',
+            delivery: serializeOpenClawFleetDigestDelivery(missingDigestDelivery, new Map([[run.id, run]])),
+          })
+        }
+
+        if (schedule.escalate_on_critical === 1 && digest.escalations.length > 0) {
+          if (schedule.escalation_email) {
+            const escalationDelivery = await deliverOpenClawFleetDigestRun(db, run, {
+              actor: auth.session.email,
+              recipientEmail: schedule.escalation_email,
+              deliveryKind: 'escalation',
+            })
+            deliveries.push({
+              ...escalationDelivery,
+              delivery: serializeOpenClawFleetDigestDelivery(escalationDelivery.delivery, new Map([[run.id, run]])),
+            })
+          } else {
+            const missingEscalationDelivery = recordOpenClawFleetDigestDelivery(db, {
+              runId: run.id,
+              deliveryKind: 'escalation',
+              recipientEmail: 'unconfigured',
+              status: 'skipped',
+              errorCode: 'NO_ESCALATION_RECIPIENT',
+              errorMessage: 'No escalation recipient is configured for the fleet digest.',
+              detailsJson: JSON.stringify({ actor: auth.session.email }),
+            })
+            deliveries.push({
+              ok: false,
+              status: 'skipped',
+              errorCode: 'NO_ESCALATION_RECIPIENT',
+              errorMessage: 'No escalation recipient is configured for the fleet digest.',
+              delivery: serializeOpenClawFleetDigestDelivery(missingEscalationDelivery, new Map([[run.id, run]])),
+            })
+          }
+        }
+      }
+
+      logAuditEvent(db, {
+        action: 'admin.openclaw_fleet_digest.run',
+        actor: auth.session.email,
+        target: 'openclaw-fleet:digest',
+        details: {
+          role: auth.session.role,
+          triggerKind,
+          deliver,
+          scheduledForAt: dueState.scheduledForAt,
+          runId: run.id,
+          deliveryCount: deliveries.length,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        skipped: false,
+        run: serializeOpenClawFleetDigestRun(getOpenClawFleetDigestRunById(db, run.id) as OpenClawFleetDigestRunRow),
+        digest: buildOpenClawFleetDigestEnvelope(db, new URL(c.req.url).origin),
+        deliveries,
+      })
+    }
+
+    const { digest, run } = buildPersistedOpenClawFleetDigestRun(db, new URL(c.req.url).origin, {
+      triggerKind,
+      actor: auth.session.email,
+    })
+    const deliveries: Array<{
+      ok: boolean
+      status: OpenClawFleetDigestDeliveryStatus
+      errorCode: string | null
+      errorMessage: string | null
+      delivery: SerializedOpenClawFleetDigestDelivery
+    }> = []
+    if (deliver) {
+      const schedule = getOpenClawFleetDigestSchedule(db)
+      const targetEmail = schedule.delivery_email ?? auth.session.email
+      const digestDelivery = await deliverOpenClawFleetDigestRun(db, run, {
+        actor: auth.session.email,
+        recipientEmail: targetEmail,
+        deliveryKind: 'digest',
+      })
+      deliveries.push({
+        ...digestDelivery,
+        delivery: serializeOpenClawFleetDigestDelivery(digestDelivery.delivery, new Map([[run.id, run]])),
+      })
+      if (schedule.escalate_on_critical === 1 && digest.escalations.length > 0 && schedule.escalation_email) {
+        const escalationDelivery = await deliverOpenClawFleetDigestRun(db, run, {
+          actor: auth.session.email,
+          recipientEmail: schedule.escalation_email,
+          deliveryKind: 'escalation',
+        })
+        deliveries.push({
+          ...escalationDelivery,
+          delivery: serializeOpenClawFleetDigestDelivery(escalationDelivery.delivery, new Map([[run.id, run]])),
+        })
+      }
+    }
+    logAuditEvent(db, {
+      action: 'admin.openclaw_fleet_digest.run',
+      actor: auth.session.email,
+      target: 'openclaw-fleet:digest',
+      details: {
+        role: auth.session.role,
+        triggerKind,
+        deliver,
+        runId: run.id,
+        deliveryCount: deliveries.length,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ok: true,
+      skipped: false,
+      run: serializeOpenClawFleetDigestRun(getOpenClawFleetDigestRunById(db, run.id) as OpenClawFleetDigestRunRow),
+      digest: buildOpenClawFleetDigestEnvelope(db, new URL(c.req.url).origin),
+      deliveries,
+    })
   })
 
   router.post('/fleet/digest/deliver', async (c) => {
@@ -1750,40 +2363,56 @@ export function openClawAdminRouter(db: Database) {
       return c.json({ error: 'Only admins can deliver digests to a different mailbox', errorCode: 'FORBIDDEN' }, 403)
     }
 
-    if (!isEmailDeliveryConfigured()) {
-      return c.json({ error: 'Email delivery is not configured for fleet digests', errorCode: 'EMAIL_DELIVERY_UNAVAILABLE' }, 503)
+    const deliveryKind: OpenClawFleetDigestDeliveryKind = body.kind === 'escalation' ? 'escalation' : 'digest'
+    const runId = normalizePositiveInteger(body.runId)
+    const run = runId
+      ? getOpenClawFleetDigestRunById(db, runId)
+      : buildPersistedOpenClawFleetDigestRun(db, new URL(c.req.url).origin, {
+          triggerKind: 'manual',
+          actor: auth.session.email,
+        }).run
+
+    if (!run) {
+      return c.json({ error: 'Digest run not found', errorCode: 'NOT_FOUND' }, 404)
     }
 
-    const digest = buildOpenClawFleetDigest(db, new URL(c.req.url).origin)
     const email = requestedEmail ?? auth.session.email
-    const delivered = await sendOperatorDigestEmail({
-      email,
-      subject: `Beam OpenClaw fleet digest · ${new Date().toISOString().slice(0, 10)}`,
-      markdown: digest.markdown,
+    const result = await deliverOpenClawFleetDigestRun(db, run, {
+      actor: auth.session.email,
+      recipientEmail: email,
+      deliveryKind,
     })
 
-    if (!delivered) {
-      return c.json({ error: 'Failed to deliver fleet digest', errorCode: 'EMAIL_DELIVERY_FAILED' }, 500)
-    }
-
     logAuditEvent(db, {
-      action: 'admin.openclaw_fleet_digest.delivered',
+      action: result.ok ? 'admin.openclaw_fleet_digest.delivered' : 'admin.openclaw_fleet_digest.delivery_failed',
       actor: auth.session.email,
       target: 'openclaw-fleet:digest',
       details: {
         role: auth.session.role,
         email,
-        actionItems: digest.summary.actionItems,
-        criticalItems: digest.summary.criticalItems,
+        deliveryKind,
+        runId: run.id,
+        status: result.status,
+        errorCode: result.errorCode,
       },
     })
+
+    if (!result.ok) {
+      const statusCode = result.status === 'unavailable' ? 503 : 500
+      return c.json({
+        error: result.errorMessage ?? 'Failed to deliver fleet digest',
+        errorCode: result.errorCode ?? 'EMAIL_DELIVERY_FAILED',
+        runId: run.id,
+      }, statusCode)
+    }
 
     c.header('Cache-Control', 'no-store')
     return c.json({
       ok: true,
       email,
-      deliveredAt: new Date().toISOString(),
-      summary: digest.summary,
+      kind: deliveryKind,
+      deliveredAt: result.delivery.delivered_at,
+      summary: parseJson<Record<string, unknown>>(run.summary_json, {}) as BuiltOpenClawFleetDigest['summary'],
     })
   })
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -182,6 +182,10 @@ export type OpenClawRouteSource = 'agent-folder' | 'workspace-agent' | 'gateway-
 export type OpenClawRouteReportedState = 'live' | 'idle' | 'ended'
 export type OpenClawRouteRuntimeState = 'live' | 'idle' | 'stale' | 'ended' | 'conflict' | 'revoked'
 export type OpenClawRouteOwnerResolutionState = 'implicit' | 'preferred' | 'disabled'
+export type OpenClawFleetDigestRunTriggerKind = 'manual' | 'scheduled'
+export type OpenClawFleetDigestDeliveryKind = 'digest' | 'escalation'
+export type OpenClawFleetDigestDeliveryStatus = 'delivered' | 'failed' | 'unavailable' | 'skipped'
+export type OpenClawFleetDigestRunDeliveryState = 'pending' | 'delivered' | 'partial' | 'failed' | 'unavailable'
 
 export interface WorkspaceRow {
   id: number
@@ -358,6 +362,48 @@ export interface OpenClawHostHeartbeatRow {
   health_status: OpenClawHostHealth
   details_json: string | null
   heartbeat_at: string
+}
+
+export interface OpenClawFleetDigestScheduleRow {
+  id: number
+  enabled: number
+  delivery_email: string | null
+  escalation_email: string | null
+  run_hour_utc: number
+  run_minute_utc: number
+  escalate_on_critical: number
+  last_scheduled_for_at: string | null
+  last_run_id: number | null
+  last_delivery_at: string | null
+  last_escalation_delivery_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface OpenClawFleetDigestRunRow {
+  id: number
+  trigger_kind: OpenClawFleetDigestRunTriggerKind
+  actor: string | null
+  generated_at: string
+  summary_json: string
+  action_items_json: string
+  escalation_items_json: string
+  markdown: string
+  delivery_state: OpenClawFleetDigestRunDeliveryState
+  last_delivery_error_code: string | null
+  created_at: string
+}
+
+export interface OpenClawFleetDigestDeliveryRow {
+  id: number
+  run_id: number | null
+  delivery_kind: OpenClawFleetDigestDeliveryKind
+  recipient_email: string
+  status: OpenClawFleetDigestDeliveryStatus
+  error_code: string | null
+  error_message: string | null
+  delivered_at: string
+  details_json: string | null
 }
 
 export interface WorkspacePolicyRow {

--- a/scripts/workspace/fleet-digest-tick.mjs
+++ b/scripts/workspace/fleet-digest-tick.mjs
@@ -1,0 +1,48 @@
+import { optionalFlag, createAdminHeaders, createAdminToken, requestJson } from '../production/shared.mjs'
+
+async function main() {
+  const directoryUrl = optionalFlag('--directory-url', process.env['BEAM_DIRECTORY_URL'] ?? 'http://localhost:43100')
+  const adminEmail = optionalFlag('--email', 'ops@beam.local')
+  const providedToken = optionalFlag('--token', process.env['BEAM_ADMIN_TOKEN'] ?? null)
+  const deliver = optionalFlag('--deliver', 'true') !== 'false'
+  const respectSchedule = optionalFlag('--respect-schedule', 'true') !== 'false'
+  const token = providedToken ?? await createAdminToken(directoryUrl, adminEmail)
+
+  const response = await requestJson(`${directoryUrl}/admin/openclaw/fleet/digest/run`, {
+    method: 'POST',
+    headers: createAdminHeaders(token),
+    body: JSON.stringify({
+      triggerKind: 'scheduled',
+      deliver,
+      respectSchedule,
+    }),
+  })
+
+  console.log(JSON.stringify({
+    ok: true,
+    directoryUrl,
+    deliver,
+    respectSchedule,
+    skipped: response.skipped,
+    reason: response.reason ?? null,
+    nextRunAt: response.nextRunAt ?? response.schedule?.nextRunAt ?? null,
+    run: response.run
+      ? {
+          id: response.run.id,
+          generatedAt: response.run.generatedAt,
+          deliveryState: response.run.deliveryState,
+        }
+      : null,
+    deliveries: response.deliveries?.map((entry) => ({
+      kind: entry.delivery.kind,
+      status: entry.status,
+      errorCode: entry.errorCode,
+      recipientEmail: entry.delivery.recipientEmail,
+    })) ?? [],
+  }, null, 2))
+}
+
+main().catch((error) => {
+  console.error('[workspace:fleet-digest:tick] failed:', error)
+  process.exitCode = 1
+})

--- a/scripts/workspace/fleet-digest.mjs
+++ b/scripts/workspace/fleet-digest.mjs
@@ -11,9 +11,24 @@ async function main() {
     await fleet.markHostStale('beta', 12)
     await fleet.rotateHost('beta')
     await fleet.createConflict()
+    const now = new Date()
+    await fleet.updateFleetDigestSchedule({
+      enabled: true,
+      deliveryEmail: 'ops@beam.local',
+      escalationEmail: 'critical@beam.local',
+      runHourUtc: now.getUTCHours(),
+      runMinuteUtc: now.getUTCMinutes(),
+      escalateOnCritical: true,
+    })
 
     const digest = await fleet.fetchFleetDigest()
     const markdownExport = await fleet.fetchFleetDigest({ format: 'markdown' })
+    const scheduledRun = await fleet.runFleetDigest({
+      triggerKind: 'scheduled',
+      respectSchedule: true,
+      deliver: true,
+    })
+    const digestAfterRun = await fleet.fetchFleetDigest()
 
     if (digest.summary.staleHosts < 1) {
       throw new Error(`Expected at least one stale host, found ${digest.summary.staleHosts}`)
@@ -34,6 +49,24 @@ async function main() {
     }
     if (!markdownExport.includes('## Action Items')) {
       throw new Error('Expected the fleet digest markdown export to include the action item section.')
+    }
+    if (scheduledRun.skipped) {
+      throw new Error(`Expected the scheduled fleet digest to run, but it was skipped with reason ${scheduledRun.reason ?? 'unknown'}.`)
+    }
+    if (!scheduledRun.run) {
+      throw new Error('Expected the scheduled fleet digest run response to include a persisted run.')
+    }
+    if (digestAfterRun.history.runs.length < 1) {
+      throw new Error('Expected the fleet digest history to contain at least one run.')
+    }
+    if (digestAfterRun.history.deliveries.length < 2) {
+      throw new Error(`Expected the fleet digest history to contain at least two deliveries, found ${digestAfterRun.history.deliveries.length}.`)
+    }
+    if (!digestAfterRun.history.deliveries.some((delivery) => delivery.kind === 'digest')) {
+      throw new Error('Expected digest delivery history to include a digest delivery record.')
+    }
+    if (!digestAfterRun.history.deliveries.some((delivery) => delivery.kind === 'escalation')) {
+      throw new Error('Expected digest delivery history to include an escalation delivery record.')
     }
 
     let deliveryOutcome = {
@@ -61,6 +94,20 @@ async function main() {
       date: formatDate(),
       workspace: fleet.workspaceSlug,
       summary: digest.summary,
+      scheduledRun: {
+        id: scheduledRun.run.id,
+        deliveryState: scheduledRun.run.deliveryState,
+        deliveries: scheduledRun.deliveries?.map((delivery) => ({
+          kind: delivery.delivery.kind,
+          status: delivery.status,
+          errorCode: delivery.errorCode,
+        })) ?? [],
+      },
+      digestSchedule: digestAfterRun.schedule,
+      digestHistory: {
+        runs: digestAfterRun.history.runs.length,
+        deliveries: digestAfterRun.history.deliveries.length,
+      },
       leadingActions: digest.actionItems.slice(0, 4).map((item) => ({
         category: item.category,
         severity: item.severity,
@@ -88,7 +135,8 @@ async function main() {
 2. Rotate one host credential without applying the new credential yet.
 3. Inject one duplicate Beam identity conflict on a second host.
 4. Read the fleet digest and confirm that it turns all three states into explicit operator action items.
-5. Exercise the digest delivery path and verify the local harness reports the expected “delivery unavailable” state without SMTP configuration.
+5. Run the scheduled digest path and verify that Beam persists one run plus digest/escalation delivery history.
+6. Exercise the manual delivery path and verify the local harness reports the expected “delivery unavailable” state without SMTP configuration.
 
 ## Verification
 
@@ -97,6 +145,8 @@ async function main() {
 - Duplicate conflicts: \`${digest.summary.duplicateIdentityConflicts}\`
 - Action items: \`${digest.summary.actionItems}\`
 - Critical items: \`${digest.summary.criticalItems}\`
+- Scheduled runs: \`${digestAfterRun.history.runs.length}\`
+- Delivery history: \`${digestAfterRun.history.deliveries.length}\`
 - Delivery path: \`${deliveryOutcome.status}\`
 
 ## Evidence

--- a/scripts/workspace/fleet-shared.mjs
+++ b/scripts/workspace/fleet-shared.mjs
@@ -356,6 +356,20 @@ export async function startOpenClawFleetHarness() {
         headers: { Authorization: `Bearer ${token}` },
       })
     },
+    async updateFleetDigestSchedule(input) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/digest/schedule`, {
+        method: 'PATCH',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
+    async runFleetDigest(input = {}) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/digest/run`, {
+        method: 'POST',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
     async deliverFleetDigest(input = {}) {
       return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/digest/deliver`, {
         method: 'POST',


### PR DESCRIPTION
## Summary
- persist fleet digest schedules, run history, and delivery history in the directory
- add operator UI for schedule management, digest runs, escalations, and delivery history
- add repo-owned scheduled digest tick script, docs, and regression coverage

## Testing
- npm test --workspace=packages/directory
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build