### PR TITLE
Add 1.5.0 OpenClaw fleet autonomy plan

### DIFF
--- a/reports/1.5.0-openclaw-fleet-autonomy-plan.md
+++ b/reports/1.5.0-openclaw-fleet-autonomy-plan.md
@@ -1,0 +1,214 @@
+# Beam 1.5.0 OpenClaw Fleet Autonomy Plan
+
+## Summary
+
+Beam `1.5.0` turns the OpenClaw fleet surface from a strong operations console into a safer day-2 automation layer. The goal is not another protocol expansion. The goal is to make a growing OpenClaw fleet easier to drain, roll out, reconcile, remediate, and review from one central Beam control plane.
+
+Release intent:
+
+- central Beam remains the single identity and policy authority
+- OpenClaw stays an external connector and host daemon, not a patched runtime
+- Beam IDs remain the only identity model
+- destructive fleet actions stay explicitly operator-approved
+- autonomy means safer automation around fleet state, not removing control
+
+## Release Theme
+
+`1.5.0` is the fleet-autonomy release:
+
+- safe maintenance and drain mode
+- connector rollout rings and version visibility
+- policy packs and workspace templates for fleet-backed identities
+- desired-state reconciliation and drift cleanup
+- guided auto-remediation for stale routes and missing receipts
+- recurring rollout and maintenance digests
+
+## Why This Is Next
+
+`1.4.0` made the OpenClaw fleet connector operable:
+
+- receipt and latency summaries
+- conflict remediation
+- host groups and bulk actions
+- digest scheduling
+- Linux parity
+- repeatable drill evidence
+
+What is still not “boring” is the day-2 loop:
+
+- planned maintenance still feels manual
+- connector rollouts are visible but not first-class
+- policy rollout across many workspaces is repetitive
+- stale route drift still relies too much on human follow-up
+- recurring fleet review still needs stronger opinionated defaults
+
+`1.5.0` fixes exactly that layer.
+
+## Workstreams
+
+### `#168` Add host maintenance mode, drain, and resume controls
+
+Ship explicit host lifecycle controls:
+
+- `active`
+- `draining`
+- `maintenance`
+- `revoked`
+
+Behavior:
+
+- a draining host stops taking new delivery while preserving visibility
+- existing route ownership stays visible and auditable
+- workspace and fleet UI show why delivery is blocked
+- resume returns the host to normal routing without re-enrollment
+
+Exit criteria:
+
+- operators can drain and resume a host from the fleet surface
+- delivery to a draining host is blocked with a clear operator-visible reason
+- host status changes appear in audit and digest output
+
+### `#169` Add connector version inventory, rollout rings, and canary visibility
+
+Promote connector rollout to a first-class fleet concern.
+
+Capabilities:
+
+- record connector version per host
+- assign rollout ring per host group
+- mark hosts as `pinned`, `canary`, or `stable`
+- show upgrade lag and drift in the fleet summary
+
+Exit criteria:
+
+- operators can see which hosts are behind target connector version
+- canary/stable group state is visible in the dashboard
+- rollout status appears in recurring fleet digest output
+
+### `#170` Add policy packs and workspace templates for fleet-backed identities
+
+Reduce repeated policy setup when new hosts or workspaces come online.
+
+Capabilities:
+
+- reusable outbound/partner policy packs
+- reusable workspace templates for fleet-backed identities
+- host-group scoped defaults
+- visible template provenance in workspace and fleet UI
+
+Exit criteria:
+
+- a new fleet-backed workspace can inherit a pack/template instead of manual setup
+- operators can see whether a workspace is on the expected pack
+- drift between template and live policy is visible
+
+### `#171` Add guided auto-remediation for stale routes, missing receipts, and drift
+
+Turn recurring fleet issues into guided repair loops.
+
+Capabilities:
+
+- detect stale route state, missing receipts, and connector drift
+- generate recommended next actions
+- allow one-click safe remediation when the action is reversible
+- require explicit confirmation for destructive repair
+
+Exit criteria:
+
+- stale routes and missing receipts produce actionable remediation entries
+- the fleet surface clearly separates “suggested” from “applied”
+- remediation history is auditable
+
+### `#172` Add desired-state reconciliation and stale route garbage collection
+
+Beam should reconcile fleet intent and observed host state.
+
+Capabilities:
+
+- desired-state record for host routes and templates
+- reconciliation status per host
+- cleanup of ended or orphaned route state
+- clear classification for `live`, `stale`, `orphaned`, and `conflict`
+
+Exit criteria:
+
+- route drift is summarized by host and fleet
+- ended subagents no longer linger as deliverable routes
+- reconciliation can restore the fleet view to a correct steady state
+
+### `#173` Add recurring rollout and maintenance digests
+
+Expand recurring fleet review beyond generic digesting.
+
+Digest focus:
+
+- draining or maintenance hosts
+- connector version lag
+- unresolved drift and stale routes
+- failed or skipped remediations
+- outstanding template drift
+
+Exit criteria:
+
+- an operator can run one daily fleet review loop and see all unresolved exceptions
+- every digest entry links to host, workspace, or trace context
+- no major fleet exception class is only visible in a detail page
+
+### `#174` Run 1.5.0 autonomy dry runs
+
+Commit fresh evidence for:
+
+- buyer-like host onboarding and workspace template path
+- operator maintenance, drain, canary rollout, and reconciliation path
+- fleet drill with drift, stale routes, and remediation flow
+
+Required reports:
+
+- `reports/1.5.0-buyer-dry-run.md`
+- `reports/1.5.0-operator-dry-run.md`
+- `reports/1.5.0-fleet-drill.md`
+
+### `#175` Prepare 1.5.0 cut checklist, release notes, and go/no-go gates
+
+Ship only when the fleet-autonomy layer is boring enough to trust.
+
+Required proof:
+
+- maintenance/drain/resume works
+- connector rollout rings and lag views are real
+- policy packs/templates apply cleanly
+- stale route drift is detected and reconciled
+- remediation entries are actionable and auditable
+- recurring digests cover rollout and maintenance state
+- buyer/operator/fleet evidence is committed
+- final release smoke proves API, docs, public status, npm, and fleet APIs
+
+## Acceptance Criteria
+
+- at least three approved hosts are visible in one central fleet view
+- each host reports connector version, health, and reconciliation state
+- one host can be drained and resumed without losing control-plane state
+- one canary rollout path is visible across host groups
+- one stale-route or drift condition is detected and then reconciled
+- one remediation suggestion is generated and applied with audit trail
+- buyer/operator/fleet dry runs are committed under `reports/`
+- final release smoke proves the live `1.5.0` cut
+
+## Explicit Non-Goals
+
+- no free-form custom DID editor
+- no OpenClaw core patching
+- no generic connector marketplace
+- no new protocol-family headline feature
+- no Slack-style collab surface
+
+## Proposed GitHub Breakdown
+
+- `#168` host maintenance mode, drain, and resume controls
+- `#169` connector version inventory, rollout rings, and canary visibility
+- `#170` policy packs and workspace templates for fleet-backed identities
+- `#171` guided auto-remediation for stale routes, missing receipts, and drift
+- `#172` desired-state reconciliation and stale route garbage collection
+- `#173` recurring rollout and maintenance digests
+- `#174` `1.5.0` buyer/operator/fleet dry runs
+- `#175` `1.5.0` RC checklist, release notes, and go/no-go gates


### PR DESCRIPTION
## Summary
- add the post-1.4.0 1.5.0 fleet autonomy plan report
- close the 1.4.0 milestone and open the 1.5.0 milestone with start issues
- keep the next track focused on maintenance, rollout, reconciliation, and remediation
