### PR TITLE
Add fleet credential review and route health summaries

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -196,6 +196,9 @@ The fleet surface also gives operators explicit day-2 actions:
 - deliver a fleet digest that calls out stale hosts, pending credential work, duplicate conflicts, and missing receipts
 - configure one daily digest schedule with a separate escalation mailbox for critical fleet items
 - inspect persistent digest run history and delivery history directly in the fleet surface
+- work a dedicated credential review queue that highlights overdue rotations, open rotation windows, recovery ownership gaps, and post-recovery cleanup
+- complete recovery cleanup after a successful cutover so the host drops back into the normal credential review loop
+- inspect a route-health and SLO summary that rolls up missing receipts, failed receipts, latency buckets, and the exact hosts currently degrading fleet delivery
 - label hosts with environment and group metadata such as `prod`, `staging`, `lab`, `edge`, or team ownership
 - stage guarded bulk actions across multiple hosts before a real revoke, with an explicit confirm phrase
 - clear staged revoke reviews again when a maintenance plan changes
@@ -203,9 +206,9 @@ The fleet surface also gives operators explicit day-2 actions:
 The host detail and fleet summary now also expose the operational thresholds behind those actions:
 
 - credential rotation interval, next due time, and the next allowed rotation window
-- recovery owner, replacement host label, and cutover window notes
+- recovery owner, replacement host label, cutover window notes, and a cleanup-ready state after recovery completes
 - receipt coverage across active routes
-- p50 / p95 latency and latency SLO breaches for recent host-backed deliveries
+- p50 / p95 latency, SLO bucket counts, and direct links back to the host, workspace, and latest trace that caused the warning
 
 That means operators can treat the fleet page as the source of truth for both host health and the next required maintenance action, instead of jumping between traces and local host logs.
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -346,6 +346,8 @@ export interface OpenClawHostSummary {
       nextRotationWindowStartsAt: string | null
       nextRotationWindowEndsAt: string | null
       dueInHours: number | null
+      windowOpen: boolean
+      hoursUntilWindowStarts: number | null
       reviewState: OpenClawHostRotationReviewState
     }
     recovery: {
@@ -356,6 +358,7 @@ export interface OpenClawHostSummary {
       windowStartsAt: string | null
       windowEndsAt: string | null
       updatedAt: string | null
+      cleanupRecommended: boolean
     }
   }
   placement: {
@@ -493,6 +496,83 @@ export interface OpenClawFleetOverviewResponse {
     pendingCredentialActions: number
     actionItems: number
     criticalItems: number
+  }
+  credentialPolicy: {
+    counts: {
+      overdue: number
+      dueSoon: number
+      windowOpen: number
+      rotationPending: number
+      recoveryPrepared: number
+      recoveryCutover: number
+      recoveryCompleted: number
+      cleanupRecommended: number
+      missingRecoveryOwner: number
+    }
+    attentionHosts: Array<{
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      healthStatus: OpenClawHostHealth
+      credentialState: OpenClawHostCredentialState
+      credentialAgeHours: number | null
+      rotationReviewState: OpenClawHostRotationReviewState
+      nextRotationDueAt: string | null
+      nextRotationWindowStartsAt: string | null
+      nextRotationWindowEndsAt: string | null
+      dueInHours: number | null
+      windowOpen: boolean
+      recoveryStatus: OpenClawHostRecoveryRunbookState
+      recoveryOwner: string | null
+      cleanupRecommended: boolean
+      reasons: string[]
+      severity: 'warning' | 'critical'
+      href: string
+      workspaceHref: string | null
+    }>
+  }
+  routeHealth: {
+    summary: {
+      targetLatencyMs: number
+      activeRoutes: number
+      routesWithReceipts: number
+      routesMissingReceipts: number
+      receiptCoverageRatio: number | null
+      failedReceipts: number
+      degradedHosts: number
+      hostsWithMissingReceipts: number
+      hostsWithFailedReceipts: number
+    }
+    latency: {
+      samples: number
+      avgMs: number | null
+      p50Ms: number | null
+      p95Ms: number | null
+      overSlo: number
+      overDoubleSlo: number
+      buckets: {
+        withinTarget: number
+        overTarget: number
+        overDoubleTarget: number
+      }
+    }
+    attentionHosts: Array<{
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      healthStatus: OpenClawHostHealth
+      receiptCoverageRatio: number | null
+      missingReceipts: number
+      failedReceipts: number
+      activeRoutes: number
+      p95LatencyMs: number | null
+      overSlo: number
+      reasons: string[]
+      severity: 'warning' | 'critical'
+      href: string
+      workspaceHref: string | null
+      traceHref: string | null
+    }>
   }
   hosts: OpenClawHostSummary[]
   conflicts: OpenClawConflictGroup[]
@@ -738,6 +818,10 @@ export interface OpenClawHostPolicyPatchInput {
 }
 
 export interface OpenClawHostPolicyActionResponse {
+  host: OpenClawHostSummary
+}
+
+export interface OpenClawHostRecoveryCleanupResponse {
   host: OpenClawHostSummary
 }
 
@@ -2540,6 +2624,9 @@ export const directoryApi = {
     method: 'POST',
   }, { admin: true }),
   recoverOpenClawHost: (id: number) => request<OpenClawHostCredentialActionResponse>(`/admin/openclaw/hosts/${id}/recover`, {
+    method: 'POST',
+  }, { admin: true }),
+  completeOpenClawHostRecoveryCleanup: (id: number) => request<OpenClawHostRecoveryCleanupResponse>(`/admin/openclaw/hosts/${id}/recovery/cleanup`, {
     method: 'POST',
   }, { admin: true }),
   updateOpenClawHostPolicy: (id: number, input: OpenClawHostPolicyPatchInput) => request<OpenClawHostPolicyActionResponse>(`/admin/openclaw/hosts/${id}/policy`, {

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -509,6 +509,12 @@ export default function OpenClawFleetPage() {
     }
   }
 
+  function focusHost(hostId: number) {
+    const next = new URLSearchParams(searchParams)
+    next.set('host', String(hostId))
+    setSearchParams(next, { replace: true })
+  }
+
   function updateFleetQueryParam(key: 'environment' | 'group', value: string) {
     const next = new URLSearchParams(searchParams)
     if (!value || value === 'all') {
@@ -587,6 +593,14 @@ export default function OpenClawFleetPage() {
       await Promise.all([loadOverview(), loadDigest()])
       await loadHost(host.id)
     }, `Recovery credential for ${hostTitle(host)} issued.`)
+  }
+
+  async function handleCompleteRecoveryCleanup(host: OpenClawHostSummary) {
+    await runAction(`cleanup-${host.id}`, async () => {
+      await directoryApi.completeOpenClawHostRecoveryCleanup(host.id)
+      await Promise.all([loadOverview(), loadDigest()])
+      await loadHost(host.id)
+    }, `Recovery cleanup completed for ${hostTitle(host)}.`)
   }
 
   async function handleSavePlacement(host: OpenClawHostSummary) {
@@ -803,6 +817,177 @@ export default function OpenClawFleetPage() {
         <MetricCard label="Latency watch" value={!overview ? '—' : formatNumber(overview.summary.degradedHosts)} tone={(overview?.summary.degradedHosts ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Rotation due" value={!overview ? '—' : formatNumber(overview.summary.rotationDueHosts)} tone={(overview?.summary.rotationDueHosts ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Duplicate conflicts" value={!overview ? '—' : formatNumber(overview.summary.duplicateIdentityConflicts)} tone={(overview?.summary.duplicateIdentityConflicts ?? 0) > 0 ? 'critical' : 'default'} />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Credential review queue</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Hosts that need rotation attention, recovery ownership, or post-recovery cleanup before they fall out of the normal fleet loop.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.credentialPolicy.attentionHosts.length)} queued` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3 xl:grid-cols-5">
+            <MetricCard label="Overdue" value={!overview ? '—' : formatNumber(overview.credentialPolicy.counts.overdue)} tone={(overview?.credentialPolicy.counts.overdue ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Due soon" value={!overview ? '—' : formatNumber(overview.credentialPolicy.counts.dueSoon)} tone={(overview?.credentialPolicy.counts.dueSoon ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Window open" value={!overview ? '—' : formatNumber(overview.credentialPolicy.counts.windowOpen)} tone={(overview?.credentialPolicy.counts.windowOpen ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Cutovers open" value={!overview ? '—' : formatNumber(overview.credentialPolicy.counts.recoveryCutover)} tone={(overview?.credentialPolicy.counts.recoveryCutover ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Cleanup ready" value={!overview ? '—' : formatNumber(overview.credentialPolicy.counts.cleanupRecommended)} tone={(overview?.credentialPolicy.counts.cleanupRecommended ?? 0) > 0 ? 'warning' : 'default'} />
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.credentialPolicy.attentionHosts.length > 0 ? (
+              overview.credentialPolicy.attentionHosts.map((item) => {
+                const host = overview.hosts.find((candidate) => candidate.id === item.hostId) ?? null
+                return (
+                  <div key={`credential-review-${item.hostId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.hostLabel || `Host ${item.hostId}`}</div>
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                          {item.reasons.join(' · ')}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <StatusPill label={item.severity} tone={item.severity === 'critical' ? 'critical' : 'warning'} />
+                        <StatusPill label={item.rotationReviewState} tone={item.rotationReviewState === 'overdue' ? 'critical' : item.rotationReviewState === 'due_soon' ? 'warning' : 'default'} />
+                        <StatusPill label={item.recoveryStatus} tone={item.recoveryStatus === 'cutover_pending' ? 'critical' : item.recoveryStatus === 'prepared' ? 'warning' : item.recoveryStatus === 'completed' ? 'success' : 'default'} />
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                      <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace default'}</div>
+                      <div>{item.credentialAgeHours === null ? 'No credential age recorded' : `Credential age ${formatNumber(item.credentialAgeHours)}h`}</div>
+                      <div>{item.nextRotationDueAt ? `Rotation due ${formatDateTime(item.nextRotationDueAt)}` : 'No rotation due timestamp'}</div>
+                      <div>{item.windowOpen ? 'Rotation window is open now' : item.nextRotationWindowStartsAt ? `Window opens ${formatDateTime(item.nextRotationWindowStartsAt)}` : 'No rotation window yet'}</div>
+                      <div>{item.recoveryOwner ? `Recovery owner ${item.recoveryOwner}` : 'No recovery owner assigned'}</div>
+                      <div>{item.cleanupRecommended ? 'Recovery cleanup is ready' : 'No cleanup action pending'}</div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        onClick={() => focusHost(item.hostId)}
+                      >
+                        Open host
+                      </button>
+                      {host?.status === 'active' ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={actionBusy === `rotate-${host.id}`}
+                          onClick={() => { void handleRotate(host) }}
+                        >
+                          {actionBusy === `rotate-${host.id}` ? 'Rotating…' : 'Rotate credential'}
+                        </button>
+                      ) : null}
+                      {host && (host.status === 'revoked' || host.healthStatus === 'stale' || item.recoveryStatus === 'cutover_pending') ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={actionBusy === `recover-${host.id}`}
+                          onClick={() => { void handleRecover(host) }}
+                        >
+                          {actionBusy === `recover-${host.id}` ? 'Recovering…' : 'Recover host'}
+                        </button>
+                      ) : null}
+                      {host && item.cleanupRecommended ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={actionBusy === `cleanup-${host.id}`}
+                          onClick={() => { void handleCompleteRecoveryCleanup(host) }}
+                        >
+                          {actionBusy === `cleanup-${host.id}` ? 'Cleaning…' : 'Complete cleanup'}
+                        </button>
+                      ) : null}
+                    </div>
+                  </div>
+                )
+              })
+            ) : (
+              <EmptyPanel label="No hosts are waiting in the credential review queue." />
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Route health and SLO</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Fleet-wide receipt coverage, latency buckets, and the hosts currently driving degraded route health.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.routeHealth.attentionHosts.length)} hosts need review` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <MetricCard label="Coverage" value={!overview ? '—' : formatPercent(overview.routeHealth.summary.receiptCoverageRatio)} tone={(overview?.routeHealth.summary.receiptCoverageRatio ?? 1) < 0.8 ? 'warning' : 'success'} />
+            <MetricCard label="Missing receipts" value={!overview ? '—' : formatNumber(overview.routeHealth.summary.routesMissingReceipts)} tone={(overview?.routeHealth.summary.routesMissingReceipts ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Failed receipts" value={!overview ? '—' : formatNumber(overview.routeHealth.summary.failedReceipts)} tone={(overview?.routeHealth.summary.failedReceipts ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="p95 latency" value={!overview ? '—' : formatLatency(overview.routeHealth.latency.p95Ms)} tone={(overview?.routeHealth.latency.overSlo ?? 0) > 0 ? 'warning' : 'success'} />
+          </div>
+
+          <div className="mt-4 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2 xl:grid-cols-3">
+            <div>{overview ? `${formatNumber(overview.routeHealth.summary.activeRoutes)} active routes · ${formatNumber(overview.routeHealth.summary.routesWithReceipts)} with receipts` : '—'}</div>
+            <div>{overview ? `${formatNumber(overview.routeHealth.summary.hostsWithMissingReceipts)} hosts missing receipts · ${formatNumber(overview.routeHealth.summary.hostsWithFailedReceipts)} hosts failing` : '—'}</div>
+            <div>{overview ? `${formatNumber(overview.routeHealth.latency.buckets.withinTarget)} within target · ${formatNumber(overview.routeHealth.latency.buckets.overTarget)} over target · ${formatNumber(overview.routeHealth.latency.buckets.overDoubleTarget)} over 2x` : '—'}</div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.routeHealth.attentionHosts.length > 0 ? (
+              overview.routeHealth.attentionHosts.map((item) => (
+                <div key={`route-health-${item.hostId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.hostLabel || `Host ${item.hostId}`}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.reasons.join(' · ')}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <StatusPill label={item.severity} tone={item.severity === 'critical' ? 'critical' : 'warning'} />
+                      <StatusPill label={item.healthStatus} tone={hostHealthTone(item.healthStatus)} />
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                    <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace default'}</div>
+                    <div>{`${formatNumber(item.activeRoutes)} active · ${formatNumber(item.missingReceipts)} missing · ${formatNumber(item.failedReceipts)} failed`}</div>
+                    <div>{`Receipt coverage ${formatPercent(item.receiptCoverageRatio)}`}</div>
+                    <div>{`p95 ${formatLatency(item.p95LatencyMs)} · ${formatNumber(item.overSlo)} over target`}</div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => focusHost(item.hostId)}
+                    >
+                      Open host
+                    </button>
+                    {item.workspaceHref && item.workspaceSlug ? (
+                      <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.workspaceHref}>
+                        Open workspace
+                      </Link>
+                    ) : null}
+                    {item.traceHref ? (
+                      <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.traceHref}>
+                        Open trace
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyPanel label="No hosts are currently breaching route-health review thresholds." />
+            )}
+          </div>
+        </div>
       </section>
 
       <section className="panel">
@@ -1459,6 +1644,12 @@ export default function OpenClawFleetPage() {
                       {host.placement.revokeReviewRequestedAt ? (
                         <StatusPill label="revoke review" tone="warning" />
                       ) : null}
+                      {host.policy.rotation.windowOpen ? (
+                        <StatusPill label="rotation window open" tone="warning" />
+                      ) : null}
+                      {host.policy.recovery.cleanupRecommended ? (
+                        <StatusPill label="recovery cleanup" tone="warning" />
+                      ) : null}
                     </div>
 
                     <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
@@ -1473,6 +1664,7 @@ export default function OpenClawFleetPage() {
                       <div>{host.policy.rotation.nextRotationDueAt ? `Rotation ${host.policy.rotation.reviewState === 'overdue' ? 'overdue' : 'due'} ${formatRelativeTime(host.policy.rotation.nextRotationDueAt)}` : 'No rotation schedule yet'}</div>
                       <div>{host.summary.delivery.latency.samples > 0 ? `p95 ${formatLatency(host.summary.delivery.latency.p95Ms)} · ${formatNumber(host.summary.delivery.latency.overSlo)} breach` : 'No latency samples yet'}</div>
                       <div>{host.policy.recovery.status !== 'idle' ? `Recovery ${host.policy.recovery.status}${host.policy.recovery.owner ? ` · ${host.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
+                      <div>{host.policy.recovery.cleanupRecommended ? 'Recovery cleanup ready' : 'No recovery cleanup pending'}</div>
                     </div>
 
                     <div className="mt-3 flex flex-wrap gap-2">
@@ -1526,6 +1718,19 @@ export default function OpenClawFleetPage() {
                           }}
                         >
                           {actionBusy === `recover-${host.id}` ? 'Recovering…' : 'Recover host'}
+                        </button>
+                      ) : null}
+                      {host.policy.recovery.cleanupRecommended ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={actionBusy === `cleanup-${host.id}`}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            void handleCompleteRecoveryCleanup(host)
+                          }}
+                        >
+                          {actionBusy === `cleanup-${host.id}` ? 'Cleaning…' : 'Complete cleanup'}
                         </button>
                       ) : null}
                     </div>
@@ -2005,8 +2210,9 @@ export default function OpenClawFleetPage() {
                   <div>{selectedHost.summary.delivery.lastRequestedAt ? `Last receipt ${formatRelativeTime(selectedHost.summary.delivery.lastRequestedAt)} · ${selectedHost.summary.delivery.lastStatus ?? 'unknown'}` : 'No delivery receipts yet'}</div>
                   <div>{`Receipt coverage ${formatPercent(selectedHost.summary.delivery.coverage.ratio)} · ${formatNumber(selectedHost.summary.delivery.coverage.missingReceipts)} missing`}</div>
                   <div>{selectedHost.summary.delivery.latency.samples > 0 ? `Latency avg ${formatLatency(selectedHost.summary.delivery.latency.avgMs)} · p95 ${formatLatency(selectedHost.summary.delivery.latency.p95Ms)}` : 'No latency samples yet'}</div>
-                  <div>{selectedHost.policy.rotation.nextRotationWindowStartsAt ? `Rotation window ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowStartsAt)}` : 'No rotation window scheduled'}</div>
+                  <div>{selectedHost.policy.rotation.windowOpen ? 'Rotation window is open now' : selectedHost.policy.rotation.nextRotationWindowStartsAt ? `Rotation window ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowStartsAt)}` : 'No rotation window scheduled'}</div>
                   <div>{selectedHost.policy.recovery.status !== 'idle' ? `Recovery ${selectedHost.policy.recovery.status}${selectedHost.policy.recovery.owner ? ` · ${selectedHost.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
+                  <div>{selectedHost.policy.recovery.cleanupRecommended ? 'Recovery cleanup ready' : 'No recovery cleanup pending'}</div>
                 </div>
               </div>
 
@@ -2201,8 +2407,10 @@ export default function OpenClawFleetPage() {
                 <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
                   <div>{selectedHost.policy.rotation.nextRotationDueAt ? `Next rotation due ${formatDateTime(selectedHost.policy.rotation.nextRotationDueAt)}` : 'No next rotation due yet'}</div>
                   <div>{selectedHost.policy.rotation.nextRotationWindowEndsAt ? `Window ends ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowEndsAt)}` : 'No rotation window end yet'}</div>
+                  <div>{selectedHost.policy.rotation.windowOpen ? 'Rotation window is open now' : selectedHost.policy.rotation.hoursUntilWindowStarts !== null ? `Window opens in ${formatNumber(selectedHost.policy.rotation.hoursUntilWindowStarts)}h` : 'No rotation window queued'}</div>
                   <div>{selectedHost.policy.recovery.windowStartsAt ? `Recovery window starts ${formatDateTime(selectedHost.policy.recovery.windowStartsAt)}` : 'No recovery window start yet'}</div>
                   <div>{selectedHost.policy.recovery.windowEndsAt ? `Recovery window ends ${formatDateTime(selectedHost.policy.recovery.windowEndsAt)}` : 'No recovery window end yet'}</div>
+                  <div>{selectedHost.policy.recovery.cleanupRecommended ? 'Post-recovery cleanup is ready' : 'No post-recovery cleanup needed'}</div>
                 </div>
 
                 <div className="mt-3 flex flex-wrap gap-2">
@@ -2214,6 +2422,16 @@ export default function OpenClawFleetPage() {
                   >
                     {actionBusy === `policy-${selectedHost.id}` ? 'Saving…' : 'Save policy'}
                   </button>
+                  {selectedHost.policy.recovery.cleanupRecommended ? (
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      disabled={actionBusy === `cleanup-${selectedHost.id}`}
+                      onClick={() => { void handleCompleteRecoveryCleanup(selectedHost) }}
+                    >
+                      {actionBusy === `cleanup-${selectedHost.id}` ? 'Cleaning…' : 'Complete recovery cleanup'}
+                    </button>
+                  ) : null}
                 </div>
               </div>
 

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -692,6 +692,7 @@ test('openclaw host policy patch surfaces rotation windows and recovery runbook 
             windowDurationHours: number
             reviewState: string
             nextRotationDueAt: string | null
+            windowOpen: boolean
           }
           recovery: {
             owner: string | null
@@ -700,6 +701,7 @@ test('openclaw host policy patch surfaces rotation windows and recovery runbook 
             replacementHostLabel: string | null
             windowStartsAt: string | null
             windowEndsAt: string | null
+            cleanupRecommended: boolean
           }
         }
       }
@@ -709,12 +711,44 @@ test('openclaw host policy patch surfaces rotation windows and recovery runbook 
     assert.equal(policyBody.host.policy.rotation.windowDurationHours, 2)
     assert.equal(policyBody.host.policy.rotation.reviewState, 'overdue')
     assert.ok(policyBody.host.policy.rotation.nextRotationDueAt)
+    assert.equal(typeof policyBody.host.policy.rotation.windowOpen, 'boolean')
     assert.equal(policyBody.host.policy.recovery.owner, 'ops@example.com')
     assert.equal(policyBody.host.policy.recovery.status, 'prepared')
     assert.equal(policyBody.host.policy.recovery.notes, 'Replace chassis during the next window')
     assert.equal(policyBody.host.policy.recovery.replacementHostLabel, 'policy-replacement')
     assert.equal(policyBody.host.policy.recovery.windowStartsAt, '2026-04-02T08:00:00.000Z')
     assert.equal(policyBody.host.policy.recovery.windowEndsAt, '2026-04-02T10:00:00.000Z')
+    assert.equal(policyBody.host.policy.recovery.cleanupRecommended, false)
+
+    const overviewResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewResponse.status, 200)
+    const overviewBody = await overviewResponse.json() as {
+      credentialPolicy: {
+        counts: {
+          overdue: number
+          dueSoon: number
+          recoveryPrepared: number
+          cleanupRecommended: number
+          missingRecoveryOwner: number
+        }
+        attentionHosts: Array<{
+          hostId: number
+          recoveryStatus: string
+          reasons: string[]
+        }>
+      }
+    }
+    assert.equal(overviewBody.credentialPolicy.counts.overdue, 1)
+    assert.equal(overviewBody.credentialPolicy.counts.dueSoon, 0)
+    assert.equal(overviewBody.credentialPolicy.counts.recoveryPrepared, 1)
+    assert.equal(overviewBody.credentialPolicy.counts.cleanupRecommended, 0)
+    assert.equal(overviewBody.credentialPolicy.counts.missingRecoveryOwner, 0)
+    assert.equal(overviewBody.credentialPolicy.attentionHosts[0]?.hostId, host.host.id)
+    assert.equal(overviewBody.credentialPolicy.attentionHosts[0]?.recoveryStatus, 'prepared')
+    assert.ok(overviewBody.credentialPolicy.attentionHosts[0]?.reasons.includes('credential rotation overdue'))
+    assert.ok(overviewBody.credentialPolicy.attentionHosts[0]?.reasons.includes('recovery runbook prepared'))
 
     const digestResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/digest', {
       headers: createAdminHeaders(db, 'ops@example.com', 'operator'),
@@ -734,6 +768,52 @@ test('openclaw host policy patch surfaces rotation windows and recovery runbook 
     assert.equal(digestBody.summary.recoveryRunbooksOpen, 1)
     assert.ok(digestBody.actionItems.some((item) => item.title.includes('due for credential rotation')))
     assert.ok(digestBody.actionItems.some((item) => item.detail.includes('policy-replacement')))
+
+    updateOpenClawHost(db, {
+      id: host.host.id,
+      recoveryCompletedAt: new Date().toISOString(),
+    })
+
+    const completedHostResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}`, {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(completedHostResponse.status, 200)
+    const completedHostBody = await completedHostResponse.json() as {
+      host: {
+        policy: {
+          recovery: {
+            status: string
+            cleanupRecommended: boolean
+          }
+        }
+      }
+    }
+    assert.equal(completedHostBody.host.policy.recovery.status, 'completed')
+    assert.equal(completedHostBody.host.policy.recovery.cleanupRecommended, true)
+
+    const cleanupResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}/recovery/cleanup`, {
+      method: 'POST',
+      headers: createAdminHeaders(db, 'admin@example.com', 'admin'),
+    }))
+    assert.equal(cleanupResponse.status, 200)
+    const cleanupBody = await cleanupResponse.json() as {
+      host: {
+        policy: {
+          recovery: {
+            owner: string | null
+            status: string
+            notes: string | null
+            replacementHostLabel: string | null
+            cleanupRecommended: boolean
+          }
+        }
+      }
+    }
+    assert.equal(cleanupBody.host.policy.recovery.owner, 'ops@example.com')
+    assert.equal(cleanupBody.host.policy.recovery.status, 'idle')
+    assert.equal(cleanupBody.host.policy.recovery.notes, null)
+    assert.equal(cleanupBody.host.policy.recovery.replacementHostLabel, null)
+    assert.equal(cleanupBody.host.policy.recovery.cleanupRecommended, false)
   } finally {
     db.close()
   }
@@ -1348,11 +1428,66 @@ test('openclaw fleet overview surfaces receipt coverage and latency summaries', 
         degradedHosts: number
         latencySloBreaches: number
       }
+      routeHealth: {
+        summary: {
+          targetLatencyMs: number
+          activeRoutes: number
+          routesWithReceipts: number
+          routesMissingReceipts: number
+          receiptCoverageRatio: number | null
+          failedReceipts: number
+          degradedHosts: number
+          hostsWithMissingReceipts: number
+          hostsWithFailedReceipts: number
+        }
+        latency: {
+          samples: number
+          avgMs: number | null
+          p50Ms: number | null
+          p95Ms: number | null
+          overSlo: number
+          overDoubleSlo: number
+          buckets: {
+            withinTarget: number
+            overTarget: number
+            overDoubleTarget: number
+          }
+        }
+        attentionHosts: Array<{
+          hostId: number
+          traceHref: string | null
+          workspaceHref: string | null
+          reasons: string[]
+        }>
+      }
     }
     assert.equal(overviewBody.summary.routesMissingReceipts, 1)
     assert.equal(overviewBody.summary.receiptCoverageRatio, 0.5)
     assert.equal(overviewBody.summary.degradedHosts, 1)
     assert.equal(overviewBody.summary.latencySloBreaches, 1)
+    assert.equal(overviewBody.routeHealth.summary.targetLatencyMs, 5000)
+    assert.equal(overviewBody.routeHealth.summary.activeRoutes, 2)
+    assert.equal(overviewBody.routeHealth.summary.routesWithReceipts, 1)
+    assert.equal(overviewBody.routeHealth.summary.routesMissingReceipts, 1)
+    assert.equal(overviewBody.routeHealth.summary.receiptCoverageRatio, 0.5)
+    assert.equal(overviewBody.routeHealth.summary.failedReceipts, 0)
+    assert.equal(overviewBody.routeHealth.summary.degradedHosts, 1)
+    assert.equal(overviewBody.routeHealth.summary.hostsWithMissingReceipts, 1)
+    assert.equal(overviewBody.routeHealth.summary.hostsWithFailedReceipts, 0)
+    assert.equal(overviewBody.routeHealth.latency.samples, 3)
+    assert.equal(overviewBody.routeHealth.latency.avgMs, 4400)
+    assert.equal(overviewBody.routeHealth.latency.p50Ms, 4200)
+    assert.equal(overviewBody.routeHealth.latency.p95Ms, 7200)
+    assert.equal(overviewBody.routeHealth.latency.overSlo, 1)
+    assert.equal(overviewBody.routeHealth.latency.overDoubleSlo, 0)
+    assert.equal(overviewBody.routeHealth.latency.buckets.withinTarget, 2)
+    assert.equal(overviewBody.routeHealth.latency.buckets.overTarget, 1)
+    assert.equal(overviewBody.routeHealth.latency.buckets.overDoubleTarget, 0)
+    assert.equal(overviewBody.routeHealth.attentionHosts[0]?.hostId, host.host.id)
+    assert.equal(overviewBody.routeHealth.attentionHosts[0]?.workspaceHref, '/workspaces?workspace=openclaw-local')
+    assert.ok(overviewBody.routeHealth.attentionHosts[0]?.traceHref?.startsWith('/intents/'))
+    assert.ok(overviewBody.routeHealth.attentionHosts[0]?.reasons.includes('missing receipts'))
+    assert.ok(overviewBody.routeHealth.attentionHosts[0]?.reasons.includes('latency above target'))
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -195,6 +195,89 @@ type OpenClawHostGroupSummary = {
   hostIds: number[]
 }
 
+type OpenClawFleetCredentialPolicyAttentionHost = {
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  healthStatus: OpenClawHostHealth
+  credentialState: OpenClawHostCredentialState
+  credentialAgeHours: number | null
+  rotationReviewState: OpenClawHostRotationReviewState
+  nextRotationDueAt: string | null
+  nextRotationWindowStartsAt: string | null
+  nextRotationWindowEndsAt: string | null
+  dueInHours: number | null
+  windowOpen: boolean
+  recoveryStatus: OpenClawHostRecoveryRunbookState
+  recoveryOwner: string | null
+  cleanupRecommended: boolean
+  reasons: string[]
+  severity: OpenClawFleetDigestSeverity
+  href: string
+  workspaceHref: string | null
+}
+
+type OpenClawFleetCredentialPolicySummary = {
+  counts: {
+    overdue: number
+    dueSoon: number
+    windowOpen: number
+    rotationPending: number
+    recoveryPrepared: number
+    recoveryCutover: number
+    recoveryCompleted: number
+    cleanupRecommended: number
+    missingRecoveryOwner: number
+  }
+  attentionHosts: OpenClawFleetCredentialPolicyAttentionHost[]
+}
+
+type OpenClawFleetRouteHealthAttentionHost = {
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  healthStatus: OpenClawHostHealth
+  receiptCoverageRatio: number | null
+  missingReceipts: number
+  failedReceipts: number
+  activeRoutes: number
+  p95LatencyMs: number | null
+  overSlo: number
+  reasons: string[]
+  severity: OpenClawFleetDigestSeverity
+  href: string
+  workspaceHref: string | null
+  traceHref: string | null
+}
+
+type OpenClawFleetRouteHealthSummary = {
+  summary: {
+    targetLatencyMs: number
+    activeRoutes: number
+    routesWithReceipts: number
+    routesMissingReceipts: number
+    receiptCoverageRatio: number | null
+    failedReceipts: number
+    degradedHosts: number
+    hostsWithMissingReceipts: number
+    hostsWithFailedReceipts: number
+  }
+  latency: {
+    samples: number
+    avgMs: number | null
+    p50Ms: number | null
+    p95Ms: number | null
+    overSlo: number
+    overDoubleSlo: number
+    buckets: {
+      withinTarget: number
+      overTarget: number
+      overDoubleTarget: number
+    }
+  }
+  attentionHosts: OpenClawFleetRouteHealthAttentionHost[]
+}
+
 type OpenClawFleetBulkAction =
   | 'apply_labels'
   | 'stage_revoke_review'
@@ -388,6 +471,8 @@ function computeNextRotationWindow(
       nextRotationWindowStartsAt: null as string | null,
       nextRotationWindowEndsAt: null as string | null,
       dueInHours: null as number | null,
+      windowOpen: false,
+      hoursUntilWindowStarts: null as number | null,
       reviewState: 'scheduled' as OpenClawHostRotationReviewState,
     }
   }
@@ -402,10 +487,11 @@ function computeNextRotationWindow(
   }
   const windowEnd = new Date(windowStart.getTime() + (windowDurationHours * 60 * 60 * 1000))
   const dueInHours = hoursUntil(dueAt.toISOString())
+  const now = Date.now()
   const reviewState: OpenClawHostRotationReviewState =
-    dueMs <= Date.now()
+    dueMs <= now
       ? 'overdue'
-      : dueMs <= (Date.now() + (OPENCLAW_ROTATION_DUE_SOON_HOURS * 60 * 60 * 1000))
+      : dueMs <= (now + (OPENCLAW_ROTATION_DUE_SOON_HOURS * 60 * 60 * 1000))
         ? 'due_soon'
         : 'scheduled'
 
@@ -414,6 +500,8 @@ function computeNextRotationWindow(
     nextRotationWindowStartsAt: windowStart.toISOString(),
     nextRotationWindowEndsAt: windowEnd.toISOString(),
     dueInHours,
+    windowOpen: now >= windowStart.getTime() && now <= windowEnd.getTime(),
+    hoursUntilWindowStarts: hoursUntil(windowStart.toISOString()),
     reviewState,
   }
 }
@@ -477,9 +565,24 @@ function serializeOpenClawHostPolicy(host: OpenClawHostRow) {
   const recoveryStatus: OpenClawHostRecoveryRunbookState =
     host.credential_state === 'recovery_pending'
       ? 'cutover_pending'
-      : host.recovery_completed_at
-        ? 'completed'
-        : (rawRecoveryStatus ?? 'idle')
+      : rawRecoveryStatus === 'idle'
+        ? 'idle'
+        : host.recovery_completed_at
+          ? 'completed'
+          : (rawRecoveryStatus ?? 'idle')
+  const recoveryNotes = normalizeOptionalString(recoveryRunbook.notes)
+  const replacementHostLabel = normalizeOptionalString(recoveryRunbook.replacementHostLabel)
+  const recoveryWindowStartsAt = normalizeIsoDateTime(recoveryRunbook.windowStartsAt)
+  const recoveryWindowEndsAt = normalizeIsoDateTime(recoveryRunbook.windowEndsAt)
+  const cleanupRecommended =
+    recoveryStatus === 'completed'
+    && Boolean(
+      recoveryNotes
+      || replacementHostLabel
+      || recoveryWindowStartsAt
+      || recoveryWindowEndsAt
+      || rawRecoveryStatus === 'completed',
+    )
 
   return {
     rotation: {
@@ -490,16 +593,19 @@ function serializeOpenClawHostPolicy(host: OpenClawHostRow) {
       nextRotationWindowStartsAt: nextRotation.nextRotationWindowStartsAt,
       nextRotationWindowEndsAt: nextRotation.nextRotationWindowEndsAt,
       dueInHours: nextRotation.dueInHours,
+      windowOpen: nextRotation.windowOpen,
+      hoursUntilWindowStarts: nextRotation.hoursUntilWindowStarts,
       reviewState: nextRotation.reviewState,
     },
     recovery: {
       owner: normalizeOptionalString(recoveryRunbook.owner),
       status: recoveryStatus,
-      notes: normalizeOptionalString(recoveryRunbook.notes),
-      replacementHostLabel: normalizeOptionalString(recoveryRunbook.replacementHostLabel),
-      windowStartsAt: normalizeIsoDateTime(recoveryRunbook.windowStartsAt),
-      windowEndsAt: normalizeIsoDateTime(recoveryRunbook.windowEndsAt),
+      notes: recoveryNotes,
+      replacementHostLabel,
+      windowStartsAt: recoveryWindowStartsAt,
+      windowEndsAt: recoveryWindowEndsAt,
       updatedAt: normalizeIsoDateTime(recoveryRunbook.updatedAt) ?? host.recovery_completed_at,
+      cleanupRecommended,
     },
   }
 }
@@ -1229,6 +1335,206 @@ function summarizeOpenClawFleetGroups(hosts: Array<ReturnType<typeof serializeHo
     .sort((left, right) => left.label.localeCompare(right.label))
 }
 
+function severityWeight(severity: OpenClawFleetDigestSeverity): number {
+  return severity === 'critical' ? 0 : 1
+}
+
+function buildOpenClawFleetCredentialPolicySummary(
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): OpenClawFleetCredentialPolicySummary {
+  const counts: OpenClawFleetCredentialPolicySummary['counts'] = {
+    overdue: 0,
+    dueSoon: 0,
+    windowOpen: 0,
+    rotationPending: 0,
+    recoveryPrepared: 0,
+    recoveryCutover: 0,
+    recoveryCompleted: 0,
+    cleanupRecommended: 0,
+    missingRecoveryOwner: 0,
+  }
+  const attentionHosts: OpenClawFleetCredentialPolicyAttentionHost[] = []
+
+  for (const host of hosts) {
+    const reasons: string[] = []
+    let severity: OpenClawFleetDigestSeverity = 'warning'
+    if (host.policy.rotation.reviewState === 'overdue') {
+      counts.overdue += 1
+      reasons.push('credential rotation overdue')
+      severity = 'critical'
+    } else if (host.policy.rotation.reviewState === 'due_soon') {
+      counts.dueSoon += 1
+      reasons.push('credential rotation due soon')
+    }
+
+    if (host.policy.rotation.windowOpen) {
+      counts.windowOpen += 1
+      reasons.push('rotation window open')
+    }
+
+    if (host.credentialState === 'rotation_pending') {
+      counts.rotationPending += 1
+      reasons.push('rotated credential not yet active')
+    }
+
+    if (host.policy.recovery.status === 'prepared') {
+      counts.recoveryPrepared += 1
+      reasons.push('recovery runbook prepared')
+    } else if (host.policy.recovery.status === 'cutover_pending') {
+      counts.recoveryCutover += 1
+      reasons.push('recovery cutover pending')
+      severity = 'critical'
+    } else if (host.policy.recovery.status === 'completed') {
+      counts.recoveryCompleted += 1
+    }
+
+    if (host.policy.recovery.cleanupRecommended) {
+      counts.cleanupRecommended += 1
+      reasons.push('post-recovery cleanup recommended')
+    }
+
+    if (host.policy.recovery.status !== 'idle' && !host.policy.recovery.owner) {
+      counts.missingRecoveryOwner += 1
+      reasons.push('recovery owner missing')
+    }
+
+    if (reasons.length === 0) {
+      continue
+    }
+
+    attentionHosts.push({
+      hostId: host.id,
+      hostLabel: host.label,
+      workspaceSlug: host.workspaceSlug,
+      healthStatus: host.healthStatus,
+      credentialState: host.credentialState,
+      credentialAgeHours: host.credentialAgeHours,
+      rotationReviewState: host.policy.rotation.reviewState,
+      nextRotationDueAt: host.policy.rotation.nextRotationDueAt,
+      nextRotationWindowStartsAt: host.policy.rotation.nextRotationWindowStartsAt,
+      nextRotationWindowEndsAt: host.policy.rotation.nextRotationWindowEndsAt,
+      dueInHours: host.policy.rotation.dueInHours,
+      windowOpen: host.policy.rotation.windowOpen,
+      recoveryStatus: host.policy.recovery.status,
+      recoveryOwner: host.policy.recovery.owner,
+      cleanupRecommended: host.policy.recovery.cleanupRecommended,
+      reasons,
+      severity,
+      href: buildOpenClawFleetHref(host.id),
+      workspaceHref: buildWorkspaceHref(host.workspaceSlug),
+    })
+  }
+
+  attentionHosts.sort((left, right) =>
+    severityWeight(left.severity) - severityWeight(right.severity)
+      || (left.dueInHours ?? Number.POSITIVE_INFINITY) - (right.dueInHours ?? Number.POSITIVE_INFINITY)
+      || (right.credentialAgeHours ?? 0) - (left.credentialAgeHours ?? 0)
+      || left.hostId - right.hostId)
+
+  return {
+    counts,
+    attentionHosts,
+  }
+}
+
+function buildOpenClawFleetRouteHealthSummary(
+  db: Database,
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): OpenClawFleetRouteHealthSummary {
+  const targetBeamIds = hosts.flatMap((host) => listOpenClawResolvedRoutesForHost(db, host.id).map((route) => route.beam_id))
+  const recentLogs = listRecentIntentLogsByTargets(db, targetBeamIds)
+  const ackLatencies = recentLogs
+    .filter((log) => log.status === 'acked' && typeof log.round_trip_latency_ms === 'number')
+    .map((log) => log.round_trip_latency_ms as number)
+  const totalLatency = ackLatencies.reduce((sum, value) => sum + value, 0)
+  const overTarget = ackLatencies.filter((value) => value > OPENCLAW_ROUTE_LATENCY_SLO_MS)
+  const overDoubleTarget = ackLatencies.filter((value) => value > OPENCLAW_ROUTE_LATENCY_SLO_MS * 2)
+  const attentionHosts: OpenClawFleetRouteHealthAttentionHost[] = []
+
+  for (const host of hosts) {
+    const reasons: string[] = []
+    let severity: OpenClawFleetDigestSeverity = 'warning'
+    if (host.healthStatus === 'stale') {
+      reasons.push('host stale')
+      severity = 'critical'
+    }
+    if (host.summary.delivery.failed > 0) {
+      reasons.push('failed receipts')
+      severity = 'critical'
+    }
+    if (host.summary.delivery.coverage.missingReceipts > 0) {
+      reasons.push('missing receipts')
+    }
+    if (host.summary.delivery.latency.overSlo > 0) {
+      reasons.push('latency above target')
+      if ((host.summary.delivery.latency.p95Ms ?? 0) > OPENCLAW_ROUTE_LATENCY_SLO_MS * 2) {
+        severity = 'critical'
+      }
+    }
+    if (reasons.length === 0) {
+      continue
+    }
+    attentionHosts.push({
+      hostId: host.id,
+      hostLabel: host.label,
+      workspaceSlug: host.workspaceSlug,
+      healthStatus: host.healthStatus,
+      receiptCoverageRatio: host.summary.delivery.coverage.ratio,
+      missingReceipts: host.summary.delivery.coverage.missingReceipts,
+      failedReceipts: host.summary.delivery.failed,
+      activeRoutes: host.summary.delivery.coverage.activeRoutes,
+      p95LatencyMs: host.summary.delivery.latency.p95Ms,
+      overSlo: host.summary.delivery.latency.overSlo,
+      reasons,
+      severity,
+      href: buildOpenClawFleetHref(host.id),
+      workspaceHref: buildWorkspaceHref(host.workspaceSlug),
+      traceHref: host.summary.delivery.lastHref,
+    })
+  }
+
+  attentionHosts.sort((left, right) =>
+    severityWeight(left.severity) - severityWeight(right.severity)
+      || right.failedReceipts - left.failedReceipts
+      || right.missingReceipts - left.missingReceipts
+      || (right.p95LatencyMs ?? 0) - (left.p95LatencyMs ?? 0)
+      || left.hostId - right.hostId)
+
+  const activeRoutes = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.activeRoutes, 0)
+  const routesWithReceipts = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.routesWithReceipts, 0)
+  const routesMissingReceipts = hosts.reduce((sum, host) => sum + host.summary.delivery.coverage.missingReceipts, 0)
+  const failedReceipts = hosts.reduce((sum, host) => sum + host.summary.delivery.failed, 0)
+  const degradedHosts = hosts.filter((host) => host.summary.delivery.latency.degraded).length
+
+  return {
+    summary: {
+      targetLatencyMs: OPENCLAW_ROUTE_LATENCY_SLO_MS,
+      activeRoutes,
+      routesWithReceipts,
+      routesMissingReceipts,
+      receiptCoverageRatio: activeRoutes > 0 ? Number((routesWithReceipts / activeRoutes).toFixed(3)) : null,
+      failedReceipts,
+      degradedHosts,
+      hostsWithMissingReceipts: hosts.filter((host) => host.summary.delivery.coverage.missingReceipts > 0).length,
+      hostsWithFailedReceipts: hosts.filter((host) => host.summary.delivery.failed > 0).length,
+    },
+    latency: {
+      samples: ackLatencies.length,
+      avgMs: ackLatencies.length > 0 ? Math.round(totalLatency / ackLatencies.length) : null,
+      p50Ms: percentile(ackLatencies, 0.5),
+      p95Ms: percentile(ackLatencies, 0.95),
+      overSlo: overTarget.length,
+      overDoubleSlo: overDoubleTarget.length,
+      buckets: {
+        withinTarget: ackLatencies.filter((value) => value <= OPENCLAW_ROUTE_LATENCY_SLO_MS).length,
+        overTarget: overTarget.length,
+        overDoubleTarget: overDoubleTarget.length,
+      },
+    },
+    attentionHosts,
+  }
+}
+
 function buildOpenClawFleetEscalations(actionItems: OpenClawFleetDigestItem[]): OpenClawFleetEscalation[] {
   return actionItems.filter((item) => item.severity === 'critical')
 }
@@ -1468,6 +1774,22 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
         nextAction: host.policy.recovery.status === 'cutover_pending'
           ? 'Complete the recovery cutover, confirm fresh routes on the replacement host, then close the runbook state.'
           : 'Review the recovery notes and schedule the replacement window before the next operator handoff.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: null,
+      })
+    }
+
+    if (host.policy.recovery.cleanupRecommended) {
+      actionItems.push({
+        id: `recovery-cleanup:${host.id}`,
+        severity: 'warning',
+        category: 'credential',
+        title: `${hostTitleForDigest(host)} has recovery cleanup pending`,
+        detail: `${baseDetail} already completed recovery cutover, but the runbook still carries recovery-specific window or replacement metadata.`,
+        nextAction: 'Review the replacement host state and then complete recovery cleanup so the host returns to the normal credential review queue.',
         hostId: host.id,
         hostLabel: host.label,
         workspaceSlug: host.workspaceSlug,
@@ -1920,6 +2242,8 @@ export function openClawAdminRouter(db: Database) {
     const digest = buildOpenClawFleetDigest(db, new URL(c.req.url).origin)
     const environments = summarizeOpenClawFleetEnvironments(hosts)
     const hostGroups = summarizeOpenClawFleetGroups(hosts)
+    const credentialPolicy = buildOpenClawFleetCredentialPolicySummary(hosts)
+    const routeHealth = buildOpenClawFleetRouteHealthSummary(db, hosts)
     const summary = hosts.reduce((acc, host) => {
       acc.totalHosts += 1
       if (host.status === 'pending') acc.pendingHosts += 1
@@ -1974,6 +2298,8 @@ export function openClawAdminRouter(db: Database) {
       },
       hosts,
       conflicts,
+      credentialPolicy,
+      routeHealth,
       environments,
       hostGroups,
     })
@@ -3002,6 +3328,64 @@ export function openClawAdminRouter(db: Database) {
         directoryUrl: new URL(c.req.url).origin,
         credential: recovered.credential,
       }),
+    })
+  })
+
+  router.post('/hosts/:id/recovery/cleanup', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const policy = serializeOpenClawHostPolicy(host)
+    if (!policy.recovery.cleanupRecommended) {
+      return c.json({ error: 'Recovery cleanup is not currently required', errorCode: 'RECOVERY_CLEANUP_NOT_REQUIRED' }, 409)
+    }
+
+    const metadata = parseOpenClawHostMetadata(host.metadata_json)
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: serializeOpenClawHostMetadata({
+        ...metadata,
+        recoveryRunbook: {
+          ...(metadata.recoveryRunbook ?? {}),
+          owner: normalizeOptionalString(metadata.recoveryRunbook?.owner),
+          status: 'idle',
+          notes: null,
+          replacementHostLabel: null,
+          windowStartsAt: null,
+          windowEndsAt: null,
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.recovery_cleanup_completed',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+        owner: serializeOpenClawHostPolicy(updated).recovery.owner,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      host: serializeHost(db, updated),
     })
   })
 


### PR DESCRIPTION
## Summary
- add a credential review queue with rotation windows, recovery state, and cleanup actions
- add route-health and SLO summaries with receipt coverage, latency buckets, and trace/workspace links
- extend fleet tests and workspace docs for the new operator flow

Closes #152
Closes #153