### PR TITLE
Prepare 1.4.0 drill evidence and release cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.4.0 (2026-04-02)
+
+### OpenClaw Fleet Automation
+- add a credential review queue with rotation windows, recovery ownership, and explicit post-recovery cleanup
+- add fleet receipt coverage, latency buckets, and route-health summaries with direct host, workspace, and trace links
+- automate approval-heavy outbound motion for fleet-backed workspaces through the workspace approval queue
+- add guided duplicate conflict remediation, route-owner recommendations, and explicit disable/reassign flows
+- group hosts by environment or ownership and add guarded bulk fleet actions
+- schedule fleet digests with persisted run history, delivery history, and escalation delivery evidence
+- commit buyer, operator, fleet, digest, and Linux parity reports before cutting the release
+
+### Compatibility Note
+- No protocol-family change in this release train. Beam `1.4.0` remains on `beam/1`.
+
 ## v1.3.0 (2026-04-02)
 
 ### OpenClaw Fleet Operations

--- a/docs/api/directory.md
+++ b/docs/api/directory.md
@@ -99,11 +99,11 @@ Typical health response:
   "protocol": "beam/1",
   "connectedAgents": 12,
   "timestamp": "2026-03-08T12:00:00.000Z",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
   "deployedAt": "2026-04-01T19:00:00.000Z",
   "release": {
-    "version": "1.3.0",
+    "version": "1.4.0",
     "gitSha": "abcdef1234567890abcdef1234567890abcdef12",
     "gitShaShort": "abcdef1",
     "deployedAt": "2026-04-01T19:00:00.000Z"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol-docs",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol-docs",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "devDependencies": {
         "vitepress": "1.6.4"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,5 +18,5 @@
   "engines": {
     "node": ">=20.19.0"
   },
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,7 +5765,7 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "beam-protocol-sdk": "^1.3.0",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,7 +6391,7 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "beam-protocol-sdk": "^1.3.0"
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",

--- a/reports/1.4.0-buyer-dry-run.md
+++ b/reports/1.4.0-buyer-dry-run.md
@@ -1,0 +1,42 @@
+# Beam 1.4.0 Buyer Dry Run
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T15:35:38.440Z`
+- surface: OpenClaw fleet docs and operator-facing control-plane copy
+
+## Result
+
+`PASS`
+
+## Path
+
+1. The docs home still points operators to Beam Workspaces as the identity and control-plane layer.
+2. The Beam Workspaces guide now explains the OpenClaw fleet model, host approval, credential rotation and recovery, Linux install parity, and fleet digest commands in plain operator language.
+3. The dashboard surface vocabulary matches the guide: host approval, host detail, duplicate identity conflicts, host badges, partner channels, timeline, digest, route-owner actions, and thread composer.
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "checks": {
+    "docsHome": true,
+    "workspaceGuide": true,
+    "dashboardSurface": true,
+    "openClawFleetSurface": true,
+    "manualHostApproval": true,
+    "credentialLifecycle": true,
+    "linuxInstallPath": true,
+    "hostStatusCommands": true,
+    "partnerChannels": true,
+    "timeline": true,
+    "digest": true,
+    "threadComposer": true,
+    "hostBadges": true,
+    "routeOwnerActions": true
+  }
+}
+```

--- a/reports/1.4.0-fleet-digest.md
+++ b/reports/1.4.0-fleet-digest.md
@@ -1,0 +1,126 @@
+# Beam 1.4.0 Fleet Digest
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T15:36:09.651Z`
+- environment: local three-host OpenClaw fleet harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Mark one host stale.
+2. Rotate one host credential without applying the new credential yet.
+3. Inject one duplicate Beam identity conflict on a second host.
+4. Read the fleet digest and confirm that it turns all three states into explicit operator action items.
+5. Run the scheduled digest path and verify that Beam persists one run plus digest/escalation delivery history.
+6. Exercise the manual delivery path and verify the local harness reports the expected “delivery unavailable” state without SMTP configuration.
+
+## Verification
+
+- Stale hosts: `1`
+- Pending credential actions: `1`
+- Duplicate conflicts: `1`
+- Action items: `4`
+- Critical items: `2`
+- Scheduled runs: `1`
+- Delivery history: `2`
+- Delivery path: `delivery_unavailable`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "workspace": "openclaw-local",
+  "summary": {
+    "totalHosts": 3,
+    "activeHosts": 3,
+    "pendingHosts": 0,
+    "revokedHosts": 0,
+    "staleHosts": 1,
+    "liveRoutes": 1,
+    "staleRoutes": 1,
+    "failedReceipts": 0,
+    "routesMissingReceipts": 1,
+    "degradedHosts": 1,
+    "latencySloBreaches": 0,
+    "rotationDueHosts": 0,
+    "recoveryRunbooksOpen": 0,
+    "receiptCoverageRatio": 0,
+    "duplicateIdentityConflicts": 1,
+    "pendingCredentialActions": 1,
+    "actionItems": 4,
+    "criticalItems": 2,
+    "escalations": 2,
+    "warningItems": 2
+  },
+  "scheduledRun": {
+    "id": 1,
+    "deliveryState": "unavailable",
+    "deliveries": [
+      {
+        "kind": "digest",
+        "status": "unavailable",
+        "errorCode": "EMAIL_DELIVERY_UNAVAILABLE"
+      },
+      {
+        "kind": "escalation",
+        "status": "unavailable",
+        "errorCode": "EMAIL_DELIVERY_UNAVAILABLE"
+      }
+    ]
+  },
+  "digestSchedule": {
+    "enabled": true,
+    "deliveryEmail": "ops@beam.local",
+    "escalationEmail": "critical@beam.local",
+    "runHourUtc": 15,
+    "runMinuteUtc": 36,
+    "escalateOnCritical": true,
+    "lastScheduledForAt": "2026-04-02T15:36:00.000Z",
+    "lastRunAt": "2026-04-02T15:36:09.640Z",
+    "lastDeliveryAt": "2026-04-02T15:36:09.640Z",
+    "lastEscalationDeliveryAt": "2026-04-02T15:36:09.641Z",
+    "nextRunAt": "2026-04-03T15:36:00.000Z"
+  },
+  "digestHistory": {
+    "runs": 1,
+    "deliveries": 2
+  },
+  "leadingActions": [
+    {
+      "category": "delivery",
+      "severity": "warning",
+      "title": "OpenClaw Host Gamma has live routes without receipts",
+      "nextAction": "Send a Beam ping to the host and confirm the trace closes with a successful receipt."
+    },
+    {
+      "category": "host",
+      "severity": "critical",
+      "title": "OpenClaw Host Beta has gone stale",
+      "nextAction": "Inspect the service status on the host, then recover or replace the host if it no longer owns the route."
+    },
+    {
+      "category": "credential",
+      "severity": "warning",
+      "title": "OpenClaw Host Beta is waiting for rotated credentials",
+      "nextAction": "Apply the rotated credential pack on the host and wait for the next heartbeat to restore route health."
+    },
+    {
+      "category": "conflict",
+      "severity": "critical",
+      "title": "atlas@openclaw.beam.directory has duplicate live routes",
+      "nextAction": "Prefer exactly one route owner or revoke/disable the conflicting host route before retrying delivery."
+    }
+  ],
+  "deliveryOutcome": {
+    "status": "delivery_unavailable",
+    "note": "Digest delivery is wired end to end, but the local harness intentionally has no SMTP or Resend configuration."
+  }
+}
+```

--- a/reports/1.4.0-fleet-drill.md
+++ b/reports/1.4.0-fleet-drill.md
@@ -1,0 +1,120 @@
+# Beam 1.4.0 Fleet Drill
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T15:36:09.877Z`
+- environment: local three-host OpenClaw fleet harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Bootstrap three approved OpenClaw hosts into one central Beam directory.
+2. Connect one live Beam route per host over WebSocket.
+3. Send a real ring of host-to-host messages so every host sends and receives at least once.
+4. Inject a duplicate Beam identity conflict and confirm delivery is blocked until one explicit route owner is preferred and the duplicate route is disabled.
+5. Rotate one host credential and confirm the host returns with the rotated secret.
+6. Revoke a host, confirm delivery is blocked, then recover the host and confirm delivery resumes on the same Beam trace model.
+
+## Verification
+
+- Approved hosts visible: `3`
+- Ring messages delivered: `3`
+- Duplicate conflict count: `1`
+- Duplicate conflicts after owner resolution: `0`
+- Revoked hosts after remediation: `1`
+- Conflict response status: `FORBIDDEN`
+- Revoked response status: `FORBIDDEN`
+- Recovery credential state: `recovery_pending`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "workspace": "openclaw-local",
+  "hosts": [
+    {
+      "id": 1,
+      "label": "OpenClaw Host Alpha",
+      "hostname": "alpha.local"
+    },
+    {
+      "id": 2,
+      "label": "OpenClaw Host Beta",
+      "hostname": "beta.local"
+    },
+    {
+      "id": 3,
+      "label": "OpenClaw Host Gamma",
+      "hostname": "gamma.local"
+    }
+  ],
+  "ring": [
+    {
+      "nonce": "d9b6542e-3cf4-43e1-b64f-c07ec1470367",
+      "to": "beacon@openclaw.beam.directory",
+      "from": "atlas@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet alpha -> beta"
+    },
+    {
+      "nonce": "72903ae5-cda3-43d8-874f-0204ad5ea4f2",
+      "to": "cipher@openclaw.beam.directory",
+      "from": "beacon@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet beta -> gamma"
+    },
+    {
+      "nonce": "94a0f4d3-c0bb-4122-8e1a-4517e77198ee",
+      "to": "atlas@openclaw.beam.directory",
+      "from": "cipher@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet gamma -> alpha"
+    }
+  ],
+  "conflict": {
+    "duplicateIdentityConflicts": 1,
+    "response": {
+      "error": "Agent atlas@openclaw.beam.directory is claimed by multiple OpenClaw hosts",
+      "errorCode": "FORBIDDEN"
+    }
+  },
+  "resolved": {
+    "duplicateIdentityConflicts": 0,
+    "message": {
+      "nonce": "b6414179-bcc5-4291-8b5d-e474f5f3c288",
+      "to": "atlas@openclaw.beam.directory",
+      "from": "beacon@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "beta -> alpha after conflict resolution"
+    }
+  },
+  "rotated": {
+    "hostId": 2,
+    "credentialState": "rotation_pending"
+  },
+  "revoked": {
+    "revokedHosts": 1,
+    "response": {
+      "error": "Agent cipher@openclaw.beam.directory belongs to a revoked OpenClaw host",
+      "errorCode": "FORBIDDEN"
+    }
+  },
+  "recovered": {
+    "hostId": 3,
+    "credentialState": "recovery_pending",
+    "message": {
+      "nonce": "28b37c21-b779-4f58-9da8-da6eaf7db05e",
+      "to": "cipher@openclaw.beam.directory",
+      "from": "atlas@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "alpha -> gamma after recovery"
+    }
+  }
+}
+```

--- a/reports/1.4.0-linux-fleet-smoke.md
+++ b/reports/1.4.0-linux-fleet-smoke.md
@@ -1,0 +1,59 @@
+# Beam 1.4.0 Linux Host Smoke
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T15:35:39.131Z`
+- environment: simulated Linux user-service install on a temporary HOME with a fake systemctl shim
+
+## Result
+
+`PASS`
+
+## Verification
+
+1. Install the OpenClaw host daemon as a systemd user service.
+2. Confirm the generated unit file exists and enforces `UMask=0077`.
+3. Confirm the service reports installed, enabled, and active through the Linux status path.
+4. Uninstall the service and confirm the manifest is removed and the service reports inactive.
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "platform": "linux-simulated",
+  "unitPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.config/systemd/user/beam-openclaw-host.service",
+  "installed": {
+    "platform": "linux",
+    "serviceLabel": "beam-openclaw-host.service",
+    "installed": true,
+    "running": true,
+    "enabled": true,
+    "activeState": "active",
+    "subState": "running",
+    "unitFileState": "enabled",
+    "manifestPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.config/systemd/user/beam-openclaw-host.service",
+    "stdoutPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.local/state/beam/beam-openclaw-host.log",
+    "stderrPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.local/state/beam/beam-openclaw-host.err.log",
+    "statePath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.openclaw/workspace/secrets/beam-openclaw-host.json",
+    "adminSessionCachePath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.openclaw/workspace/secrets/beam-admin-session.json"
+  },
+  "removed": {
+    "platform": "linux",
+    "serviceLabel": "beam-openclaw-host.service",
+    "installed": false,
+    "running": false,
+    "enabled": false,
+    "activeState": "inactive",
+    "subState": "dead",
+    "unitFileState": "disabled",
+    "manifestPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.config/systemd/user/beam-openclaw-host.service",
+    "stdoutPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.local/state/beam/beam-openclaw-host.log",
+    "stderrPath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.local/state/beam/beam-openclaw-host.err.log",
+    "statePath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.openclaw/workspace/secrets/beam-openclaw-host.json",
+    "adminSessionCachePath": "/var/folders/b2/d863mz3d3wx49r5w3bb7gt8w0000gn/T/beam-linux-host-smoke-KLRejV/home/.openclaw/workspace/secrets/beam-admin-session.json"
+  }
+}
+```

--- a/reports/1.4.0-operator-dry-run.md
+++ b/reports/1.4.0-operator-dry-run.md
@@ -1,0 +1,104 @@
+# Beam 1.4.0 Operator Dry Run
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T15:35:59.242Z`
+- environment: local three-host OpenClaw fleet harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Bootstrap three approved OpenClaw hosts into one central Beam control plane.
+2. Verify the fleet overview, selected host detail, and workspace host badges.
+3. Force one stale host, rotate one host credential, and confirm the fleet digest surfaces both conditions with next actions.
+4. Introduce a duplicate Beam identity on a second host, then resolve it through explicit route-owner actions.
+5. Revoke and recover the affected host and confirm the fleet returns to an active, healthy state without rebuilding workspace bindings.
+
+## Verification
+
+- Approved active hosts: `3`
+- Live routes: `3`
+- Selected host identities: `1`
+- Stale hosts before remediation: `1`
+- Pending credential actions in digest: `1`
+- Duplicate conflicts after injection: `1`
+- Duplicate conflicts after owner resolution: `0`
+- Revoked gamma status: `revoked`
+- Gamma route after recovery: `live`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "workspace": "openclaw-local",
+  "summary": {
+    "totalHosts": 3,
+    "pendingHosts": 0,
+    "activeHosts": 3,
+    "revokedHosts": 0,
+    "staleHosts": 0,
+    "liveRoutes": 3,
+    "staleRoutes": 0,
+    "conflictRoutes": 0,
+    "endedRoutes": 0,
+    "failedReceipts": 0,
+    "routesMissingReceipts": 3,
+    "degradedHosts": 3,
+    "latencySloBreaches": 0,
+    "rotationDueHosts": 0,
+    "recoveryRunbooksOpen": 0,
+    "receiptCoverageRatio": 0,
+    "duplicateIdentityConflicts": 0,
+    "pendingCredentialActions": 0,
+    "actionItems": 3,
+    "criticalItems": 0
+  },
+  "selectedHost": {
+    "id": 2,
+    "label": "OpenClaw Host Beta",
+    "routeCount": 1,
+    "identityCount": 1,
+    "heartbeatCount": 1
+  },
+  "stale": {
+    "staleHosts": 1
+  },
+  "rotated": {
+    "hostId": 2,
+    "credentialState": "rotation_pending"
+  },
+  "digest": {
+    "actionItems": 4,
+    "criticalItems": 2,
+    "pendingCredentialActions": 1,
+    "duplicateIdentityConflicts": 1
+  },
+  "conflict": {
+    "total": 1,
+    "beamId": "atlas@openclaw.beam.directory",
+    "routeState": "conflict"
+  },
+  "resolved": {
+    "duplicateIdentityConflicts": 0,
+    "disabledRouteId": 4,
+    "ownerResolutionState": "disabled"
+  },
+  "revoked": {
+    "hostId": 3,
+    "status": "revoked",
+    "healthStatus": "revoked"
+  },
+  "recovered": {
+    "hostId": 3,
+    "status": "active",
+    "healthStatus": "healthy",
+    "credentialState": "ready"
+  }
+}
+```

--- a/reports/1.4.0-rc1-checklist.md
+++ b/reports/1.4.0-rc1-checklist.md
@@ -1,0 +1,59 @@
+# Beam 1.4.0 RC1 Checklist
+
+Status: `candidate`
+
+Last updated: `2026-04-02`
+
+## Scope
+
+Beam `1.4.0` is the OpenClaw fleet automation release:
+
+- host credential policies, rotation windows, and safer recovery cleanup
+- fleet receipt coverage, latency buckets, and route-health/SLO summaries
+- approval queue automation for fleet-backed workspaces
+- guided duplicate conflict remediation with route-owner recommendations
+- host groups, environment labels, and guarded bulk fleet actions
+- scheduled fleet digests with persisted run and delivery history
+- repo-visible buyer/operator/fleet evidence before the final cut
+
+## Evidence
+
+- Buyer dry run: [1.4.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-buyer-dry-run.md)
+- Operator dry run: [1.4.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-operator-dry-run.md)
+- Fleet drill: [1.4.0-fleet-drill.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-fleet-drill.md)
+- Fleet digest: [1.4.0-fleet-digest.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-fleet-digest.md)
+- Linux parity smoke: [1.4.0-linux-fleet-smoke.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-linux-fleet-smoke.md)
+- Release smoke: [1.4.0-release-smoke.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.4.0-release-smoke.md)
+
+## Gates
+
+- [x] Credential review queue exposes overdue rotation work, window-open state, and recovery cleanup.
+- [x] Fleet route-health summary exposes receipt coverage, failed receipts, p95 latency, and trace/workspace links.
+- [x] Approval queue automation for fleet-backed workspaces is merged on `main`.
+- [x] Duplicate Beam identity conflicts expose guided remediation and route-owner actions.
+- [x] Host groups, environment labels, and guarded bulk actions are merged on `main`.
+- [x] Scheduled fleet digests persist run history and delivery history.
+- [x] Buyer/operator/fleet evidence is committed under `reports/`.
+- [x] Linux/systemd parity is exercised by a repo-owned smoke.
+- [x] Monorepo build, tests, E2E, and docs build are green on the candidate.
+- [ ] Final release smoke proves `1.4.0` across API, public site, docs, npm, and fleet APIs.
+
+## Candidate Verification
+
+Verified locally on `2026-04-02`:
+
+- `npm run build`
+- `npm test`
+- `npm run test:e2e`
+- `npm -C docs run build`
+- `npm run workspace:buyer-dry-run -- --release 1.4.0 --output reports/1.4.0-buyer-dry-run.md`
+- `npm run workspace:operator-dry-run -- --release 1.4.0 --output reports/1.4.0-operator-dry-run.md`
+- `npm run workspace:fleet-drill -- --release 1.4.0 --output reports/1.4.0-fleet-drill.md`
+- `npm run workspace:fleet-digest -- --release 1.4.0 --output reports/1.4.0-fleet-digest.md`
+- `npm run workspace:openclaw-linux-smoke -- --release 1.4.0 --output reports/1.4.0-linux-fleet-smoke.md`
+
+## Notes
+
+- Local digest delivery is intentionally `EMAIL_DELIVERY_UNAVAILABLE` when SMTP or Resend is not configured. The schedule, persistence, and escalation paths are still exercised end to end.
+- `1.4.0` stays on the existing Beam protocol family. No protocol-family change is part of this release.
+- The release smoke gate flips only after the tagged `v1.4.0` deployment is live.

--- a/reports/1.4.0-release-notes-draft.md
+++ b/reports/1.4.0-release-notes-draft.md
@@ -1,0 +1,47 @@
+# Beam 1.4.0 Release Notes
+
+Release status: `draft`
+
+## Summary
+
+Beam `1.4.0` turns the OpenClaw fleet surface from a strong operator console into a low-toil automation layer. The headline is not a new protocol primitive; it is safer recurring fleet work with clearer policies, summaries, grouping, and operator follow-through.
+
+## Highlights
+
+### Credential policy and recovery review
+
+- add a dedicated credential review queue with overdue, due-soon, and window-open rotation state
+- surface recovery ownership, cutover state, and explicit post-recovery cleanup before the host returns to the normal loop
+- make the fleet view the place where credential work is reviewed instead of a sequence of host-detail clicks
+
+### Receipt and latency summaries
+
+- add receipt-coverage and route-health summaries for the whole fleet
+- surface missing receipts, failed receipts, and p95 latency with direct links back to host, workspace, and trace context
+- make SLO drift visible as fleet health, not just per-intent detail
+
+### Approval and remediation automation
+
+- expand the workspace approval queue for fleet-backed outbound motion and policy-backed defaults
+- add guided duplicate conflict remediation with route-owner recommendations, disable/reassign paths, and audit trail
+- keep blocked or risky motion inside Beam instead of shell- or memory-driven operator work
+
+### Grouped fleet operations
+
+- group hosts by environment or function and filter the fleet by those labels
+- add guarded bulk actions so operators can work multiple hosts without turning revoke and recovery into unsafe one-offs
+- retain explicit confirmation and staged review semantics for destructive fleet actions
+
+### Scheduled fleet digest
+
+- persist digest schedules, run history, delivery history, and escalation output inside Beam
+- make the daily fleet loop reproducible and inspectable instead of a manual “remember to run the script” step
+
+### Evidence-backed release
+
+- commit repo-visible buyer, operator, fleet, digest, and Linux parity evidence under `reports/`
+- gate the release on explicit proof instead of operator confidence alone
+
+## Compatibility Note
+
+No protocol-family change in this release train. Beam `1.4.0` remains on `beam/1`.

--- a/scripts/production/shared.mjs
+++ b/scripts/production/shared.mjs
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { once } from 'node:events'
+import { readFileSync } from 'node:fs'
 import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import net from 'node:net'
 import path from 'node:path'
@@ -9,6 +10,14 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { setTimeout as sleep } from 'node:timers/promises'
 
 export const repoRoot = path.resolve(fileURLToPath(new URL('../../', import.meta.url)))
+export const repoPackageVersion = (() => {
+  try {
+    const packageJson = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+    return typeof packageJson.version === 'string' ? packageJson.version : '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+})()
 const directoryEntry = path.join(repoRoot, 'packages/directory/dist/index.js')
 const messageBusEntry = path.join(repoRoot, 'packages/message-bus/dist/server.js')
 const directoryDbModule = path.join(repoRoot, 'packages/directory/dist/db.js')
@@ -34,6 +43,14 @@ export function optionalFlag(name, fallback = null) {
   }
 
   return trimmed
+}
+
+export function resolveReleaseLabel(fallback = repoPackageVersion) {
+  const label = optionalFlag('--release', fallback)
+  if (typeof label === 'string' && label.trim().length > 0) {
+    return label.trim()
+  }
+  return fallback
 }
 
 export async function ensureBuiltArtifacts() {

--- a/scripts/workspace/buyer-dry-run.mjs
+++ b/scripts/workspace/buyer-dry-run.mjs
@@ -1,8 +1,9 @@
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
-import { formatDate, formatDateTime, optionalFlag, repoRoot, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { formatDate, formatDateTime, optionalFlag, repoRoot, resolveReleaseLabel, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
 
-const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.3.0-buyer-dry-run.md'))
+const releaseLabel = resolveReleaseLabel()
+const outputPath = optionalFlag('--output', path.join(process.cwd(), `reports/${releaseLabel}-buyer-dry-run.md`))
 
 function assertIncludes(haystack, needle, label) {
   if (!haystack.includes(needle)) {
@@ -64,7 +65,7 @@ async function main() {
     },
   }
 
-  const markdown = `# Beam 1.3.0 Buyer Dry Run
+  const markdown = `# Beam ${releaseLabel} Buyer Dry Run
 
 ## Context
 

--- a/scripts/workspace/fleet-digest.mjs
+++ b/scripts/workspace/fleet-digest.mjs
@@ -1,8 +1,9 @@
 import path from 'node:path'
-import { formatDate, formatDateTime, optionalFlag, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { formatDate, formatDateTime, optionalFlag, resolveReleaseLabel, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
 import { startOpenClawFleetHarness } from './fleet-shared.mjs'
 
-const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.3.0-fleet-digest.md'))
+const releaseLabel = resolveReleaseLabel()
+const outputPath = optionalFlag('--output', path.join(process.cwd(), `reports/${releaseLabel}-fleet-digest.md`))
 
 async function main() {
   const fleet = await startOpenClawFleetHarness()
@@ -117,7 +118,7 @@ async function main() {
       deliveryOutcome,
     }
 
-    const markdown = `# Beam 1.3.0 Fleet Digest
+    const markdown = `# Beam ${releaseLabel} Fleet Digest
 
 ## Context
 

--- a/scripts/workspace/fleet-smoke.mjs
+++ b/scripts/workspace/fleet-smoke.mjs
@@ -1,12 +1,13 @@
 import path from 'node:path'
-import { formatDate, formatDateTime, optionalFlag, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { formatDate, formatDateTime, optionalFlag, resolveReleaseLabel, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
 import {
   closeFleetClient,
   sendFleetIntent,
   startOpenClawFleetHarness,
 } from './fleet-shared.mjs'
 
-const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.3.0-fleet-drill.md'))
+const releaseLabel = resolveReleaseLabel()
+const outputPath = optionalFlag('--output', path.join(process.cwd(), `reports/${releaseLabel}-fleet-drill.md`))
 
 async function expectInbound(ws, expectedFrom, expectedMessage) {
   const payload = await new Promise((resolve, reject) => {
@@ -196,7 +197,7 @@ async function main() {
       },
     }
 
-    const markdown = `# Beam 1.3.0 Fleet Drill
+    const markdown = `# Beam ${releaseLabel} Fleet Drill
 
 ## Context
 

--- a/scripts/workspace/linux-host-smoke.mjs
+++ b/scripts/workspace/linux-host-smoke.mjs
@@ -4,9 +4,10 @@ import os from 'node:os'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
-import { formatDate, formatDateTime, optionalFlag, repoRoot, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { formatDate, formatDateTime, optionalFlag, repoRoot, resolveReleaseLabel, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
 
-const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.3.0-linux-fleet-smoke.md'))
+const releaseLabel = resolveReleaseLabel()
+const outputPath = optionalFlag('--output', path.join(process.cwd(), `reports/${releaseLabel}-linux-fleet-smoke.md`))
 const installerPath = path.join(repoRoot, 'scripts/workspace/install-openclaw-host-agent.mjs')
 const nodePath = process.execPath
 
@@ -162,7 +163,7 @@ async function main() {
     removed,
   }
 
-  const markdown = `# Beam 1.3.0 Linux Host Smoke
+  const markdown = `# Beam ${releaseLabel} Linux Host Smoke
 
 ## Context
 

--- a/scripts/workspace/operator-dry-run.mjs
+++ b/scripts/workspace/operator-dry-run.mjs
@@ -1,8 +1,9 @@
 import path from 'node:path'
-import { formatDate, formatDateTime, optionalFlag, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
+import { formatDate, formatDateTime, optionalFlag, resolveReleaseLabel, toJsonBlock, writeMarkdownReport } from '../production/shared.mjs'
 import { startOpenClawFleetHarness } from './fleet-shared.mjs'
 
-const outputPath = optionalFlag('--output', path.join(process.cwd(), 'reports/1.3.0-operator-dry-run.md'))
+const releaseLabel = resolveReleaseLabel()
+const outputPath = optionalFlag('--output', path.join(process.cwd(), `reports/${releaseLabel}-operator-dry-run.md`))
 
 async function main() {
   const fleet = await startOpenClawFleetHarness()
@@ -165,7 +166,7 @@ async function main() {
       },
     }
 
-    const markdown = `# Beam 1.3.0 Operator Dry Run
+    const markdown = `# Beam ${releaseLabel} Operator Dry Run
 
 ## Context
 


### PR DESCRIPTION
## Summary
- make the workspace drill and fleet smoke scripts release-aware so they can emit 1.4.0 artifacts cleanly
- commit 1.4.0 buyer/operator/fleet/digest/Linux reports plus the RC checklist and release notes draft
- bump the monorepo and docs package versions to 1.4.0 and add the changelog entry for the release cut

Closes #158
Closes #159