### PR TITLE
Add fleet maintenance and rollout controls

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -191,6 +191,7 @@ The fleet surface also gives operators explicit day-2 actions:
 
 - rotate host credentials without reinstalling the whole host
 - recover or replace a revoked or lost host with a new credential cutover
+- place a host into maintenance mode or drain it before planned work, then resume it explicitly when Beam delivery is safe again
 - prefer, disable, or reset route ownership when duplicate Beam identities appear
 - open a guided remediation view for one duplicated Beam ID, keep the recommended owner route, and optionally disable the competing routes in one step
 - deliver a fleet digest that calls out stale hosts, pending credential work, duplicate conflicts, and missing receipts
@@ -200,6 +201,8 @@ The fleet surface also gives operators explicit day-2 actions:
 - complete recovery cleanup after a successful cutover so the host drops back into the normal credential review loop
 - inspect a route-health and SLO summary that rolls up missing receipts, failed receipts, latency buckets, and the exact hosts currently degrading fleet delivery
 - label hosts with environment and group metadata such as `prod`, `staging`, `lab`, `edge`, or team ownership
+- track connector rollout rings (`stable`, `canary`, `pinned`), desired connector versions, and drift directly on each host
+- inspect one fleet-wide rollout inventory that shows version buckets, canary coverage, pinned hosts, and drift attention before a connector rollout spreads
 - stage guarded bulk actions across multiple hosts before a real revoke, with an explicit confirm phrase
 - clear staged revoke reviews again when a maintenance plan changes
 
@@ -207,6 +210,8 @@ The host detail and fleet summary now also expose the operational thresholds beh
 
 - credential rotation interval, next due time, and the next allowed rotation window
 - recovery owner, replacement host label, cutover window notes, and a cleanup-ready state after recovery completes
+- maintenance owner, maintenance reason, maintenance start time, and whether Beam delivery is intentionally blocked for that host
+- the connector rollout ring, desired connector version, and whether the currently reported connector version has drifted
 - receipt coverage across active routes
 - p50 / p95 latency, SLO bucket counts, and direct links back to the host, workspace, and latest trace that caused the warning
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -28,6 +28,9 @@ export type WorkspacePolicyRuleExternalInitiation = 'inherit' | 'allow' | 'deny'
 export type OpenClawHostStatus = 'pending' | 'active' | 'revoked'
 export type OpenClawHostHealth = 'pending' | 'healthy' | 'watch' | 'stale' | 'revoked'
 export type OpenClawHostCredentialState = 'missing' | 'ready' | 'rotation_pending' | 'recovery_pending' | 'revoked'
+export type OpenClawHostMaintenanceState = 'serving' | 'maintenance' | 'draining'
+export type OpenClawHostRolloutRing = 'canary' | 'stable' | 'pinned'
+export type OpenClawHostRolloutVersionState = 'unmanaged' | 'current' | 'drifted'
 export type OpenClawHostEnrollmentStatus = 'issued' | 'pending' | 'approved' | 'revoked' | 'expired'
 export type OpenClawRouteSource = 'agent-folder' | 'workspace-agent' | 'gateway-agent' | 'subagent-run'
 export type OpenClawRouteReportedState = 'live' | 'idle' | 'ended'
@@ -369,6 +372,22 @@ export interface OpenClawHostSummary {
     revokeReviewRequestedBy: string | null
     revokeReviewReason: string | null
   }
+  maintenance: {
+    state: OpenClawHostMaintenanceState
+    owner: string | null
+    reason: string | null
+    startedAt: string | null
+    updatedAt: string | null
+    deliveryBlocked: boolean
+  }
+  rollout: {
+    ring: OpenClawHostRolloutRing
+    desiredConnectorVersion: string | null
+    notes: string | null
+    updatedAt: string | null
+    versionState: OpenClawHostRolloutVersionState
+    canary: boolean
+  }
   enrollment: OpenClawEnrollmentRequest | null
   summary: {
     total: number
@@ -574,6 +593,66 @@ export interface OpenClawFleetOverviewResponse {
       traceHref: string | null
     }>
   }
+  maintenance: {
+    counts: {
+      maintenance: number
+      draining: number
+      blocked: number
+    }
+    attentionHosts: Array<{
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      healthStatus: OpenClawHostHealth
+      state: OpenClawHostMaintenanceState
+      owner: string | null
+      reason: string | null
+      startedAt: string | null
+      reasons: string[]
+      severity: 'warning' | 'critical'
+      href: string
+      workspaceHref: string | null
+    }>
+  }
+  rollout: {
+    summary: {
+      versions: number
+      canaryHosts: number
+      driftHosts: number
+      unmanagedHosts: number
+    }
+    versions: Array<{
+      version: string
+      hostCount: number
+      canaryHosts: number
+      staleHosts: number
+      driftHosts: number
+      rings: OpenClawHostRolloutRing[]
+      hostIds: number[]
+    }>
+    rings: Array<{
+      ring: OpenClawHostRolloutRing
+      hostCount: number
+      canaryHosts: number
+      driftHosts: number
+      versions: string[]
+      hostIds: number[]
+    }>
+    attentionHosts: Array<{
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      healthStatus: OpenClawHostHealth
+      ring: OpenClawHostRolloutRing
+      connectorVersion: string
+      desiredConnectorVersion: string | null
+      versionState: OpenClawHostRolloutVersionState
+      reasons: string[]
+      severity: 'warning' | 'critical'
+      href: string
+      workspaceHref: string | null
+    }>
+  }
   hosts: OpenClawHostSummary[]
   conflicts: OpenClawConflictGroup[]
   environments: OpenClawFleetEnvironmentSummary[]
@@ -776,6 +855,11 @@ export interface OpenClawHostProfilePatchInput {
   clearRevokeReview?: boolean
 }
 
+export interface OpenClawHostMaintenanceActionInput {
+  owner?: string | null
+  reason?: string | null
+}
+
 export interface OpenClawFleetBulkActionInput {
   action: OpenClawFleetBulkAction
   hostIds: number[]
@@ -815,6 +899,12 @@ export interface OpenClawHostPolicyPatchInput {
   replacementHostLabel?: string | null
   recoveryWindowStartsAt?: string | null
   recoveryWindowEndsAt?: string | null
+}
+
+export interface OpenClawHostRolloutPatchInput {
+  ring?: OpenClawHostRolloutRing | null
+  desiredConnectorVersion?: string | null
+  notes?: string | null
 }
 
 export interface OpenClawHostPolicyActionResponse {
@@ -2609,6 +2699,17 @@ export const directoryApi = {
     method: 'PATCH',
     body: JSON.stringify(input),
   }, { admin: true }),
+  enableOpenClawHostMaintenance: (id: number, input?: OpenClawHostMaintenanceActionInput) => request<{ host: OpenClawHostSummary }>(`/admin/openclaw/hosts/${id}/maintenance`, {
+    method: 'POST',
+    body: JSON.stringify(input ?? {}),
+  }, { admin: true }),
+  drainOpenClawHost: (id: number, input?: OpenClawHostMaintenanceActionInput) => request<{ host: OpenClawHostSummary }>(`/admin/openclaw/hosts/${id}/drain`, {
+    method: 'POST',
+    body: JSON.stringify(input ?? {}),
+  }, { admin: true }),
+  resumeOpenClawHost: (id: number) => request<{ host: OpenClawHostSummary }>(`/admin/openclaw/hosts/${id}/resume`, {
+    method: 'POST',
+  }, { admin: true }),
   runOpenClawFleetBulkAction: (input: OpenClawFleetBulkActionInput) => request<OpenClawFleetBulkActionResponse>('/admin/openclaw/fleet/bulk-actions', {
     method: 'POST',
     body: JSON.stringify(input),
@@ -2630,6 +2731,10 @@ export const directoryApi = {
     method: 'POST',
   }, { admin: true }),
   updateOpenClawHostPolicy: (id: number, input: OpenClawHostPolicyPatchInput) => request<OpenClawHostPolicyActionResponse>(`/admin/openclaw/hosts/${id}/policy`, {
+    method: 'PATCH',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  updateOpenClawHostRollout: (id: number, input: OpenClawHostRolloutPatchInput) => request<{ host: OpenClawHostSummary }>(`/admin/openclaw/hosts/${id}/rollout`, {
     method: 'PATCH',
     body: JSON.stringify(input),
   }, { admin: true }),

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -20,9 +20,11 @@ import {
   type OpenClawHostSummary,
   type OpenClawHostStatus,
   type OpenClawHostCredentialState,
+  type OpenClawHostMaintenanceState,
   type OpenClawHostProfilePatchInput,
   type OpenClawHostPolicyPatchInput,
   type OpenClawHostRecoveryRunbookState,
+  type OpenClawHostRolloutRing,
   type OpenClawRouteRuntimeState,
   type OpenClawRouteOwnerResolutionState,
   type OpenClawRouteSource,
@@ -83,6 +85,32 @@ function credentialStateTone(status: OpenClawHostCredentialState): 'default' | '
       return 'warning'
     case 'revoked':
       return 'critical'
+    default:
+      return 'default'
+  }
+}
+
+function maintenanceStateTone(status: OpenClawHostMaintenanceState): 'default' | 'warning' | 'critical' | 'success' {
+  switch (status) {
+    case 'serving':
+      return 'success'
+    case 'maintenance':
+      return 'warning'
+    case 'draining':
+      return 'critical'
+    default:
+      return 'default'
+  }
+}
+
+function rolloutRingTone(ring: OpenClawHostRolloutRing): 'default' | 'warning' | 'critical' | 'success' {
+  switch (ring) {
+    case 'canary':
+      return 'warning'
+    case 'pinned':
+      return 'critical'
+    case 'stable':
+      return 'success'
     default:
       return 'default'
   }
@@ -209,6 +237,17 @@ type HostPlacementFormState = {
   owner: string
 }
 
+type HostMaintenanceFormState = {
+  owner: string
+  reason: string
+}
+
+type HostRolloutFormState = {
+  ring: OpenClawHostRolloutRing
+  desiredConnectorVersion: string
+  notes: string
+}
+
 type DigestScheduleFormState = {
   enabled: boolean
   deliveryEmail: string
@@ -268,6 +307,15 @@ export default function OpenClawFleetPage() {
     environmentLabel: '',
     groupLabels: '',
     owner: '',
+  })
+  const [maintenanceForm, setMaintenanceForm] = useState<HostMaintenanceFormState>({
+    owner: '',
+    reason: '',
+  })
+  const [rolloutForm, setRolloutForm] = useState<HostRolloutFormState>({
+    ring: 'stable',
+    desiredConnectorVersion: '',
+    notes: '',
   })
   const [digestScheduleForm, setDigestScheduleForm] = useState<DigestScheduleFormState>({
     enabled: true,
@@ -478,6 +526,15 @@ export default function OpenClawFleetPage() {
       groupLabels: hostGroupLabels(selectedHost).join(', '),
       owner: selectedHost.placement.owner ?? '',
     })
+    setMaintenanceForm({
+      owner: selectedHost.maintenance.owner ?? '',
+      reason: selectedHost.maintenance.reason ?? '',
+    })
+    setRolloutForm({
+      ring: selectedHost.rollout.ring,
+      desiredConnectorVersion: selectedHost.rollout.desiredConnectorVersion ?? '',
+      notes: selectedHost.rollout.notes ?? '',
+    })
   }, [selectedHost?.id, selectedHost?.updatedAt])
 
   useEffect(() => {
@@ -641,6 +698,44 @@ export default function OpenClawFleetPage() {
       await Promise.all([loadOverview(), loadDigest()])
       await loadHost(host.id)
     }, `Policy for ${hostTitle(host)} updated.`)
+  }
+
+  async function handleEnterMaintenance(host: OpenClawHostSummary) {
+    await runAction(`maintenance-${host.id}`, async () => {
+      await directoryApi.enableOpenClawHostMaintenance(host.id, {
+        owner: maintenanceForm.owner.trim() || null,
+        reason: maintenanceForm.reason.trim() || null,
+      })
+      await refreshAll(host.id, selectedConflictBeamId)
+    }, `Maintenance enabled for ${hostTitle(host)}.`)
+  }
+
+  async function handleDrainHost(host: OpenClawHostSummary) {
+    await runAction(`drain-${host.id}`, async () => {
+      await directoryApi.drainOpenClawHost(host.id, {
+        owner: maintenanceForm.owner.trim() || null,
+        reason: maintenanceForm.reason.trim() || null,
+      })
+      await refreshAll(host.id, selectedConflictBeamId)
+    }, `Drain started for ${hostTitle(host)}.`)
+  }
+
+  async function handleResumeHost(host: OpenClawHostSummary) {
+    await runAction(`resume-${host.id}`, async () => {
+      await directoryApi.resumeOpenClawHost(host.id)
+      await refreshAll(host.id, selectedConflictBeamId)
+    }, `${hostTitle(host)} resumed.`)
+  }
+
+  async function handleSaveRollout(host: OpenClawHostSummary) {
+    await runAction(`rollout-${host.id}`, async () => {
+      await directoryApi.updateOpenClawHostRollout(host.id, {
+        ring: rolloutForm.ring,
+        desiredConnectorVersion: rolloutForm.desiredConnectorVersion.trim() || null,
+        notes: rolloutForm.notes.trim() || null,
+      })
+      await refreshAll(host.id, selectedConflictBeamId)
+    }, `Rollout settings updated for ${hostTitle(host)}.`)
   }
 
   async function handleRevoke(host: OpenClawHostSummary) {
@@ -815,6 +910,7 @@ export default function OpenClawFleetPage() {
         <MetricCard label="Live routes" value={!overview ? '—' : formatNumber(overview.summary.liveRoutes)} tone={(overview?.summary.liveRoutes ?? 0) > 0 ? 'success' : 'default'} />
         <MetricCard label="Receipt coverage" value={!overview ? '—' : formatPercent(overview.summary.receiptCoverageRatio)} tone={(overview?.summary.receiptCoverageRatio ?? 1) < 0.8 ? 'warning' : 'success'} />
         <MetricCard label="Latency watch" value={!overview ? '—' : formatNumber(overview.summary.degradedHosts)} tone={(overview?.summary.degradedHosts ?? 0) > 0 ? 'warning' : 'default'} />
+        <MetricCard label="Maint. blocked" value={!overview ? '—' : formatNumber(overview.maintenance.counts.blocked)} tone={(overview?.maintenance.counts.blocked ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Rotation due" value={!overview ? '—' : formatNumber(overview.summary.rotationDueHosts)} tone={(overview?.summary.rotationDueHosts ?? 0) > 0 ? 'warning' : 'default'} />
         <MetricCard label="Duplicate conflicts" value={!overview ? '—' : formatNumber(overview.summary.duplicateIdentityConflicts)} tone={(overview?.summary.duplicateIdentityConflicts ?? 0) > 0 ? 'critical' : 'default'} />
       </section>
@@ -1644,6 +1740,13 @@ export default function OpenClawFleetPage() {
                       {host.placement.revokeReviewRequestedAt ? (
                         <StatusPill label="revoke review" tone="warning" />
                       ) : null}
+                      {host.maintenance.state !== 'serving' ? (
+                        <StatusPill label={host.maintenance.state} tone={maintenanceStateTone(host.maintenance.state)} />
+                      ) : null}
+                      <StatusPill label={`ring:${host.rollout.ring}`} tone={rolloutRingTone(host.rollout.ring)} />
+                      {host.rollout.versionState === 'drifted' ? (
+                        <StatusPill label="rollout drift" tone="warning" />
+                      ) : null}
                       {host.policy.rotation.windowOpen ? (
                         <StatusPill label="rotation window open" tone="warning" />
                       ) : null}
@@ -1661,6 +1764,8 @@ export default function OpenClawFleetPage() {
                       <div>{host.approvedAt ? `Approved ${formatRelativeTime(host.approvedAt)}` : 'Waiting for approval'}</div>
                       <div>{host.revokedAt ? `Revoked ${formatRelativeTime(host.revokedAt)}` : 'Credential active or pending'}</div>
                       <div>{host.credentialIssuedAt ? `Credential age ${host.credentialAgeHours ?? 0}h` : 'No credential issued yet'}</div>
+                      <div>{host.maintenance.state === 'serving' ? 'Serving traffic' : `${host.maintenance.state} · ${host.maintenance.owner ?? 'no owner'}${host.maintenance.reason ? ` · ${host.maintenance.reason}` : ''}`}</div>
+                      <div>{host.rollout.desiredConnectorVersion ? `Rollout ${host.rollout.ring} · want ${host.rollout.desiredConnectorVersion} · ${host.rollout.versionState}` : `Rollout ${host.rollout.ring} · ${host.rollout.versionState}`}</div>
                       <div>{host.policy.rotation.nextRotationDueAt ? `Rotation ${host.policy.rotation.reviewState === 'overdue' ? 'overdue' : 'due'} ${formatRelativeTime(host.policy.rotation.nextRotationDueAt)}` : 'No rotation schedule yet'}</div>
                       <div>{host.summary.delivery.latency.samples > 0 ? `p95 ${formatLatency(host.summary.delivery.latency.p95Ms)} · ${formatNumber(host.summary.delivery.latency.overSlo)} breach` : 'No latency samples yet'}</div>
                       <div>{host.policy.recovery.status !== 'idle' ? `Recovery ${host.policy.recovery.status}${host.policy.recovery.owner ? ` · ${host.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
@@ -1705,6 +1810,45 @@ export default function OpenClawFleetPage() {
                           }}
                         >
                           {actionBusy === `rotate-${host.id}` ? 'Rotating…' : 'Rotate credential'}
+                        </button>
+                      ) : null}
+                      {host.status === 'active' && host.maintenance.state === 'serving' ? (
+                        <>
+                          <button
+                            type="button"
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            disabled={actionBusy === `maintenance-${host.id}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleEnterMaintenance(host)
+                            }}
+                          >
+                            {actionBusy === `maintenance-${host.id}` ? 'Applying…' : 'Enter maintenance'}
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                            disabled={actionBusy === `drain-${host.id}`}
+                            onClick={(event) => {
+                              event.stopPropagation()
+                              void handleDrainHost(host)
+                            }}
+                          >
+                            {actionBusy === `drain-${host.id}` ? 'Draining…' : 'Drain host'}
+                          </button>
+                        </>
+                      ) : null}
+                      {host.maintenance.state !== 'serving' ? (
+                        <button
+                          type="button"
+                          className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={actionBusy === `resume-${host.id}`}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            void handleResumeHost(host)
+                          }}
+                        >
+                          {actionBusy === `resume-${host.id}` ? 'Resuming…' : 'Resume host'}
                         </button>
                       ) : null}
                       {host.status === 'revoked' || host.healthStatus === 'stale' ? (
@@ -2163,6 +2307,162 @@ export default function OpenClawFleetPage() {
         </div>
       </section>
 
+      <section className="grid gap-6 xl:grid-cols-2">
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Maintenance</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Hosts intentionally blocked for maintenance or drain. Beam delivery is blocked until the host resumes serving.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.maintenance.attentionHosts.length)} hosts` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <MetricCard label="Maintenance" value={!overview ? '—' : formatNumber(overview.maintenance.counts.maintenance)} tone={(overview?.maintenance.counts.maintenance ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Draining" value={!overview ? '—' : formatNumber(overview.maintenance.counts.draining)} tone={(overview?.maintenance.counts.draining ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Blocked delivery" value={!overview ? '—' : formatNumber(overview.maintenance.counts.blocked)} tone={(overview?.maintenance.counts.blocked ?? 0) > 0 ? 'warning' : 'default'} />
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.maintenance.attentionHosts.length > 0 ? (
+              overview.maintenance.attentionHosts.map((item) => (
+                <div key={`maintenance-${item.hostId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.hostLabel || `Host ${item.hostId}`}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                        {item.reason || 'No operator reason recorded'}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <StatusPill label={item.state} tone={maintenanceStateTone(item.state)} />
+                      {item.state !== 'serving' ? <StatusPill label="delivery blocked" tone="warning" /> : null}
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                    <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace default'}</div>
+                    <div>{item.owner ? `Owner ${item.owner}` : 'No maintenance owner assigned'}</div>
+                    <div>{item.startedAt ? `Started ${formatRelativeTime(item.startedAt)}` : 'No start time recorded'}</div>
+                    <div>{item.state !== 'serving' ? 'Outbound Beam delivery is blocked' : 'No delivery block recorded'}</div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => focusHost(item.hostId)}
+                    >
+                      Open host
+                    </button>
+                    {item.workspaceHref ? (
+                      <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.workspaceHref}>
+                        Open workspace
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyPanel label="No hosts are currently in maintenance or drain." />
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Connector rollout</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Version inventory, rollout rings, and canary/drift visibility across the approved host fleet.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.rollout.summary.versions)} versions` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-3 xl:grid-cols-6">
+            <MetricCard label="Hosts" value={!overview ? '—' : formatNumber(overview.hosts.length)} />
+            <MetricCard label="Canary" value={!overview ? '—' : formatNumber(overview.rollout.summary.canaryHosts)} tone={(overview?.rollout.summary.canaryHosts ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Pinned" value={!overview ? '—' : formatNumber(overview.rollout.rings.find((ring) => ring.ring === 'pinned')?.hostCount ?? 0)} tone={(overview?.rollout.rings.find((ring) => ring.ring === 'pinned')?.hostCount ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Drift" value={!overview ? '—' : formatNumber(overview.rollout.summary.driftHosts)} tone={(overview?.rollout.summary.driftHosts ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Unmanaged" value={!overview ? '—' : formatNumber(overview.rollout.summary.unmanagedHosts)} tone={(overview?.rollout.summary.unmanagedHosts ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Versions" value={!overview ? '—' : formatNumber(overview.rollout.summary.versions)} />
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Version inventory</div>
+              <div className="mt-3 space-y-3">
+                {overview && overview.rollout.versions.length > 0 ? overview.rollout.versions.map((item) => (
+                  <div key={`version-${item.version}`} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                    <div className="font-medium text-slate-900 dark:text-slate-100">{item.version}</div>
+                    <div className="mt-1">{`${formatNumber(item.hostCount)} hosts · ${formatNumber(item.canaryHosts)} canary · ${formatNumber(item.driftHosts)} drifted · ${formatNumber(item.staleHosts)} stale`}</div>
+                  </div>
+                )) : <EmptyPanel label="No rollout versions recorded yet." />}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Rollout rings</div>
+              <div className="mt-3 space-y-3">
+                {overview && overview.rollout.rings.length > 0 ? overview.rollout.rings.map((item) => (
+                  <div key={`ring-${item.ring}`} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                    <div className="flex items-center gap-2">
+                      <StatusPill label={item.ring} tone={rolloutRingTone(item.ring)} />
+                      <span>{`${formatNumber(item.hostCount)} hosts`}</span>
+                    </div>
+                    <div className="mt-1">{`${formatNumber(item.canaryHosts)} canary · ${formatNumber(item.driftHosts)} drifted · ${formatNumber(item.versions.length)} versions`}</div>
+                  </div>
+                )) : <EmptyPanel label="No rollout ring data recorded yet." />}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.rollout.attentionHosts.length > 0 ? (
+              overview.rollout.attentionHosts.map((item) => (
+                <div key={`rollout-${item.hostId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.hostLabel || `Host ${item.hostId}`}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.reasons.join(' · ')}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <StatusPill label={item.ring} tone={rolloutRingTone(item.ring)} />
+                      <StatusPill label={item.versionState} tone={item.versionState === 'drifted' ? 'warning' : item.versionState === 'current' ? 'success' : 'default'} />
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                    <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace default'}</div>
+                    <div>{`Current ${item.connectorVersion}${item.desiredConnectorVersion ? ` · desired ${item.desiredConnectorVersion}` : ''}`}</div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      onClick={() => focusHost(item.hostId)}
+                    >
+                      Open host
+                    </button>
+                    {item.workspaceHref ? (
+                      <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.workspaceHref}>
+                        Open workspace
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyPanel label="No rollout drift or canary attention hosts." />
+            )}
+          </div>
+        </div>
+      </section>
+
       <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
         <div className="panel">
           <div className="flex items-start justify-between gap-3">
@@ -2194,6 +2494,11 @@ export default function OpenClawFleetPage() {
                   {hostGroupLabels(selectedHost).map((group) => (
                     <StatusPill key={`${selectedHost.id}-${group}`} label={`group:${group}`} />
                   ))}
+                  <StatusPill label={selectedHost.maintenance.state} tone={maintenanceStateTone(selectedHost.maintenance.state)} />
+                  <StatusPill label={`ring:${selectedHost.rollout.ring}`} tone={rolloutRingTone(selectedHost.rollout.ring)} />
+                  {selectedHost.rollout.versionState === 'drifted' ? (
+                    <StatusPill label="rollout drift" tone="warning" />
+                  ) : null}
                   {selectedHost.placement.revokeReviewRequestedAt ? (
                     <StatusPill label="revoke review" tone="warning" />
                   ) : null}
@@ -2213,6 +2518,10 @@ export default function OpenClawFleetPage() {
                   <div>{selectedHost.policy.rotation.windowOpen ? 'Rotation window is open now' : selectedHost.policy.rotation.nextRotationWindowStartsAt ? `Rotation window ${formatDateTime(selectedHost.policy.rotation.nextRotationWindowStartsAt)}` : 'No rotation window scheduled'}</div>
                   <div>{selectedHost.policy.recovery.status !== 'idle' ? `Recovery ${selectedHost.policy.recovery.status}${selectedHost.policy.recovery.owner ? ` · ${selectedHost.policy.recovery.owner}` : ''}` : 'Recovery runbook idle'}</div>
                   <div>{selectedHost.policy.recovery.cleanupRecommended ? 'Recovery cleanup ready' : 'No recovery cleanup pending'}</div>
+                  <div>{selectedHost.maintenance.state === 'serving' ? 'Host is serving traffic' : `${selectedHost.maintenance.state} since ${selectedHost.maintenance.startedAt ? formatRelativeTime(selectedHost.maintenance.startedAt) : 'unknown'}${selectedHost.maintenance.owner ? ` · ${selectedHost.maintenance.owner}` : ''}`}</div>
+                  <div>{selectedHost.maintenance.deliveryBlocked ? 'Beam delivery is blocked by host maintenance state' : 'No maintenance delivery block active'}</div>
+                  <div>{selectedHost.rollout.desiredConnectorVersion ? `Desired connector ${selectedHost.rollout.desiredConnectorVersion}` : 'No desired connector version pinned'}</div>
+                  <div>{`Connector ${selectedHost.connectorVersion} · rollout ${selectedHost.rollout.versionState}`}</div>
                 </div>
               </div>
 
@@ -2432,6 +2741,148 @@ export default function OpenClawFleetPage() {
                       {actionBusy === `cleanup-${selectedHost.id}` ? 'Cleaning…' : 'Complete recovery cleanup'}
                     </button>
                   ) : null}
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Maintenance and drain</div>
+                    <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      Pause or drain one host intentionally. Beam blocks outbound delivery for maintenance and drain until the host resumes serving.
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusPill label={selectedHost.maintenance.state} tone={maintenanceStateTone(selectedHost.maintenance.state)} />
+                    {selectedHost.maintenance.deliveryBlocked ? <StatusPill label="delivery blocked" tone="warning" /> : null}
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Maintenance owner</span>
+                    <input
+                      className="input-field"
+                      placeholder="ops@example.com"
+                      value={maintenanceForm.owner}
+                      onChange={(event) => setMaintenanceForm((current) => ({ ...current, owner: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400 md:col-span-2">
+                    <span>Reason</span>
+                    <textarea
+                      className="input-field min-h-[96px]"
+                      placeholder="Kernel update, host migration, connector canary rollback..."
+                      value={maintenanceForm.reason}
+                      onChange={(event) => setMaintenanceForm((current) => ({ ...current, reason: event.target.value }))}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                  <div>{selectedHost.maintenance.startedAt ? `Started ${formatDateTime(selectedHost.maintenance.startedAt)}` : 'No maintenance window recorded'}</div>
+                  <div>{selectedHost.maintenance.updatedAt ? `Last updated ${formatDateTime(selectedHost.maintenance.updatedAt)}` : 'No maintenance updates yet'}</div>
+                  <div>{selectedHost.maintenance.owner ? `Owner ${selectedHost.maintenance.owner}` : 'No maintenance owner assigned'}</div>
+                  <div>{selectedHost.maintenance.reason ? `Reason: ${selectedHost.maintenance.reason}` : 'No maintenance reason recorded'}</div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {selectedHost.status === 'active' && selectedHost.maintenance.state === 'serving' ? (
+                    <>
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        disabled={actionBusy === `maintenance-${selectedHost.id}`}
+                        onClick={() => { void handleEnterMaintenance(selectedHost) }}
+                      >
+                        {actionBusy === `maintenance-${selectedHost.id}` ? 'Applying…' : 'Enter maintenance'}
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        disabled={actionBusy === `drain-${selectedHost.id}`}
+                        onClick={() => { void handleDrainHost(selectedHost) }}
+                      >
+                        {actionBusy === `drain-${selectedHost.id}` ? 'Draining…' : 'Drain host'}
+                      </button>
+                    </>
+                  ) : null}
+                  {selectedHost.maintenance.state !== 'serving' ? (
+                    <button
+                      type="button"
+                      className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                      disabled={actionBusy === `resume-${selectedHost.id}`}
+                      onClick={() => { void handleResumeHost(selectedHost) }}
+                    >
+                      {actionBusy === `resume-${selectedHost.id}` ? 'Resuming…' : 'Resume host'}
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Connector rollout</div>
+                    <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                      Track rollout rings, desired connector version, and version drift without leaving the fleet surface.
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <StatusPill label={`ring:${selectedHost.rollout.ring}`} tone={rolloutRingTone(selectedHost.rollout.ring)} />
+                    <StatusPill label={selectedHost.rollout.versionState} tone={selectedHost.rollout.versionState === 'drifted' ? 'warning' : selectedHost.rollout.versionState === 'current' ? 'success' : 'default'} />
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 md:grid-cols-3">
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400">
+                    <span>Rollout ring</span>
+                    <select
+                      className="input-field"
+                      value={rolloutForm.ring}
+                      onChange={(event) => setRolloutForm((current) => ({ ...current, ring: event.target.value as OpenClawHostRolloutRing }))}
+                    >
+                      <option value="stable">stable</option>
+                      <option value="canary">canary</option>
+                      <option value="pinned">pinned</option>
+                    </select>
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400 md:col-span-2">
+                    <span>Desired connector version</span>
+                    <input
+                      className="input-field"
+                      placeholder="1.5.0"
+                      value={rolloutForm.desiredConnectorVersion}
+                      onChange={(event) => setRolloutForm((current) => ({ ...current, desiredConnectorVersion: event.target.value }))}
+                    />
+                  </label>
+                  <label className="space-y-1 text-xs text-slate-500 dark:text-slate-400 md:col-span-3">
+                    <span>Notes</span>
+                    <textarea
+                      className="input-field min-h-[96px]"
+                      placeholder="Canary cohort, change ticket, rollout guardrails..."
+                      value={rolloutForm.notes}
+                      onChange={(event) => setRolloutForm((current) => ({ ...current, notes: event.target.value }))}
+                    />
+                  </label>
+                </div>
+
+                <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                  <div>{`Current connector ${selectedHost.connectorVersion}`}</div>
+                  <div>{selectedHost.rollout.updatedAt ? `Last rollout update ${formatDateTime(selectedHost.rollout.updatedAt)}` : 'No rollout update yet'}</div>
+                  <div>{selectedHost.rollout.desiredConnectorVersion ? `Desired version ${selectedHost.rollout.desiredConnectorVersion}` : 'No desired version configured'}</div>
+                  <div>{selectedHost.rollout.canary ? 'Canary visibility enabled for this host' : 'Not marked as canary'}</div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                    disabled={actionBusy === `rollout-${selectedHost.id}`}
+                    onClick={() => { void handleSaveRollout(selectedHost) }}
+                  >
+                    {actionBusy === `rollout-${selectedHost.id}` ? 'Saving…' : 'Save rollout'}
+                  </button>
                 </div>
               </div>
 

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -1627,6 +1627,124 @@ test('stale openclaw host routes block Beam delivery before transport dispatch',
   }
 })
 
+test('openclaw host maintenance and drain block delivery until resume', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const sender = createFixtureAgent('sender@openclaw.beam.directory')
+    const receiver = createFixtureAgent('maint@openclaw.beam.directory')
+    registerFixtureAgent(db, sender, 'Sender')
+    registerFixtureAgent(db, receiver, 'Maintenance Receiver')
+    createAcl(db, {
+      targetBeamId: receiver.beamId,
+      intentType: 'conversation.message',
+      allowedFrom: sender.beamId,
+    })
+
+    const host = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Maintenance',
+      hostname: 'maint.local',
+      beamId: receiver.beamId,
+      routeKey: 'maint-route',
+      workspaceSlug: 'openclaw-local',
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    const maintenanceResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}/maintenance`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        owner: 'ops@example.com',
+        reason: 'kernel update',
+      }),
+    }))
+    assert.equal(maintenanceResponse.status, 200)
+    const maintenanceBody = await maintenanceResponse.json() as {
+      host: {
+        maintenance: {
+          state: string
+          owner: string | null
+          reason: string | null
+          deliveryBlocked: boolean
+        }
+      }
+    }
+    assert.equal(maintenanceBody.host.maintenance.state, 'maintenance')
+    assert.equal(maintenanceBody.host.maintenance.owner, 'ops@example.com')
+    assert.equal(maintenanceBody.host.maintenance.reason, 'kernel update')
+    assert.equal(maintenanceBody.host.maintenance.deliveryBlocked, true)
+
+    const maintenanceNonce = randomUUID()
+    await assert.rejects(
+      relayIntentFromHttp(db, createSignedConversationIntent(sender, receiver.beamId, maintenanceNonce), 250),
+      (error: unknown) => error instanceof RelayError && error.code === 'FORBIDDEN' && error.message.includes('maintenance mode'),
+    )
+    assert.equal(getIntentLogByNonce(db, maintenanceNonce)?.error_code, 'HOST_MAINTENANCE')
+
+    const drainResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}/drain`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        owner: 'ops@example.com',
+        reason: 'drain connections',
+      }),
+    }))
+    assert.equal(drainResponse.status, 200)
+    const drainBody = await drainResponse.json() as {
+      host: {
+        maintenance: {
+          state: string
+          reason: string | null
+        }
+      }
+    }
+    assert.equal(drainBody.host.maintenance.state, 'draining')
+    assert.equal(drainBody.host.maintenance.reason, 'drain connections')
+
+    const drainNonce = randomUUID()
+    await assert.rejects(
+      relayIntentFromHttp(db, createSignedConversationIntent(sender, receiver.beamId, drainNonce), 250),
+      (error: unknown) => error instanceof RelayError && error.code === 'FORBIDDEN' && error.message.includes('draining OpenClaw host'),
+    )
+    assert.equal(getIntentLogByNonce(db, drainNonce)?.error_code, 'HOST_DRAINING')
+
+    const resumeResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${host.host.id}/resume`, {
+      method: 'POST',
+      headers: createAdminHeaders(db, 'admin@example.com', 'admin'),
+    }))
+    assert.equal(resumeResponse.status, 200)
+    const resumeBody = await resumeResponse.json() as {
+      host: {
+        maintenance: {
+          state: string
+          reason: string | null
+          deliveryBlocked: boolean
+        }
+      }
+    }
+    assert.equal(resumeBody.host.maintenance.state, 'serving')
+    assert.equal(resumeBody.host.maintenance.reason, null)
+    assert.equal(resumeBody.host.maintenance.deliveryBlocked, false)
+
+    const resumedNonce = randomUUID()
+    await assert.rejects(
+      relayIntentFromHttp(db, createSignedConversationIntent(sender, receiver.beamId, resumedNonce), 250),
+      (error: unknown) => error instanceof RelayError && error.code !== 'FORBIDDEN',
+    )
+    const resumedLog = getIntentLogByNonce(db, resumedNonce)
+    assert.notEqual(resumedLog?.error_code, 'HOST_MAINTENANCE')
+    assert.notEqual(resumedLog?.error_code, 'HOST_DRAINING')
+  } finally {
+    db.close()
+  }
+})
+
 test('revoked openclaw host routes block Beam delivery immediately', async () => {
   const db = createDatabase(':memory:')
 
@@ -1803,6 +1921,159 @@ test('fleet digest summarizes stale hosts, duplicate conflicts, and failed deliv
       body: JSON.stringify({}),
     }))
     assert.equal(deliverUnavailable.status, 503)
+  } finally {
+    db.close()
+  }
+})
+
+test('fleet overview surfaces maintenance counts and rollout inventory', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    const alpha = createFixtureAgent('atlas@openclaw.beam.directory')
+    const beta = createFixtureAgent('bravo@openclaw.beam.directory')
+    const gamma = createFixtureAgent('charlie@openclaw.beam.directory')
+    registerFixtureAgent(db, alpha, 'Atlas')
+    registerFixtureAgent(db, beta, 'Bravo')
+    registerFixtureAgent(db, gamma, 'Charlie')
+
+    const hostAlpha = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Alpha',
+      hostname: 'alpha.local',
+      beamId: alpha.beamId,
+      routeKey: 'alpha-route',
+      workspaceSlug: 'openclaw-local',
+    })
+    const hostBravo = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Bravo',
+      hostname: 'bravo.local',
+      beamId: beta.beamId,
+      routeKey: 'bravo-route',
+      workspaceSlug: 'openclaw-local',
+    })
+    const hostCharlie = createApprovedHostWithRoute(db, {
+      label: 'OpenClaw Host Charlie',
+      hostname: 'charlie.local',
+      beamId: gamma.beamId,
+      routeKey: 'charlie-route',
+      workspaceSlug: 'openclaw-local',
+    })
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    const maintenanceResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${hostBravo.host.id}/maintenance`, {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        owner: 'ops@example.com',
+        reason: 'planned maintenance',
+      }),
+    }))
+    assert.equal(maintenanceResponse.status, 200)
+
+    const canaryResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${hostAlpha.host.id}/rollout`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        ring: 'canary',
+        desiredConnectorVersion: '1.2.0-test',
+        notes: 'canary cohort',
+      }),
+    }))
+    assert.equal(canaryResponse.status, 200)
+
+    const driftResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${hostCharlie.host.id}/rollout`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        ring: 'pinned',
+        desiredConnectorVersion: '9.9.9-test',
+        notes: 'hold back rollout',
+      }),
+    }))
+    assert.equal(driftResponse.status, 200)
+    const driftBody = await driftResponse.json() as {
+      host: {
+        rollout: {
+          ring: string
+          desiredConnectorVersion: string | null
+          versionState: string
+        }
+      }
+    }
+    assert.equal(driftBody.host.rollout.ring, 'pinned')
+    assert.equal(driftBody.host.rollout.desiredConnectorVersion, '9.9.9-test')
+    assert.equal(driftBody.host.rollout.versionState, 'drifted')
+
+    const overviewResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewResponse.status, 200)
+    const overviewBody = await overviewResponse.json() as {
+      maintenance: {
+        counts: {
+          maintenance: number
+          draining: number
+          blocked: number
+        }
+        attentionHosts: Array<{
+          hostId: number
+          state: string
+          reasons: string[]
+        }>
+      }
+      rollout: {
+        summary: {
+          versions: number
+          canaryHosts: number
+          driftHosts: number
+          unmanagedHosts: number
+        }
+        versions: Array<{
+          version: string
+          hostCount: number
+          canaryHosts: number
+          driftHosts: number
+        }>
+        rings: Array<{
+          ring: string
+          hostCount: number
+          canaryHosts: number
+          driftHosts: number
+        }>
+        attentionHosts: Array<{
+          hostId: number
+          ring: string
+          versionState: string
+          reasons: string[]
+        }>
+      }
+    }
+
+    assert.equal(overviewBody.maintenance.counts.maintenance, 1)
+    assert.equal(overviewBody.maintenance.counts.draining, 0)
+    assert.equal(overviewBody.maintenance.counts.blocked, 1)
+    assert.equal(overviewBody.maintenance.attentionHosts[0]?.hostId, hostBravo.host.id)
+    assert.equal(overviewBody.maintenance.attentionHosts[0]?.state, 'maintenance')
+    assert.ok(overviewBody.maintenance.attentionHosts[0]?.reasons.includes('planned maintenance'))
+
+    assert.equal(overviewBody.rollout.summary.versions, 1)
+    assert.equal(overviewBody.rollout.summary.canaryHosts, 1)
+    assert.equal(overviewBody.rollout.summary.driftHosts, 1)
+    assert.equal(overviewBody.rollout.summary.unmanagedHosts, 1)
+    assert.equal(overviewBody.rollout.versions[0]?.version, '1.2.0-test')
+    assert.equal(overviewBody.rollout.versions[0]?.hostCount, 3)
+    assert.equal(overviewBody.rollout.versions[0]?.canaryHosts, 1)
+    assert.equal(overviewBody.rollout.versions[0]?.driftHosts, 1)
+    assert.equal(overviewBody.rollout.rings.find((entry) => entry.ring === 'canary')?.hostCount, 1)
+    assert.equal(overviewBody.rollout.rings.find((entry) => entry.ring === 'pinned')?.hostCount, 1)
+    assert.equal(overviewBody.rollout.attentionHosts.find((entry) => entry.hostId === hostAlpha.host.id)?.ring, 'canary')
+    assert.equal(overviewBody.rollout.attentionHosts.find((entry) => entry.hostId === hostCharlie.host.id)?.versionState, 'drifted')
+    assert.ok(overviewBody.rollout.attentionHosts.find((entry) => entry.hostId === hostCharlie.host.id)?.reasons.some((reason) => reason.includes('expected 9.9.9-test')))
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -176,6 +176,12 @@ type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
 
 type OpenClawHostRecoveryRunbookState = 'idle' | 'prepared' | 'cutover_pending' | 'completed'
 
+type OpenClawHostMaintenanceState = 'serving' | 'maintenance' | 'draining'
+
+type OpenClawHostRolloutRing = 'canary' | 'stable' | 'pinned'
+
+type OpenClawHostRolloutVersionState = 'unmanaged' | 'current' | 'drifted'
+
 type OpenClawHostEnvironmentSummary = {
   label: string
   hostCount: number
@@ -278,6 +284,76 @@ type OpenClawFleetRouteHealthSummary = {
   attentionHosts: OpenClawFleetRouteHealthAttentionHost[]
 }
 
+type OpenClawFleetMaintenanceAttentionHost = {
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  healthStatus: OpenClawHostHealth
+  state: OpenClawHostMaintenanceState
+  owner: string | null
+  reason: string | null
+  startedAt: string | null
+  reasons: string[]
+  severity: OpenClawFleetDigestSeverity
+  href: string
+  workspaceHref: string | null
+}
+
+type OpenClawFleetMaintenanceSummary = {
+  counts: {
+    maintenance: number
+    draining: number
+    blocked: number
+  }
+  attentionHosts: OpenClawFleetMaintenanceAttentionHost[]
+}
+
+type OpenClawFleetRolloutAttentionHost = {
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  healthStatus: OpenClawHostHealth
+  ring: OpenClawHostRolloutRing
+  connectorVersion: string
+  desiredConnectorVersion: string | null
+  versionState: OpenClawHostRolloutVersionState
+  reasons: string[]
+  severity: OpenClawFleetDigestSeverity
+  href: string
+  workspaceHref: string | null
+}
+
+type OpenClawFleetConnectorVersionSummary = {
+  version: string
+  hostCount: number
+  canaryHosts: number
+  staleHosts: number
+  driftHosts: number
+  rings: OpenClawHostRolloutRing[]
+  hostIds: number[]
+}
+
+type OpenClawFleetRolloutRingSummary = {
+  ring: OpenClawHostRolloutRing
+  hostCount: number
+  canaryHosts: number
+  driftHosts: number
+  versions: string[]
+  hostIds: number[]
+}
+
+type OpenClawFleetRolloutSummary = {
+  summary: {
+    versions: number
+    canaryHosts: number
+    driftHosts: number
+    unmanagedHosts: number
+  }
+  versions: OpenClawFleetConnectorVersionSummary[]
+  rings: OpenClawFleetRolloutRingSummary[]
+  attentionHosts: OpenClawFleetRolloutAttentionHost[]
+}
+
 type OpenClawFleetBulkAction =
   | 'apply_labels'
   | 'stage_revoke_review'
@@ -305,6 +381,19 @@ type OpenClawHostMetadataJson = {
     revokeReviewRequestedAt?: string | null
     revokeReviewRequestedBy?: string | null
     revokeReviewReason?: string | null
+  }
+  maintenance?: {
+    state?: OpenClawHostMaintenanceState | null
+    owner?: string | null
+    reason?: string | null
+    startedAt?: string | null
+    updatedAt?: string | null
+  }
+  rollout?: {
+    ring?: OpenClawHostRolloutRing | null
+    desiredConnectorVersion?: string | null
+    notes?: string | null
+    updatedAt?: string | null
   }
 }
 
@@ -452,7 +541,13 @@ function serializeOpenClawHostMetadata(metadata: OpenClawHostMetadataJson): stri
   if (metadata.placement) {
     cleaned.placement = metadata.placement
   }
-  if (!cleaned.credentialPolicy && !cleaned.recoveryRunbook && !cleaned.placement) {
+  if (metadata.maintenance) {
+    cleaned.maintenance = metadata.maintenance
+  }
+  if (metadata.rollout) {
+    cleaned.rollout = metadata.rollout
+  }
+  if (!cleaned.credentialPolicy && !cleaned.recoveryRunbook && !cleaned.placement && !cleaned.maintenance && !cleaned.rollout) {
     return null
   }
   return JSON.stringify(cleaned)
@@ -623,6 +718,119 @@ function serializeOpenClawHostPlacement(host: OpenClawHostRow) {
     revokeReviewRequestedAt: normalizeIsoDateTime(placement.revokeReviewRequestedAt),
     revokeReviewRequestedBy: normalizeOptionalString(placement.revokeReviewRequestedBy),
     revokeReviewReason: normalizeOptionalString(placement.revokeReviewReason),
+  }
+}
+
+function normalizeOpenClawHostMaintenanceState(value: unknown): OpenClawHostMaintenanceState {
+  return value === 'maintenance' || value === 'draining' ? value : 'serving'
+}
+
+function normalizeOpenClawHostRolloutRing(value: unknown): OpenClawHostRolloutRing {
+  return value === 'canary' || value === 'pinned' ? value : 'stable'
+}
+
+function serializeOpenClawHostMaintenance(host: OpenClawHostRow) {
+  const metadata = parseOpenClawHostMetadata(host.metadata_json)
+  const maintenance = metadata.maintenance && typeof metadata.maintenance === 'object'
+    ? metadata.maintenance
+    : {}
+
+  const state = normalizeOpenClawHostMaintenanceState(maintenance.state)
+  return {
+    state,
+    owner: normalizeOptionalString(maintenance.owner),
+    reason: normalizeOptionalString(maintenance.reason),
+    startedAt: normalizeIsoDateTime(maintenance.startedAt),
+    updatedAt: normalizeIsoDateTime(maintenance.updatedAt),
+    deliveryBlocked: state !== 'serving',
+  }
+}
+
+function serializeOpenClawHostRollout(host: OpenClawHostRow) {
+  const metadata = parseOpenClawHostMetadata(host.metadata_json)
+  const rollout = metadata.rollout && typeof metadata.rollout === 'object'
+    ? metadata.rollout
+    : {}
+
+  const desiredConnectorVersion = normalizeOptionalString(rollout.desiredConnectorVersion)
+  const versionState: OpenClawHostRolloutVersionState = desiredConnectorVersion
+    ? (desiredConnectorVersion === host.connector_version ? 'current' : 'drifted')
+    : 'unmanaged'
+
+  return {
+    ring: normalizeOpenClawHostRolloutRing(rollout.ring),
+    desiredConnectorVersion,
+    notes: normalizeOptionalString(rollout.notes),
+    updatedAt: normalizeIsoDateTime(rollout.updatedAt),
+    versionState,
+    canary: normalizeOpenClawHostRolloutRing(rollout.ring) === 'canary',
+  }
+}
+
+function buildOpenClawHostMaintenancePatch(
+  host: OpenClawHostRow,
+  input: {
+    state: OpenClawHostMaintenanceState
+    owner?: string | null
+    reason?: string | null
+  },
+) {
+  const metadata = parseOpenClawHostMetadata(host.metadata_json)
+  const current = serializeOpenClawHostMaintenance(host)
+  const now = new Date().toISOString()
+  const state = normalizeOpenClawHostMaintenanceState(input.state)
+  const nextMaintenance = {
+    state,
+    owner: input.owner !== undefined ? normalizeOptionalString(input.owner) : current.owner,
+    reason: state === 'serving'
+      ? null
+      : (input.reason !== undefined ? normalizeOptionalString(input.reason) : current.reason),
+    startedAt: state === 'serving'
+      ? null
+      : (current.state === state && current.startedAt ? current.startedAt : now),
+    updatedAt: now,
+  }
+
+  const nextMetadata: OpenClawHostMetadataJson = {
+    ...metadata,
+    maintenance: nextMaintenance,
+  }
+
+  return {
+    maintenance: nextMaintenance,
+    metadataJson: serializeOpenClawHostMetadata(nextMetadata),
+  }
+}
+
+function buildOpenClawHostRolloutPatch(
+  host: OpenClawHostRow,
+  input: {
+    ring?: OpenClawHostRolloutRing | null
+    desiredConnectorVersion?: string | null
+    notes?: string | null
+  },
+) {
+  const metadata = parseOpenClawHostMetadata(host.metadata_json)
+  const current = serializeOpenClawHostRollout(host)
+  const nextRollout = {
+    ring: input.ring ? normalizeOpenClawHostRolloutRing(input.ring) : current.ring,
+    desiredConnectorVersion: input.desiredConnectorVersion !== undefined
+      ? normalizeOptionalString(input.desiredConnectorVersion)
+      : current.desiredConnectorVersion,
+    notes: input.notes !== undefined
+      ? normalizeOptionalString(input.notes)
+      : current.notes,
+    updatedAt: new Date().toISOString(),
+  }
+
+  const nextMetadata: OpenClawHostMetadataJson = {
+    ...metadata,
+    rollout: nextRollout,
+  }
+
+  return {
+    rollout: nextRollout,
+    metadataJson: serializeOpenClawHostMetadata(nextMetadata),
   }
 }
 
@@ -1239,6 +1447,8 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
   const summary = summarizeRoutes(db, routes)
   const policy = serializeOpenClawHostPolicy(host)
   const placement = serializeOpenClawHostPlacement(host)
+  const maintenance = serializeOpenClawHostMaintenance(host)
+  const rollout = serializeOpenClawHostRollout(host)
 
   return {
     id: host.id,
@@ -1269,6 +1479,8 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
     updatedAt: host.updated_at,
     policy,
     placement,
+    maintenance,
+    rollout,
     enrollment: serializeEnrollment(enrollment),
     summary,
   }
@@ -1333,6 +1545,189 @@ function summarizeOpenClawFleetGroups(hosts: Array<ReturnType<typeof serializeHo
       environments: [...group.environments].sort((left, right) => left.localeCompare(right)),
     }))
     .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+function buildOpenClawFleetMaintenanceSummary(
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): OpenClawFleetMaintenanceSummary {
+  const counts: OpenClawFleetMaintenanceSummary['counts'] = {
+    maintenance: 0,
+    draining: 0,
+    blocked: 0,
+  }
+  const attentionHosts: OpenClawFleetMaintenanceAttentionHost[] = []
+
+  for (const host of hosts) {
+    if (host.maintenance.state === 'serving') {
+      continue
+    }
+
+    if (host.maintenance.state === 'maintenance') {
+      counts.maintenance += 1
+    }
+    if (host.maintenance.state === 'draining') {
+      counts.draining += 1
+    }
+    counts.blocked += 1
+
+    const reasons = [
+      host.maintenance.state === 'draining' ? 'delivery drain active' : 'maintenance mode active',
+      host.maintenance.reason,
+    ].filter(Boolean) as string[]
+
+    attentionHosts.push({
+      hostId: host.id,
+      hostLabel: host.label,
+      workspaceSlug: host.workspaceSlug,
+      healthStatus: host.healthStatus,
+      state: host.maintenance.state,
+      owner: host.maintenance.owner,
+      reason: host.maintenance.reason,
+      startedAt: host.maintenance.startedAt,
+      reasons,
+      severity: host.healthStatus === 'stale' ? 'critical' : 'warning',
+      href: buildOpenClawFleetHref(host.id),
+      workspaceHref: buildWorkspaceHref(host.workspaceSlug),
+    })
+  }
+
+  attentionHosts.sort((left, right) =>
+    severityWeight(left.severity) - severityWeight(right.severity)
+      || (Date.parse(left.startedAt ?? '') || 0) - (Date.parse(right.startedAt ?? '') || 0)
+      || left.hostId - right.hostId)
+
+  return {
+    counts,
+    attentionHosts,
+  }
+}
+
+function buildOpenClawFleetRolloutSummary(
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): OpenClawFleetRolloutSummary {
+  const versionBuckets = new Map<string, OpenClawFleetConnectorVersionSummary>()
+  const ringBuckets = new Map<OpenClawHostRolloutRing, OpenClawFleetRolloutRingSummary>()
+  const attentionHosts: OpenClawFleetRolloutAttentionHost[] = []
+  let canaryHosts = 0
+  let driftHosts = 0
+  let unmanagedHosts = 0
+
+  for (const host of hosts) {
+    const versionLabel = host.connectorVersion || 'unknown'
+    const versionBucket = versionBuckets.get(versionLabel) ?? {
+      version: versionLabel,
+      hostCount: 0,
+      canaryHosts: 0,
+      staleHosts: 0,
+      driftHosts: 0,
+      rings: [],
+      hostIds: [],
+    }
+    versionBucket.hostCount += 1
+    versionBucket.staleHosts += host.healthStatus === 'stale' ? 1 : 0
+    versionBucket.hostIds.push(host.id)
+    if (!versionBucket.rings.includes(host.rollout.ring)) {
+      versionBucket.rings.push(host.rollout.ring)
+    }
+    if (host.rollout.canary) {
+      versionBucket.canaryHosts += 1
+      canaryHosts += 1
+    }
+    if (host.rollout.versionState === 'drifted') {
+      versionBucket.driftHosts += 1
+      driftHosts += 1
+    }
+    if (host.rollout.versionState === 'unmanaged') {
+      unmanagedHosts += 1
+    }
+    versionBuckets.set(versionLabel, versionBucket)
+
+    const ringBucket = ringBuckets.get(host.rollout.ring) ?? {
+      ring: host.rollout.ring,
+      hostCount: 0,
+      canaryHosts: 0,
+      driftHosts: 0,
+      versions: [],
+      hostIds: [],
+    }
+    ringBucket.hostCount += 1
+    ringBucket.hostIds.push(host.id)
+    if (host.rollout.canary) {
+      ringBucket.canaryHosts += 1
+    }
+    if (host.rollout.versionState === 'drifted') {
+      ringBucket.driftHosts += 1
+    }
+    if (!ringBucket.versions.includes(versionLabel)) {
+      ringBucket.versions.push(versionLabel)
+    }
+    ringBuckets.set(host.rollout.ring, ringBucket)
+
+    const reasons: string[] = []
+    let severity: OpenClawFleetDigestSeverity = 'warning'
+    if (host.rollout.versionState === 'drifted') {
+      reasons.push(`expected ${host.rollout.desiredConnectorVersion}`)
+    }
+    if (host.rollout.canary) {
+      reasons.push('canary ring')
+    }
+    if (host.rollout.canary && host.healthStatus === 'stale') {
+      reasons.push('canary host is stale')
+      severity = 'critical'
+    }
+    if (host.rollout.versionState === 'drifted' && host.healthStatus === 'stale') {
+      severity = 'critical'
+    }
+    if (reasons.length === 0) {
+      continue
+    }
+
+    attentionHosts.push({
+      hostId: host.id,
+      hostLabel: host.label,
+      workspaceSlug: host.workspaceSlug,
+      healthStatus: host.healthStatus,
+      ring: host.rollout.ring,
+      connectorVersion: host.connectorVersion,
+      desiredConnectorVersion: host.rollout.desiredConnectorVersion,
+      versionState: host.rollout.versionState,
+      reasons,
+      severity,
+      href: buildOpenClawFleetHref(host.id),
+      workspaceHref: buildWorkspaceHref(host.workspaceSlug),
+    })
+  }
+
+  const versions = [...versionBuckets.values()]
+    .map((bucket) => ({
+      ...bucket,
+      rings: [...bucket.rings].sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => right.hostCount - left.hostCount || left.version.localeCompare(right.version))
+
+  const rings = [...ringBuckets.values()]
+    .map((bucket) => ({
+      ...bucket,
+      versions: [...bucket.versions].sort((left, right) => left.localeCompare(right)),
+    }))
+    .sort((left, right) => left.ring.localeCompare(right.ring))
+
+  attentionHosts.sort((left, right) =>
+    severityWeight(left.severity) - severityWeight(right.severity)
+      || left.ring.localeCompare(right.ring)
+      || left.hostId - right.hostId)
+
+  return {
+    summary: {
+      versions: versions.length,
+      canaryHosts,
+      driftHosts,
+      unmanagedHosts,
+    },
+    versions,
+    rings,
+    attentionHosts,
+  }
 }
 
 function severityWeight(severity: OpenClawFleetDigestSeverity): number {
@@ -1716,6 +2111,24 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
       })
     }
 
+    if (host.maintenance.state === 'maintenance' || host.maintenance.state === 'draining') {
+      actionItems.push({
+        id: `host-maintenance:${host.id}`,
+        severity: host.maintenance.state === 'draining' ? 'critical' : 'warning',
+        category: 'host',
+        title: `${hostTitleForDigest(host)} is ${host.maintenance.state}`,
+        detail: `${baseDetail} is blocking new Beam delivery while ${host.maintenance.state === 'draining' ? 'draining live routes for maintenance' : 'under scheduled maintenance'}${host.maintenance.reason ? `: ${host.maintenance.reason}` : ''}.`,
+        nextAction: host.maintenance.state === 'draining'
+          ? 'Resume the host after the maintenance window ends, or complete the cutover to a replacement host.'
+          : 'Resume the host when maintenance is complete, or switch to drain mode if the machine is about to be replaced.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: lastTraceHref,
+      })
+    }
+
     if (host.policy.rotation.reviewState === 'overdue' || host.policy.rotation.reviewState === 'due_soon') {
       actionItems.push({
         id: `credential-window:${host.id}`,
@@ -1811,6 +2224,38 @@ function buildOpenClawFleetDigest(db: Database, baseUrl: string) {
         workspaceSlug: host.workspaceSlug,
         href: hostHref,
         traceHref: lastTraceHref,
+      })
+    }
+
+    if (host.rollout.versionState === 'drifted') {
+      actionItems.push({
+        id: `rollout-drift:${host.id}`,
+        severity: host.healthStatus === 'stale' ? 'critical' : 'warning',
+        category: 'host',
+        title: `${hostTitleForDigest(host)} is off the desired connector version`,
+        detail: `${baseDetail} is on connector ${host.connectorVersion} while the rollout target is ${host.rollout.desiredConnectorVersion}.`,
+        nextAction: 'Finish the connector rollout on this host or move it to a pinned ring with an explicit owner note.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: null,
+      })
+    }
+
+    if (host.rollout.canary && host.healthStatus === 'stale') {
+      actionItems.push({
+        id: `rollout-canary:${host.id}`,
+        severity: 'critical',
+        category: 'host',
+        title: `${hostTitleForDigest(host)} is a stale canary host`,
+        detail: `${baseDetail} is carrying canary rollout visibility but is currently stale, so the rollout signal is no longer trustworthy.`,
+        nextAction: 'Recover the canary host or remove it from the canary ring before trusting rollout health for this connector version.',
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        href: hostHref,
+        traceHref: null,
       })
     }
 
@@ -2242,6 +2687,8 @@ export function openClawAdminRouter(db: Database) {
     const digest = buildOpenClawFleetDigest(db, new URL(c.req.url).origin)
     const environments = summarizeOpenClawFleetEnvironments(hosts)
     const hostGroups = summarizeOpenClawFleetGroups(hosts)
+    const maintenance = buildOpenClawFleetMaintenanceSummary(hosts)
+    const rollout = buildOpenClawFleetRolloutSummary(hosts)
     const credentialPolicy = buildOpenClawFleetCredentialPolicySummary(hosts)
     const routeHealth = buildOpenClawFleetRouteHealthSummary(db, hosts)
     const summary = hosts.reduce((acc, host) => {
@@ -2298,6 +2745,8 @@ export function openClawAdminRouter(db: Database) {
       },
       hosts,
       conflicts,
+      maintenance,
+      rollout,
       credentialPolicy,
       routeHealth,
       environments,
@@ -3183,6 +3632,148 @@ export function openClawAdminRouter(db: Database) {
     })
   })
 
+  router.post('/hosts/:id/maintenance', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const patch = buildOpenClawHostMaintenancePatch(host, {
+      state: 'maintenance',
+      owner: normalizeOptionalString(body.owner) ?? auth.session.email,
+      reason: normalizeOptionalString(body.reason),
+    })
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: patch.metadataJson,
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.maintenance_enabled',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+        owner: patch.maintenance.owner,
+        reason: patch.maintenance.reason,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({ host: serializeHost(db, updated) })
+  })
+
+  router.post('/hosts/:id/drain', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const patch = buildOpenClawHostMaintenancePatch(host, {
+      state: 'draining',
+      owner: normalizeOptionalString(body.owner) ?? auth.session.email,
+      reason: normalizeOptionalString(body.reason),
+    })
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: patch.metadataJson,
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.drain_started',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+        owner: patch.maintenance.owner,
+        reason: patch.maintenance.reason,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({ host: serializeHost(db, updated) })
+  })
+
+  router.post('/hosts/:id/resume', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    const patch = buildOpenClawHostMaintenancePatch(host, {
+      state: 'serving',
+    })
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: patch.metadataJson,
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.resumed',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({ host: serializeHost(db, updated) })
+  })
+
   router.patch('/hosts/:id/policy', async (c) => {
     const auth = requireAdminRole(db, c.req.raw, 'admin')
     if (auth instanceof Response) {
@@ -3267,6 +3858,66 @@ export function openClawAdminRouter(db: Database) {
         rotationWindowDurationHours: nextMetadata.credentialPolicy?.rotationWindowDurationHours ?? null,
         recoveryOwner: nextMetadata.recoveryRunbook?.owner ?? null,
         recoveryStatus: nextMetadata.recoveryRunbook?.status ?? null,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      host: serializeHost(db, updated),
+    })
+  })
+
+  router.patch('/hosts/:id/rollout', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const hostId = normalizePositiveInteger(c.req.param('id'))
+    if (!hostId) {
+      return c.json({ error: 'Invalid host id', errorCode: 'INVALID_HOST_ID' }, 400)
+    }
+
+    const host = getOpenClawHostById(db, hostId)
+    if (!host) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const patch = buildOpenClawHostRolloutPatch(host, {
+      ring: body.ring === 'canary' || body.ring === 'stable' || body.ring === 'pinned'
+        ? body.ring
+        : undefined,
+      desiredConnectorVersion: Object.prototype.hasOwnProperty.call(body, 'desiredConnectorVersion')
+        ? normalizeOptionalString(body.desiredConnectorVersion)
+        : undefined,
+      notes: Object.prototype.hasOwnProperty.call(body, 'notes')
+        ? normalizeOptionalString(body.notes)
+        : undefined,
+    })
+
+    const updated = updateOpenClawHost(db, {
+      id: host.id,
+      metadataJson: patch.metadataJson,
+    })
+    if (!updated) {
+      return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_host.rollout_updated',
+      actor: auth.session.email,
+      target: `openclaw-host:${updated.id}`,
+      details: {
+        role: auth.session.role,
+        ring: patch.rollout.ring,
+        desiredConnectorVersion: patch.rollout.desiredConnectorVersion,
       },
     })
 

--- a/packages/directory/src/websocket.ts
+++ b/packages/directory/src/websocket.ts
@@ -6,6 +6,7 @@ import type { IntentFrame, IntentLogRow, IntentTraceEventRow, ResultFrame } from
 import {
   finalizeIntentLog,
   getAgent,
+  getOpenClawHostById,
   getIntentLogByNonce,
   getLatestIntentTraceEvent,
   hasActiveDelegation,
@@ -48,6 +49,8 @@ type ConnectionSession = {
   ws: WebSocket
   authenticatedViaApiKey: boolean
 }
+
+type OpenClawHostMaintenanceState = 'serving' | 'maintenance' | 'draining'
 
 const connections = new Map<string, ConnectionSession>()
 const intentFeedSubscribers = new Set<WebSocket>()
@@ -127,6 +130,33 @@ function parseTraceDetails(trace: IntentTraceEventRow | null): Record<string, un
   }
 }
 
+function getOpenClawHostMaintenance(metadataJson: string | null): {
+  state: OpenClawHostMaintenanceState
+  reason: string | null
+} {
+  if (!metadataJson) {
+    return { state: 'serving', reason: null }
+  }
+
+  try {
+    const parsed = JSON.parse(metadataJson) as {
+      maintenance?: {
+        state?: unknown
+        reason?: unknown
+      }
+    }
+    const state = parsed?.maintenance?.state === 'maintenance' || parsed?.maintenance?.state === 'draining'
+      ? parsed.maintenance.state
+      : 'serving'
+    const reason = typeof parsed?.maintenance?.reason === 'string' && parsed.maintenance.reason.trim()
+      ? parsed.maintenance.reason.trim()
+      : null
+    return { state, reason }
+  } catch {
+    return { state: 'serving', reason: null }
+  }
+}
+
 function getOpenClawDeliveryBlock(
   db: Database,
   beamId: string,
@@ -164,6 +194,24 @@ function getOpenClawDeliveryBlock(
       details: {
         hostId: preferredRoute.host_id,
         hostLabel: preferredRoute.host_label ?? preferredRoute.hostname,
+      },
+    }
+  }
+
+  const host = getOpenClawHostById(db, preferredRoute.host_id)
+  const maintenance = getOpenClawHostMaintenance(host?.metadata_json ?? null)
+  if (maintenance.state === 'maintenance' || maintenance.state === 'draining') {
+    return {
+      relayCode: 'FORBIDDEN',
+      errorCode: maintenance.state === 'draining' ? 'HOST_DRAINING' : 'HOST_MAINTENANCE',
+      message: maintenance.state === 'draining'
+        ? `Agent ${beamId} belongs to a draining OpenClaw host`
+        : `Agent ${beamId} belongs to an OpenClaw host in maintenance mode`,
+      details: {
+        hostId: preferredRoute.host_id,
+        hostLabel: preferredRoute.host_label ?? preferredRoute.hostname,
+        maintenanceState: maintenance.state,
+        reason: maintenance.reason,
       },
     }
   }


### PR DESCRIPTION
## Summary
- add OpenClaw host maintenance, drain, resume, and rollout-ring controls to the fleet backend
- block Beam delivery for hosts in maintenance or drain and surface maintenance/rollout state in the fleet UI
- add directory tests and workspace docs for maintenance blocking and rollout inventory

## Verification
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test --workspace=packages/directory
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build --workspace=packages/dashboard
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run build
- npm -C /Users/tobik/Documents/BEAM/beam-protocol test
- npm -C /Users/tobik/Documents/BEAM/beam-protocol run test:e2e
- npm -C /Users/tobik/Documents/BEAM/beam-protocol/docs run build