### PR TITLE
Add fleet policy packs and guided remediation

### DIFF
--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -203,6 +203,11 @@ The fleet surface also gives operators explicit day-2 actions:
 - label hosts with environment and group metadata such as `prod`, `staging`, `lab`, `edge`, or team ownership
 - track connector rollout rings (`stable`, `canary`, `pinned`), desired connector versions, and drift directly on each host
 - inspect one fleet-wide rollout inventory that shows version buckets, canary coverage, pinned hosts, and drift attention before a connector rollout spreads
+- define reusable policy packs for fleet-backed identities and attach them to workspace templates by host group
+- detect workspace drift when a fleet-backed workspace no longer matches its expected template or policy pack
+- reapply the expected workspace template directly from the fleet remediation surface when Beam finds template drift
+- end only stale routes on one host when old sessions linger after heartbeat expiry
+- drain a host with missing or failed receipts through a guided remediation flow before deeper repair work begins
 - stage guarded bulk actions across multiple hosts before a real revoke, with an explicit confirm phrase
 - clear staged revoke reviews again when a maintenance plan changes
 
@@ -212,6 +217,7 @@ The host detail and fleet summary now also expose the operational thresholds beh
 - recovery owner, replacement host label, cutover window notes, and a cleanup-ready state after recovery completes
 - maintenance owner, maintenance reason, maintenance start time, and whether Beam delivery is intentionally blocked for that host
 - the connector rollout ring, desired connector version, and whether the currently reported connector version has drifted
+- the active workspace template, linked policy pack, host-group match, and template application provenance for fleet-backed workspaces
 - receipt coverage across active routes
 - p50 / p95 latency, SLO bucket counts, and direct links back to the host, workspace, and latest trace that caused the warning
 
@@ -225,6 +231,24 @@ For the new grouping and guarded bulk actions, the normal operator flow is:
 4. verify the staged review directly on the host detail before a real revoke
 
 This keeps labels, host ownership, and revoke-review intent in Beam itself instead of spreading those decisions across local notes or machine-specific scripts.
+
+For policy packs and guided remediation, the normal operator loop is:
+
+1. open the fleet overview and check `Policy packs and workspace templates`
+2. confirm whether the workspace is expected to inherit one fleet template for its host group
+3. inspect `Guided remediation` for rollout drift, stale routes, missing receipts, or template drift
+4. use the lowest-risk action first:
+   - `Align rollout` to adopt the live connector as the desired target
+   - `End stale routes` to remove expired sessions from delivery
+   - `Drain host` when receipts are missing or failing
+   - `Reapply template` when workspace policy or defaults drifted from the expected pack
+
+The guarded remediation actions require explicit confirmation phrases:
+
+- `DRAIN_HOST` before Beam drains a host for missing or failed receipts
+- `REAPPLY_TEMPLATE` before Beam reapplies the expected workspace template
+
+That keeps destructive or policy-resetting actions explicit while still letting one operator complete the full repair flow from the fleet surface instead of jumping into raw database or host state.
 
 If you have just pulled new Beam code and want the local containers rebuilt before importing again, run:
 

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -493,6 +493,103 @@ export interface OpenClawConflictDetailResponse {
   history: OpenClawConflictHistoryItem[]
 }
 
+export interface OpenClawPolicyPack {
+  id: number
+  key: string
+  label: string
+  description: string | null
+  hostGroupLabel: string | null
+  policy: WorkspacePolicyDocument
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OpenClawWorkspaceTemplate {
+  id: number
+  key: string
+  label: string
+  description: string | null
+  hostGroupLabel: string | null
+  policyPackKey: string | null
+  policyPackLabel: string | null
+  template: {
+    defaultThreadScope: WorkspaceThreadScope
+    externalHandoffsEnabled: boolean
+    description: string | null
+  }
+  createdAt: string
+  updatedAt: string
+}
+
+export interface OpenClawFleetTemplateAttentionWorkspace {
+  workspaceId: number
+  workspaceSlug: string
+  workspaceName: string
+  hostGroups: string[]
+  templateKey: string | null
+  expectedTemplateKey: string | null
+  policyPackKey: string | null
+  drifted: boolean
+  reason: string
+  href: string
+}
+
+export interface OpenClawFleetTemplateSummary {
+  summary: {
+    policyPacks: number
+    workspaceTemplates: number
+    templatedWorkspaces: number
+    driftedWorkspaces: number
+  }
+  policyPacks: OpenClawPolicyPack[]
+  workspaceTemplates: OpenClawWorkspaceTemplate[]
+  attentionWorkspaces: OpenClawFleetTemplateAttentionWorkspace[]
+}
+
+export type OpenClawFleetRemediationKind =
+  | 'align_rollout'
+  | 'end_stale_routes'
+  | 'drain_missing_receipts'
+  | 'reapply_template'
+
+export interface OpenClawFleetRemediationItem {
+  id: string
+  kind: OpenClawFleetRemediationKind
+  severity: 'warning' | 'critical'
+  title: string
+  detail: string
+  nextAction: string
+  safe: boolean
+  requiresConfirmation: boolean
+  hostId: number | null
+  hostLabel: string | null
+  workspaceSlug: string | null
+  templateKey: string | null
+  href: string | null
+}
+
+export interface OpenClawFleetRemediationHistoryItem {
+  id: string
+  action: string
+  actor: string | null
+  timestamp: string
+  target: string
+  kind: OpenClawFleetRemediationKind | null
+  note: string | null
+  href: string | null
+}
+
+export interface OpenClawFleetRemediationSummary {
+  summary: {
+    suggested: number
+    critical: number
+    requiresConfirmation: number
+    appliedRecently: number
+  }
+  suggested: OpenClawFleetRemediationItem[]
+  history: OpenClawFleetRemediationHistoryItem[]
+}
+
 export interface OpenClawFleetOverviewResponse {
   summary: {
     totalHosts: number
@@ -515,6 +612,9 @@ export interface OpenClawFleetOverviewResponse {
     pendingCredentialActions: number
     actionItems: number
     criticalItems: number
+    templateDriftedWorkspaces: number
+    suggestedRemediations: number
+    criticalRemediations: number
   }
   credentialPolicy: {
     counts: {
@@ -655,6 +755,8 @@ export interface OpenClawFleetOverviewResponse {
   }
   hosts: OpenClawHostSummary[]
   conflicts: OpenClawConflictGroup[]
+  templates: OpenClawFleetTemplateSummary
+  remediation: OpenClawFleetRemediationSummary
   environments: OpenClawFleetEnvironmentSummary[]
   hostGroups: OpenClawFleetHostGroupSummary[]
 }
@@ -1271,6 +1373,15 @@ export interface WorkspacePolicyDocument {
   workflowRules: WorkspacePolicyWorkflowRule[]
   metadata: {
     notes: string | null
+    template: {
+      templateKey: string | null
+      templateLabel: string | null
+      policyPackKey: string | null
+      policyPackLabel: string | null
+      hostGroupLabel: string | null
+      appliedAt: string | null
+      appliedBy: string | null
+    } | null
   }
 }
 
@@ -1333,6 +1444,34 @@ export interface WorkspaceIdentityPolicyResponse {
   } | null
   preview: WorkspacePolicyPreview
   binding: WorkspaceIdentityBinding
+}
+
+export interface OpenClawPolicyPackUpsertInput {
+  label?: string | null
+  description?: string | null
+  hostGroupLabel?: string | null
+  policy: Partial<WorkspacePolicyDocument> | WorkspacePolicyDocument
+}
+
+export interface OpenClawWorkspaceTemplateUpsertInput {
+  label?: string | null
+  description?: string | null
+  hostGroupLabel?: string | null
+  policyPackKey?: string | null
+  template: {
+    defaultThreadScope?: WorkspaceThreadScope
+    externalHandoffsEnabled?: boolean
+    description?: string | null
+  }
+}
+
+export interface OpenClawFleetRemediationApplyInput {
+  kind: OpenClawFleetRemediationKind
+  hostId?: number | null
+  workspaceSlug?: string | null
+  templateKey?: string | null
+  confirmPhrase?: string | null
+  note?: string | null
 }
 
 export interface WorkspaceIdentityCredentialBundle {
@@ -2677,6 +2816,38 @@ export const directoryApi = {
   },
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
   getOpenClawFleetOverview: () => request<OpenClawFleetOverviewResponse>('/admin/openclaw/fleet/overview', undefined, { admin: true }),
+  listOpenClawPolicyPacks: () => request<{ total: number; policyPacks: OpenClawPolicyPack[] }>('/admin/openclaw/fleet/policy-packs', undefined, { admin: true }),
+  upsertOpenClawPolicyPack: (key: string, input: OpenClawPolicyPackUpsertInput) => request<{ policyPack: OpenClawPolicyPack }>(`/admin/openclaw/fleet/policy-packs/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  listOpenClawWorkspaceTemplates: () => request<{ total: number; workspaceTemplates: OpenClawWorkspaceTemplate[] }>('/admin/openclaw/fleet/workspace-templates', undefined, { admin: true }),
+  upsertOpenClawWorkspaceTemplate: (key: string, input: OpenClawWorkspaceTemplateUpsertInput) => request<{ workspaceTemplate: OpenClawWorkspaceTemplate }>(`/admin/openclaw/fleet/workspace-templates/${encodeURIComponent(key)}`, {
+    method: 'PUT',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  applyOpenClawWorkspaceTemplate: (key: string, input: { workspaceSlug: string; note?: string | null }) => request<{
+    workspace: WorkspaceRecord
+    policy: WorkspacePolicyDocument
+    updatedAt: string | null
+    updatedBy: string | null
+  }>(`/admin/openclaw/fleet/workspace-templates/${encodeURIComponent(key)}/apply`, {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, { admin: true }),
+  applyOpenClawFleetRemediation: (input: OpenClawFleetRemediationApplyInput) => request<{
+    ok: boolean
+    kind: OpenClawFleetRemediationKind
+    host?: OpenClawHostSummary
+    workspace?: WorkspaceRecord
+    policy?: WorkspacePolicyDocument
+    updatedAt?: string | null
+    updatedBy?: string | null
+    routes?: OpenClawHostRoute[]
+  }>('/admin/openclaw/fleet/remediations/apply', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  }, { admin: true }),
   getOpenClawFleetDigest: (params?: { format?: 'json' | 'markdown' }) => request<OpenClawFleetDigestResponse>(`/admin/openclaw/fleet/digest${buildQuery({ format: params?.format })}`, undefined, { admin: true }),
   updateOpenClawFleetDigestSchedule: (input: OpenClawFleetDigestSchedulePatchInput) => request<OpenClawFleetDigestSchedulePatchResponse>('/admin/openclaw/fleet/digest/schedule', {
     method: 'PATCH',

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -9,6 +9,7 @@ import {
   type OpenClawFleetBulkActionInput,
   type OpenClawFleetDigestResponse,
   type OpenClawFleetEnvironmentSummary,
+  type OpenClawFleetRemediationItem,
   type OpenClawEnrollmentCreateInput,
   type OpenClawFleetOverviewResponse,
   type OpenClawFleetHostGroupSummary,
@@ -174,6 +175,21 @@ function digestSeverityTone(severity: 'warning' | 'critical'): 'warning' | 'crit
 
 function conflictResolutionTone(state: OpenClawConflictDetailResponse['resolutionState']): 'warning' | 'success' {
   return state === 'owner_selected' ? 'success' : 'warning'
+}
+
+function remediationActionLabel(item: OpenClawFleetRemediationItem): string {
+  switch (item.kind) {
+    case 'align_rollout':
+      return 'Align rollout'
+    case 'end_stale_routes':
+      return 'End stale routes'
+    case 'drain_missing_receipts':
+      return 'Drain host'
+    case 'reapply_template':
+      return 'Reapply template'
+    default:
+      return 'Apply'
+  }
 }
 
 function formatPercent(value: number | null): string {
@@ -804,6 +820,31 @@ export default function OpenClawFleetPage() {
       })
       await refreshAll(selectedHostId, selectedConflictBeamId)
     }, `Route ownership reset for ${route.beamId}.`)
+  }
+
+  async function handleApplyRemediation(item: OpenClawFleetRemediationItem) {
+    let confirmPhrase: string | null = null
+    if (item.requiresConfirmation) {
+      const expected = item.kind === 'drain_missing_receipts' ? 'DRAIN_HOST' : 'REAPPLY_TEMPLATE'
+      const entered = window.prompt(`Type ${expected} to confirm ${remediationActionLabel(item).toLowerCase()}.`, expected)
+      if (entered !== expected) {
+        setNotice(`Confirmation skipped for ${item.title}.`)
+        return
+      }
+      confirmPhrase = entered
+    }
+
+    await runAction(`remediation-${item.id}`, async () => {
+      await directoryApi.applyOpenClawFleetRemediation({
+        kind: item.kind,
+        hostId: item.hostId,
+        workspaceSlug: item.workspaceSlug,
+        templateKey: item.templateKey,
+        confirmPhrase,
+        note: `Applied from fleet remediation panel for ${item.id}.`,
+      })
+      await refreshAll(selectedHostId, selectedConflictBeamId)
+    }, `${item.title} remediated.`)
   }
 
   async function handleSaveDigestSchedule() {
@@ -2459,6 +2500,176 @@ export default function OpenClawFleetPage() {
             ) : (
               <EmptyPanel label="No rollout drift or canary attention hosts." />
             )}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-2">
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Policy packs and workspace templates</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                Fleet-backed workspaces can inherit one approved policy pack and one workspace template per host group.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.templates.summary.workspaceTemplates)} templates` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <MetricCard label="Policy packs" value={!overview ? '—' : formatNumber(overview.templates.summary.policyPacks)} />
+            <MetricCard label="Templates" value={!overview ? '—' : formatNumber(overview.templates.summary.workspaceTemplates)} />
+            <MetricCard label="Templated workspaces" value={!overview ? '—' : formatNumber(overview.templates.summary.templatedWorkspaces)} tone={(overview?.templates.summary.templatedWorkspaces ?? 0) > 0 ? 'success' : 'default'} />
+            <MetricCard label="Template drift" value={!overview ? '—' : formatNumber(overview.templates.summary.driftedWorkspaces)} tone={(overview?.templates.summary.driftedWorkspaces ?? 0) > 0 ? 'warning' : 'default'} />
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Policy packs</div>
+              <div className="mt-3 space-y-3">
+                {overview && overview.templates.policyPacks.length > 0 ? overview.templates.policyPacks.map((pack) => (
+                  <div key={pack.key} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                    <div className="flex items-center gap-2">
+                      <StatusPill label={pack.label} tone="default" />
+                      {pack.hostGroupLabel ? <StatusPill label={`group:${pack.hostGroupLabel}`} tone="default" /> : null}
+                    </div>
+                    <div className="mt-2">{pack.description || 'No pack description recorded.'}</div>
+                  </div>
+                )) : <EmptyPanel label="No fleet policy packs are configured yet." />}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Workspace templates</div>
+              <div className="mt-3 space-y-3">
+                {overview && overview.templates.workspaceTemplates.length > 0 ? overview.templates.workspaceTemplates.map((template) => (
+                  <div key={template.key} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusPill label={template.label} tone="default" />
+                      {template.hostGroupLabel ? <StatusPill label={`group:${template.hostGroupLabel}`} tone="default" /> : null}
+                      {template.policyPackLabel ? <StatusPill label={`pack:${template.policyPackLabel}`} tone="default" /> : null}
+                    </div>
+                    <div className="mt-2">{template.description || 'No template description recorded.'}</div>
+                    <div className="mt-2">{`${template.template.defaultThreadScope} threads · ${template.template.externalHandoffsEnabled ? 'external handoffs enabled' : 'external handoffs blocked'}`}</div>
+                  </div>
+                )) : <EmptyPanel label="No workspace templates are configured yet." />}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.templates.attentionWorkspaces.length > 0 ? (
+              overview.templates.attentionWorkspaces.map((workspace) => (
+                <div key={`template-drift-${workspace.workspaceId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{workspace.workspaceName}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{workspace.reason}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {workspace.templateKey ? <StatusPill label={`current:${workspace.templateKey}`} tone="warning" /> : null}
+                      {workspace.expectedTemplateKey ? <StatusPill label={`expected:${workspace.expectedTemplateKey}`} tone="success" /> : null}
+                    </div>
+                  </div>
+                  <div className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+                    {workspace.hostGroups.length > 0 ? `Host groups ${workspace.hostGroups.join(', ')}` : 'No host groups attached yet'}
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={workspace.href}>
+                      Open workspace
+                    </Link>
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyPanel label="No workspace template drift is currently visible." />
+            )}
+          </div>
+        </div>
+
+        <div className="panel">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="panel-title">Guided remediation</div>
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                One-click operator actions for rollout drift, stale routes, missing receipts, and workspace template drift.
+              </p>
+            </div>
+            <div className="text-xs text-slate-500 dark:text-slate-400">
+              {overview ? `${formatNumber(overview.remediation.summary.suggested)} suggested` : '—'}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            <MetricCard label="Suggested" value={!overview ? '—' : formatNumber(overview.remediation.summary.suggested)} tone={(overview?.remediation.summary.suggested ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Critical" value={!overview ? '—' : formatNumber(overview.remediation.summary.critical)} tone={(overview?.remediation.summary.critical ?? 0) > 0 ? 'critical' : 'default'} />
+            <MetricCard label="Needs confirm" value={!overview ? '—' : formatNumber(overview.remediation.summary.requiresConfirmation)} tone={(overview?.remediation.summary.requiresConfirmation ?? 0) > 0 ? 'warning' : 'default'} />
+            <MetricCard label="Applied recently" value={!overview ? '—' : formatNumber(overview.remediation.summary.appliedRecently)} />
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {overview && overview.remediation.suggested.length > 0 ? (
+              overview.remediation.suggested.map((item) => (
+                <div key={item.id} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.title}</div>
+                      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.detail}</div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <StatusPill label={item.kind} tone={digestSeverityTone(item.severity)} />
+                      {item.requiresConfirmation ? <StatusPill label="confirm required" tone="warning" /> : <StatusPill label="safe" tone="success" />}
+                    </div>
+                  </div>
+                  <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                    <div>{item.hostLabel ? `Host ${item.hostLabel}` : item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No host or workspace attached'}</div>
+                    <div>{item.nextAction}</div>
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-xl bg-slate-900 px-3 py-2 text-sm font-medium text-white transition hover:bg-slate-800 disabled:opacity-60 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+                      disabled={actionBusy === `remediation-${item.id}` || (item.kind === 'reapply_template' && !item.templateKey)}
+                      onClick={() => { void handleApplyRemediation(item) }}
+                    >
+                      {actionBusy === `remediation-${item.id}` ? 'Applying…' : remediationActionLabel(item)}
+                    </button>
+                    {item.href ? (
+                      <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.href}>
+                        Open
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
+              ))
+            ) : (
+              <EmptyPanel label="No guided remediation items are currently suggested." />
+            )}
+          </div>
+
+          <div className="mt-4 rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+            <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Recent remediation history</div>
+            <div className="mt-3 space-y-3">
+              {overview && overview.remediation.history.length > 0 ? overview.remediation.history.map((entry) => (
+                <div key={entry.id} className="rounded-xl border border-slate-200 px-3 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill label={entry.kind ?? entry.action} tone={entry.kind === 'drain_missing_receipts' ? 'warning' : 'default'} />
+                    <span>{formatDateTime(entry.timestamp)}</span>
+                  </div>
+                  <div className="mt-2">{entry.note || entry.target}</div>
+                  <div className="mt-2">{entry.actor ? `Actor ${entry.actor}` : 'Actor unknown'}</div>
+                  {entry.href ? (
+                    <div className="mt-2">
+                      <Link className="text-orange-600 hover:text-orange-700 dark:text-orange-300" to={entry.href}>
+                        Open target
+                      </Link>
+                    </div>
+                  ) : null}
+                </div>
+              )) : <EmptyPanel label="No remediation history recorded yet." />}
+            </div>
           </div>
         </div>
       </section>

--- a/packages/dashboard/src/pages/WorkspacesPage.tsx
+++ b/packages/dashboard/src/pages/WorkspacesPage.tsx
@@ -871,6 +871,7 @@ export default function WorkspacesPage() {
         },
         metadata: {
           notes: policyDefaults.notes.trim() || null,
+          template: policy?.policy.metadata.template ?? null,
         },
       })
       setPolicy(response)
@@ -2414,6 +2415,26 @@ export default function WorkspacesPage() {
                   Workspace guide
                 </a>
               </div>
+
+              {policy?.policy.metadata.template ? (
+                <div className="mt-4 grid gap-3 rounded-2xl border border-emerald-200 bg-emerald-50/70 p-4 text-sm text-emerald-950 dark:border-emerald-900/60 dark:bg-emerald-950/20 dark:text-emerald-100">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <StatusPill label={policy.policy.metadata.template.templateLabel ?? policy.policy.metadata.template.templateKey ?? 'template'} tone="success" />
+                    {policy.policy.metadata.template.policyPackLabel ? (
+                      <StatusPill label={`pack:${policy.policy.metadata.template.policyPackLabel}`} tone="default" />
+                    ) : null}
+                    {policy.policy.metadata.template.hostGroupLabel ? (
+                      <StatusPill label={`group:${policy.policy.metadata.template.hostGroupLabel}`} tone="default" />
+                    ) : null}
+                  </div>
+                  <div className="grid gap-2 text-xs text-emerald-900/80 dark:text-emerald-100/80 md:grid-cols-2">
+                    <div>{`Template key ${policy.policy.metadata.template.templateKey ?? '—'}`}</div>
+                    <div>{`Policy pack ${policy.policy.metadata.template.policyPackKey ?? '—'}`}</div>
+                    <div>{policy.policy.metadata.template.appliedAt ? `Applied ${formatDateTime(policy.policy.metadata.template.appliedAt)}` : 'Applied time unavailable'}</div>
+                    <div>{policy.policy.metadata.template.appliedBy ? `Applied by ${policy.policy.metadata.template.appliedBy}` : 'Applied by unknown operator'}</div>
+                  </div>
+                </div>
+              ) : null}
 
               <form className="mt-4 grid gap-3 rounded-2xl border border-slate-200 p-4 dark:border-slate-800" onSubmit={(event) => { void handlePolicyDefaultsSubmit(event) }}>
                 <label className="text-xs font-medium uppercase tracking-wide text-slate-400">Default external initiation</label>

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -33,11 +33,13 @@ import type {
   OpenClawHostRow,
   OpenClawHostStatus,
   OpenClawHostRouteRow,
+  OpenClawPolicyPackRow,
   OpenClawResolvedRouteRow,
   OpenClawRouteOwnerResolutionState,
   OpenClawRouteReportedState,
   OpenClawRouteRuntimeState,
   OpenClawRouteSource,
+  OpenClawWorkspaceTemplateRow,
   OrgAgentRow,
   OrgRow,
   ReportRow,
@@ -490,6 +492,35 @@ function initSchema(db: DB): void {
 
     CREATE INDEX IF NOT EXISTS idx_openclaw_fleet_digest_deliveries_run
       ON openclaw_fleet_digest_deliveries(run_id, delivered_at DESC, id DESC);
+
+    CREATE TABLE IF NOT EXISTS openclaw_policy_packs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      pack_key TEXT NOT NULL UNIQUE,
+      label TEXT NOT NULL,
+      description TEXT,
+      host_group_label TEXT,
+      policy_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_openclaw_policy_packs_group
+      ON openclaw_policy_packs(host_group_label, updated_at DESC, id DESC);
+
+    CREATE TABLE IF NOT EXISTS openclaw_workspace_templates (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      template_key TEXT NOT NULL UNIQUE,
+      label TEXT NOT NULL,
+      description TEXT,
+      host_group_label TEXT,
+      policy_pack_key TEXT,
+      template_json TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_openclaw_workspace_templates_group
+      ON openclaw_workspace_templates(host_group_label, updated_at DESC, id DESC);
 
     CREATE TABLE IF NOT EXISTS operator_notifications (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1270,6 +1301,41 @@ export function listWorkspaces(db: DB): WorkspaceRow[] {
     FROM workspaces
     ORDER BY datetime(updated_at) DESC, slug ASC
   `).all() as WorkspaceRow[]
+}
+
+export function updateWorkspace(
+  db: DB,
+  input: {
+    id: number
+    description?: string | null
+    status?: WorkspaceRow['status']
+    defaultThreadScope?: WorkspaceRow['default_thread_scope']
+    externalHandoffsEnabled?: boolean
+  },
+): WorkspaceRow | null {
+  const existing = getWorkspaceById(db, input.id)
+  if (!existing) {
+    return null
+  }
+
+  db.prepare(`
+    UPDATE workspaces
+    SET description = ?,
+        status = ?,
+        default_thread_scope = ?,
+        external_handoffs_enabled = ?,
+        updated_at = ?
+    WHERE id = ?
+  `).run(
+    input.description === undefined ? existing.description : input.description,
+    input.status ?? existing.status,
+    input.defaultThreadScope ?? existing.default_thread_scope,
+    input.externalHandoffsEnabled === undefined ? existing.external_handoffs_enabled : (input.externalHandoffsEnabled ? 1 : 0),
+    nowIso(),
+    input.id,
+  )
+
+  return getWorkspaceById(db, input.id)
 }
 
 export function getWorkspaceSummary(
@@ -4035,6 +4101,134 @@ export function listOpenClawHosts(db: DB): OpenClawHostRow[] {
   `).all() as OpenClawHostRow[]
 }
 
+export function listOpenClawPolicyPacks(db: DB): OpenClawPolicyPackRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_policy_packs
+    ORDER BY
+      CASE WHEN host_group_label IS NULL THEN 1 ELSE 0 END ASC,
+      host_group_label ASC,
+      pack_key ASC
+  `).all() as OpenClawPolicyPackRow[]
+}
+
+export function getOpenClawPolicyPackByKey(db: DB, packKey: string): OpenClawPolicyPackRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM openclaw_policy_packs
+    WHERE pack_key = ?
+    LIMIT 1
+  `).get(packKey) as OpenClawPolicyPackRow | undefined
+
+  return row ?? null
+}
+
+export function upsertOpenClawPolicyPack(
+  db: DB,
+  input: {
+    packKey: string
+    label: string
+    description?: string | null
+    hostGroupLabel?: string | null
+    policyJson: string
+  },
+): OpenClawPolicyPackRow {
+  const now = nowIso()
+  db.prepare(`
+    INSERT INTO openclaw_policy_packs (
+      pack_key,
+      label,
+      description,
+      host_group_label,
+      policy_json,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(pack_key) DO UPDATE SET
+      label = excluded.label,
+      description = excluded.description,
+      host_group_label = excluded.host_group_label,
+      policy_json = excluded.policy_json,
+      updated_at = excluded.updated_at
+  `).run(
+    input.packKey,
+    input.label,
+    input.description ?? null,
+    input.hostGroupLabel ?? null,
+    input.policyJson,
+    now,
+    now,
+  )
+
+  return getOpenClawPolicyPackByKey(db, input.packKey) as OpenClawPolicyPackRow
+}
+
+export function listOpenClawWorkspaceTemplates(db: DB): OpenClawWorkspaceTemplateRow[] {
+  return db.prepare(`
+    SELECT *
+    FROM openclaw_workspace_templates
+    ORDER BY
+      CASE WHEN host_group_label IS NULL THEN 1 ELSE 0 END ASC,
+      host_group_label ASC,
+      template_key ASC
+  `).all() as OpenClawWorkspaceTemplateRow[]
+}
+
+export function getOpenClawWorkspaceTemplateByKey(db: DB, templateKey: string): OpenClawWorkspaceTemplateRow | null {
+  const row = db.prepare(`
+    SELECT *
+    FROM openclaw_workspace_templates
+    WHERE template_key = ?
+    LIMIT 1
+  `).get(templateKey) as OpenClawWorkspaceTemplateRow | undefined
+
+  return row ?? null
+}
+
+export function upsertOpenClawWorkspaceTemplate(
+  db: DB,
+  input: {
+    templateKey: string
+    label: string
+    description?: string | null
+    hostGroupLabel?: string | null
+    policyPackKey?: string | null
+    templateJson: string
+  },
+): OpenClawWorkspaceTemplateRow {
+  const now = nowIso()
+  db.prepare(`
+    INSERT INTO openclaw_workspace_templates (
+      template_key,
+      label,
+      description,
+      host_group_label,
+      policy_pack_key,
+      template_json,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(template_key) DO UPDATE SET
+      label = excluded.label,
+      description = excluded.description,
+      host_group_label = excluded.host_group_label,
+      policy_pack_key = excluded.policy_pack_key,
+      template_json = excluded.template_json,
+      updated_at = excluded.updated_at
+  `).run(
+    input.templateKey,
+    input.label,
+    input.description ?? null,
+    input.hostGroupLabel ?? null,
+    input.policyPackKey ?? null,
+    input.templateJson,
+    now,
+    now,
+  )
+
+  return getOpenClawWorkspaceTemplateByKey(db, input.templateKey) as OpenClawWorkspaceTemplateRow
+}
+
 export function updateOpenClawHost(
   db: DB,
   input: {
@@ -4897,6 +5091,40 @@ export function applyOpenClawHostRouteEvents(
   activateOpenClawHostCredential(db, input.hostId, eventAt)
 
   return updated
+}
+
+export function markOpenClawHostRoutesEnded(
+  db: DB,
+  input: {
+    hostId: number
+    runtimeSessionState?: OpenClawRouteRuntimeState
+  },
+): OpenClawHostRouteRow[] {
+  const endedAt = nowIso()
+  const params: Array<number | string> = [endedAt, endedAt, input.hostId]
+  let sql = `
+    UPDATE openclaw_host_routes
+    SET reported_state = 'ended',
+        runtime_session_state = 'ended',
+        ended_at = ?,
+        updated_at = ?
+    WHERE host_id = ?
+      AND reported_state != 'ended'
+  `
+
+  if (input.runtimeSessionState) {
+    sql += ' AND runtime_session_state = ?'
+    params.push(input.runtimeSessionState)
+  }
+
+  db.prepare(sql).run(...params)
+  updateOpenClawHost(db, {
+    id: input.hostId,
+    lastRouteEventAt: endedAt,
+  })
+  updateOpenClawHostRouteCount(db, input.hostId)
+  recalculateOpenClawRouteStates(db)
+  return listOpenClawHostRoutes(db, input.hostId)
 }
 
 export function approveOpenClawHost(

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -330,6 +330,9 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
         pendingCredentialActions: number
         actionItems: number
         criticalItems: number
+        templateDriftedWorkspaces: number
+        suggestedRemediations: number
+        criticalRemediations: number
       }
       hosts: Array<{
         id: number
@@ -360,6 +363,9 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
       pendingCredentialActions: 0,
       actionItems: 1,
       criticalItems: 0,
+      templateDriftedWorkspaces: 0,
+      suggestedRemediations: 1,
+      criticalRemediations: 0,
     })
     assert.equal(overviewBody.hosts[0]?.workspaceSlug, 'openclaw-local')
     assert.equal(overviewBody.hosts[0]?.healthStatus, 'healthy')
@@ -409,6 +415,281 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
     assert.equal(workspaceIdentitiesBody.bindings[0]?.hostHealth, 'healthy')
     assert.equal(workspaceIdentitiesBody.bindings[0]?.routeSource, 'gateway-agent')
     assert.equal(workspaceIdentitiesBody.bindings[0]?.runtimeSessionState, 'live')
+  } finally {
+    db.close()
+  }
+})
+
+test('fleet policy packs, workspace templates, and guided remediation can restore drifted workspaces', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const atlas = createFixtureAgent('atlas-template@openclaw.beam.directory')
+    registerFixtureAgent(db, atlas, 'Atlas Template')
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    const workspaceResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'OpenClaw Local',
+        slug: 'openclaw-local',
+        description: 'Temporary workspace description',
+        defaultThreadScope: 'internal',
+        externalHandoffsEnabled: false,
+      }),
+    }))
+    assert.equal(workspaceResponse.status, 201)
+
+    const bindingResponse = await app.request(new Request('http://localhost/admin/workspaces/openclaw-local/identities', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        beamId: atlas.beamId,
+        bindingType: 'agent',
+        owner: 'ops@example.com',
+        runtimeType: 'openclaw:gateway',
+        policyProfile: 'openclaw-prod',
+        canInitiateExternal: true,
+      }),
+    }))
+    assert.equal(bindingResponse.status, 201)
+
+    const approved = createApprovedHostWithRoute(db, {
+      label: 'Template Alpha',
+      hostname: 'template-alpha.local',
+      beamId: atlas.beamId,
+      routeKey: 'template-alpha-route',
+      workspaceSlug: 'openclaw-local',
+    })
+
+    const profileResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${approved.host.id}/profile`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        environmentLabel: 'prod',
+        groupLabels: ['production'],
+      }),
+    }))
+    assert.equal(profileResponse.status, 200)
+
+    const policyPackResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/policy-packs/prod-default', {
+      method: 'PUT',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        label: 'Production default',
+        description: 'Production outbound policy',
+        hostGroupLabel: 'production',
+        policy: {
+          defaults: {
+            externalInitiation: 'deny',
+            allowedPartners: ['finance@northwind.beam.directory'],
+          },
+          bindingRules: [
+            {
+              policyProfile: 'openclaw-prod',
+              externalInitiation: 'allow',
+              allowedPartners: ['finance@northwind.beam.directory'],
+            },
+          ],
+          workflowRules: [
+            {
+              workflowType: 'quote.approval',
+              requireApproval: true,
+              allowedPartners: ['finance@northwind.beam.directory'],
+              approvers: ['ops@example.com'],
+            },
+          ],
+          metadata: {
+            notes: 'Production hosts require named approval.',
+          },
+        },
+      }),
+    }))
+    assert.equal(policyPackResponse.status, 200)
+
+    const templateResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/workspace-templates/prod-workspace', {
+      method: 'PUT',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        label: 'Production workspace',
+        description: 'Production workspace template',
+        hostGroupLabel: 'production',
+        policyPackKey: 'prod-default',
+        template: {
+          defaultThreadScope: 'handoff',
+          externalHandoffsEnabled: true,
+          description: 'Production partner workspace',
+        },
+      }),
+    }))
+    assert.equal(templateResponse.status, 200)
+
+    const listPolicyPacksResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/policy-packs', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listPolicyPacksResponse.status, 200)
+    const listPolicyPacksBody = await listPolicyPacksResponse.json() as {
+      total: number
+      policyPacks: Array<{
+        key: string
+        policy: {
+          defaults: {
+            externalInitiation: string
+          }
+        }
+      }>
+    }
+    assert.equal(listPolicyPacksBody.total, 1)
+    assert.equal(listPolicyPacksBody.policyPacks[0]?.key, 'prod-default')
+    assert.equal(listPolicyPacksBody.policyPacks[0]?.policy.defaults.externalInitiation, 'deny')
+
+    const listTemplatesResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/workspace-templates', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(listTemplatesResponse.status, 200)
+    const listTemplatesBody = await listTemplatesResponse.json() as {
+      total: number
+      workspaceTemplates: Array<{
+        key: string
+        policyPackKey: string | null
+        template: {
+          defaultThreadScope: string
+          externalHandoffsEnabled: boolean
+        }
+      }>
+    }
+    assert.equal(listTemplatesBody.total, 1)
+    assert.equal(listTemplatesBody.workspaceTemplates[0]?.key, 'prod-workspace')
+    assert.equal(listTemplatesBody.workspaceTemplates[0]?.policyPackKey, 'prod-default')
+
+    const overviewBeforeResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewBeforeResponse.status, 200)
+    const overviewBeforeBody = await overviewBeforeResponse.json() as {
+      templates: {
+        summary: {
+          policyPacks: number
+          workspaceTemplates: number
+          templatedWorkspaces: number
+          driftedWorkspaces: number
+        }
+        attentionWorkspaces: Array<{
+          workspaceSlug: string
+          expectedTemplateKey: string | null
+          reason: string
+        }>
+      }
+      remediation: {
+        suggested: Array<{
+          kind: string
+          workspaceSlug: string | null
+          templateKey: string | null
+          requiresConfirmation: boolean
+        }>
+      }
+    }
+    assert.equal(overviewBeforeBody.templates.summary.policyPacks, 1)
+    assert.equal(overviewBeforeBody.templates.summary.workspaceTemplates, 1)
+    assert.equal(overviewBeforeBody.templates.summary.templatedWorkspaces, 0)
+    assert.equal(overviewBeforeBody.templates.summary.driftedWorkspaces, 1)
+    assert.equal(overviewBeforeBody.templates.attentionWorkspaces[0]?.workspaceSlug, 'openclaw-local')
+    assert.equal(overviewBeforeBody.templates.attentionWorkspaces[0]?.expectedTemplateKey, 'prod-workspace')
+    assert.match(overviewBeforeBody.templates.attentionWorkspaces[0]?.reason ?? '', /expected workspace template/i)
+    assert.ok(overviewBeforeBody.remediation.suggested.some((item) =>
+      item.kind === 'reapply_template'
+      && item.workspaceSlug === 'openclaw-local'
+      && item.templateKey === 'prod-workspace'
+      && item.requiresConfirmation,
+    ))
+
+    const remediationResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/remediations/apply', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'reapply_template',
+        workspaceSlug: 'openclaw-local',
+        templateKey: 'prod-workspace',
+        confirmPhrase: 'REAPPLY_TEMPLATE',
+        note: 'Restore production fleet defaults',
+      }),
+    }))
+    assert.equal(remediationResponse.status, 200)
+    const remediationBody = await remediationResponse.json() as {
+      ok: boolean
+      kind: string
+      workspace: {
+        slug: string
+        description: string | null
+        defaultThreadScope: string
+        externalHandoffsEnabled: boolean
+      }
+      policy: {
+        defaults: {
+          externalInitiation: string
+          allowedPartners: string[]
+        }
+        workflowRules: Array<{
+          workflowType: string
+          requireApproval: boolean
+          approvers: string[]
+        }>
+        metadata: {
+          template: {
+            templateKey: string | null
+            policyPackKey: string | null
+            hostGroupLabel: string | null
+            appliedBy: string | null
+          } | null
+        }
+      }
+    }
+    assert.equal(remediationBody.ok, true)
+    assert.equal(remediationBody.kind, 'reapply_template')
+    assert.equal(remediationBody.workspace.slug, 'openclaw-local')
+    assert.equal(remediationBody.workspace.description, 'Production partner workspace')
+    assert.equal(remediationBody.workspace.defaultThreadScope, 'handoff')
+    assert.equal(remediationBody.workspace.externalHandoffsEnabled, true)
+    assert.equal(remediationBody.policy.defaults.externalInitiation, 'deny')
+    assert.deepEqual(remediationBody.policy.defaults.allowedPartners, ['finance@northwind.beam.directory'])
+    assert.equal(remediationBody.policy.workflowRules[0]?.workflowType, 'quote.approval')
+    assert.equal(remediationBody.policy.workflowRules[0]?.requireApproval, true)
+    assert.deepEqual(remediationBody.policy.workflowRules[0]?.approvers, ['ops@example.com'])
+    assert.equal(remediationBody.policy.metadata.template?.templateKey, 'prod-workspace')
+    assert.equal(remediationBody.policy.metadata.template?.policyPackKey, 'prod-default')
+    assert.equal(remediationBody.policy.metadata.template?.hostGroupLabel, 'production')
+    assert.equal(remediationBody.policy.metadata.template?.appliedBy, 'admin@example.com')
+
+    const overviewAfterResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewAfterResponse.status, 200)
+    const overviewAfterBody = await overviewAfterResponse.json() as {
+      templates: {
+        summary: {
+          templatedWorkspaces: number
+          driftedWorkspaces: number
+        }
+      }
+      remediation: {
+        suggested: Array<{
+          kind: string
+          workspaceSlug: string | null
+        }>
+      }
+    }
+    assert.equal(overviewAfterBody.templates.summary.templatedWorkspaces, 1)
+    assert.equal(overviewAfterBody.templates.summary.driftedWorkspaces, 0)
+    assert.ok(!overviewAfterBody.remediation.suggested.some((item) =>
+      item.kind === 'reapply_template' && item.workspaceSlug === 'openclaw-local',
+    ))
   } finally {
     db.close()
   }
@@ -1784,6 +2065,178 @@ test('revoked openclaw host routes block Beam delivery immediately', async () =>
       (error: unknown) => error instanceof RelayError && error.code === 'FORBIDDEN' && error.message.includes('revoked OpenClaw host'),
     )
     assert.equal(getIntentLogByNonce(db, nonce)?.error_code, 'HOST_REVOKED')
+  } finally {
+    db.close()
+  }
+})
+
+test('guided fleet remediations align rollout, drain missing receipts, and end stale routes', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    process.env['JWT_SECRET'] = process.env['JWT_SECRET'] ?? 'test-secret'
+    const alpha = createFixtureAgent('alpha-remediation@openclaw.beam.directory')
+    const bravo = createFixtureAgent('bravo-remediation@openclaw.beam.directory')
+    registerFixtureAgent(db, alpha, 'Alpha Remediation')
+    registerFixtureAgent(db, bravo, 'Bravo Remediation')
+
+    const app = createApp(db)
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    const workspaceResponse = await app.request(new Request('http://localhost/admin/workspaces', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        name: 'OpenClaw Local',
+        slug: 'openclaw-local',
+        externalHandoffsEnabled: true,
+      }),
+    }))
+    assert.equal(workspaceResponse.status, 201)
+
+    const alphaHost = createApprovedHostWithRoute(db, {
+      label: 'Alpha Remediation Host',
+      hostname: 'alpha-remediation.local',
+      beamId: alpha.beamId,
+      routeKey: 'alpha-remediation-route',
+      workspaceSlug: 'openclaw-local',
+    })
+    const bravoHost = createApprovedHostWithRoute(db, {
+      label: 'Bravo Remediation Host',
+      hostname: 'bravo-remediation.local',
+      beamId: bravo.beamId,
+      routeKey: 'bravo-remediation-route',
+      workspaceSlug: 'openclaw-local',
+      heartbeatAt: new Date(Date.now() - (20 * 60 * 1000)).toISOString(),
+    })
+
+    const rolloutResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${alphaHost.host.id}/rollout`, {
+      method: 'PATCH',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        ring: 'pinned',
+        desiredConnectorVersion: '9.9.9-test',
+        notes: 'intentional rollout drift',
+      }),
+    }))
+    assert.equal(rolloutResponse.status, 200)
+
+    const overviewBeforeResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewBeforeResponse.status, 200)
+    const overviewBeforeBody = await overviewBeforeResponse.json() as {
+      remediation: {
+        suggested: Array<{
+          kind: string
+          hostId: number | null
+          requiresConfirmation: boolean
+        }>
+      }
+    }
+    assert.ok(overviewBeforeBody.remediation.suggested.some((item) =>
+      item.kind === 'align_rollout' && item.hostId === alphaHost.host.id && item.requiresConfirmation === false,
+    ))
+    assert.ok(overviewBeforeBody.remediation.suggested.some((item) =>
+      item.kind === 'drain_missing_receipts' && item.hostId === alphaHost.host.id && item.requiresConfirmation,
+    ))
+    assert.ok(overviewBeforeBody.remediation.suggested.some((item) =>
+      item.kind === 'end_stale_routes' && item.hostId === bravoHost.host.id && item.requiresConfirmation === false,
+    ))
+
+    const alignResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/remediations/apply', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'align_rollout',
+        hostId: alphaHost.host.id,
+        note: 'Adopt current connector target',
+      }),
+    }))
+    assert.equal(alignResponse.status, 200)
+    const alignBody = await alignResponse.json() as {
+      ok: boolean
+      host: {
+        rollout: {
+          desiredConnectorVersion: string | null
+          versionState: string
+        }
+      }
+    }
+    assert.equal(alignBody.ok, true)
+    assert.equal(alignBody.host.rollout.desiredConnectorVersion, '1.2.0-test')
+    assert.equal(alignBody.host.rollout.versionState, 'current')
+
+    const drainResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/remediations/apply', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'drain_missing_receipts',
+        hostId: alphaHost.host.id,
+        confirmPhrase: 'DRAIN_HOST',
+        note: 'Drain host with missing receipts',
+      }),
+    }))
+    assert.equal(drainResponse.status, 200)
+    const drainBody = await drainResponse.json() as {
+      ok: boolean
+      host: {
+        maintenance: {
+          state: string
+          owner: string | null
+        }
+      }
+    }
+    assert.equal(drainBody.ok, true)
+    assert.equal(drainBody.host.maintenance.state, 'draining')
+    assert.equal(drainBody.host.maintenance.owner, 'admin@example.com')
+
+    const endStaleResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/remediations/apply', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        kind: 'end_stale_routes',
+        hostId: bravoHost.host.id,
+        note: 'End stale routes after heartbeat timeout',
+      }),
+    }))
+    assert.equal(endStaleResponse.status, 200)
+    const endStaleBody = await endStaleResponse.json() as {
+      ok: boolean
+      routes: Array<{
+        beamId: string
+        runtimeSessionState: string
+      }>
+    }
+    assert.equal(endStaleBody.ok, true)
+    assert.equal(endStaleBody.routes[0]?.beamId, bravo.beamId)
+    assert.equal(endStaleBody.routes[0]?.runtimeSessionState, 'ended')
+    assert.equal(listOpenClawResolvedRoutesByBeamId(db, bravo.beamId)[0]?.runtime_session_state, 'ended')
+
+    const overviewAfterResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/overview', {
+      headers: createAdminHeaders(db, 'viewer@example.com', 'viewer'),
+    }))
+    assert.equal(overviewAfterResponse.status, 200)
+    const overviewAfterBody = await overviewAfterResponse.json() as {
+      remediation: {
+        suggested: Array<{
+          kind: string
+          hostId: number | null
+        }>
+      }
+    }
+    assert.ok(!overviewAfterBody.remediation.suggested.some((item) =>
+      item.kind === 'align_rollout' && item.hostId === alphaHost.host.id,
+    ))
+    assert.ok(!overviewAfterBody.remediation.suggested.some((item) =>
+      item.kind === 'drain_missing_receipts' && item.hostId === alphaHost.host.id,
+    ))
+    assert.ok(!overviewAfterBody.remediation.suggested.some((item) =>
+      item.kind === 'end_stale_routes' && item.hostId === bravoHost.host.id,
+    ))
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -10,6 +10,8 @@ import {
   createOpenClawHost,
   getAgent,
   getLatestIntentLogByTarget,
+  getOpenClawPolicyPackByKey,
+  getOpenClawWorkspaceTemplateByKey,
   getOpenClawFleetDigestRunById,
   getOpenClawFleetDigestSchedule,
   getOpenClawEnrollmentRequestById,
@@ -18,6 +20,7 @@ import {
   getOpenClawHostById,
   getOpenClawHostByKey,
   getOpenClawHostRouteById,
+  getWorkspacePolicyDocument,
   getWorkspaceById,
   getWorkspaceBySlug,
   listOpenClawEnrollmentRequests,
@@ -25,11 +28,16 @@ import {
   listOpenClawFleetDigestRuns,
   listOpenClawHostHeartbeats,
   listOpenClawHosts,
+  listOpenClawPolicyPacks,
   listOpenClawResolvedRoutesByBeamId,
   listOpenClawResolvedRoutesForHost,
+  listOpenClawWorkspaceTemplates,
   listAuditLog,
+  listWorkspaces,
+  listWorkspaceIdentityBindings,
   listWorkspaceIdentityBindingsByBeamId,
   logAuditEvent,
+  markOpenClawHostRoutesEnded,
   recordOpenClawHostHeartbeat,
   recalculateOpenClawRouteStates,
   recoverOpenClawHost,
@@ -40,11 +48,16 @@ import {
   recordOpenClawFleetDigestDelivery,
   setOpenClawRouteOwnerResolution,
   syncOpenClawHostRoutes,
+  updateWorkspace,
+  updateWorkspacePolicyDocument,
   updateOpenClawEnrollmentRequest,
   updateOpenClawFleetDigestSchedule,
   updateOpenClawHost,
+  upsertOpenClawPolicyPack,
+  upsertOpenClawWorkspaceTemplate,
 } from '../db.js'
 import { getSuppliedApiKey, hostApiKeyMatches, hostKeyFromApiKey } from '../api-key.js'
+import { serializeWorkspace } from './workspaces.js'
 import type {
   IntentLogRow,
   OpenClawFleetDigestDeliveryKind,
@@ -57,6 +70,7 @@ import type {
   OpenClawHostCredentialState,
   OpenClawHostEnrollmentRequestRow,
   OpenClawHostHealth,
+  OpenClawPolicyPackRow,
   OpenClawHostRow,
   OpenClawHostRouteRow,
   OpenClawRouteOwnerResolutionState,
@@ -64,7 +78,10 @@ import type {
   OpenClawRouteReportedState,
   OpenClawRouteRuntimeState,
   OpenClawRouteSource,
+  OpenClawWorkspaceTemplateRow,
+  WorkspacePolicy,
 } from '../types.js'
+import { parseWorkspacePolicy } from '../workspace-policy.js'
 
 type OpenClawFleetDigestSeverity = 'warning' | 'critical'
 
@@ -199,6 +216,118 @@ type OpenClawHostGroupSummary = {
   pendingHosts: number
   environments: string[]
   hostIds: number[]
+}
+
+type OpenClawPolicyPackDefinition = {
+  defaults?: WorkspacePolicy['defaults']
+  bindingRules?: WorkspacePolicy['bindingRules']
+  workflowRules?: WorkspacePolicy['workflowRules']
+  metadata?: {
+    notes?: string | null
+  }
+}
+
+type OpenClawWorkspaceTemplateDefinition = {
+  defaultThreadScope?: 'internal' | 'handoff'
+  externalHandoffsEnabled?: boolean
+  description?: string | null
+}
+
+type SerializedOpenClawPolicyPack = {
+  id: number
+  key: string
+  label: string
+  description: string | null
+  hostGroupLabel: string | null
+  policy: WorkspacePolicy
+  createdAt: string
+  updatedAt: string
+}
+
+type SerializedOpenClawWorkspaceTemplate = {
+  id: number
+  key: string
+  label: string
+  description: string | null
+  hostGroupLabel: string | null
+  policyPackKey: string | null
+  policyPackLabel: string | null
+  template: {
+    defaultThreadScope: 'internal' | 'handoff'
+    externalHandoffsEnabled: boolean
+    description: string | null
+  }
+  createdAt: string
+  updatedAt: string
+}
+
+type SerializedOpenClawFleetTemplateAttentionWorkspace = {
+  workspaceId: number
+  workspaceSlug: string
+  workspaceName: string
+  hostGroups: string[]
+  templateKey: string | null
+  expectedTemplateKey: string | null
+  policyPackKey: string | null
+  drifted: boolean
+  reason: string
+  href: string
+}
+
+type SerializedOpenClawFleetTemplateSummary = {
+  summary: {
+    policyPacks: number
+    workspaceTemplates: number
+    templatedWorkspaces: number
+    driftedWorkspaces: number
+  }
+  policyPacks: SerializedOpenClawPolicyPack[]
+  workspaceTemplates: SerializedOpenClawWorkspaceTemplate[]
+  attentionWorkspaces: SerializedOpenClawFleetTemplateAttentionWorkspace[]
+}
+
+type OpenClawFleetRemediationKind =
+  | 'align_rollout'
+  | 'end_stale_routes'
+  | 'drain_missing_receipts'
+  | 'reapply_template'
+
+type SerializedOpenClawFleetRemediationItem = {
+  id: string
+  kind: OpenClawFleetRemediationKind
+  severity: OpenClawFleetDigestSeverity
+  title: string
+  detail: string
+  nextAction: string
+  safe: boolean
+  requiresConfirmation: boolean
+  hostId: number | null
+  hostLabel: string | null
+  workspaceSlug: string | null
+  templateKey: string | null
+  href: string | null
+}
+
+type SerializedOpenClawFleetRemediationHistoryItem = {
+  id: string
+  action: string
+  actor: string | null
+  timestamp: string
+  target: string
+  kind: OpenClawFleetRemediationKind | null
+  note: string | null
+  href: string | null
+}
+
+type SerializedOpenClawFleetRemediationSummary = {
+  summary: {
+    suggested: number
+    critical: number
+    requiresConfirmation: number
+    appliedRecently: number
+  }
+  suggested: SerializedOpenClawFleetRemediationItem[]
+  history: SerializedOpenClawFleetRemediationHistoryItem[]
 }
 
 type OpenClawFleetCredentialPolicyAttentionHost = {
@@ -551,6 +680,66 @@ function serializeOpenClawHostMetadata(metadata: OpenClawHostMetadataJson): stri
     return null
   }
   return JSON.stringify(cleaned)
+}
+
+function parseOpenClawPolicyPack(raw: string | null): WorkspacePolicy {
+  return parseWorkspacePolicy(raw)
+}
+
+function parseOpenClawWorkspaceTemplate(raw: string | null): OpenClawWorkspaceTemplateDefinition {
+  if (!raw) {
+    return {}
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    return {
+      defaultThreadScope: parsed.defaultThreadScope === 'handoff' ? 'handoff' : 'internal',
+      externalHandoffsEnabled: parsed.externalHandoffsEnabled === undefined
+        ? true
+        : parsed.externalHandoffsEnabled === true,
+      description: normalizeOptionalString(parsed.description),
+    }
+  } catch {
+    return {}
+  }
+}
+
+function serializeOpenClawPolicyPack(row: OpenClawPolicyPackRow): SerializedOpenClawPolicyPack {
+  return {
+    id: row.id,
+    key: row.pack_key,
+    label: row.label,
+    description: row.description,
+    hostGroupLabel: normalizeOptionalString(row.host_group_label),
+    policy: parseOpenClawPolicyPack(row.policy_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function serializeOpenClawWorkspaceTemplate(
+  row: OpenClawWorkspaceTemplateRow,
+  policyPackByKey: Map<string, SerializedOpenClawPolicyPack>,
+): SerializedOpenClawWorkspaceTemplate {
+  const template = parseOpenClawWorkspaceTemplate(row.template_json)
+  const policyPack = row.policy_pack_key ? policyPackByKey.get(row.policy_pack_key) ?? null : null
+  return {
+    id: row.id,
+    key: row.template_key,
+    label: row.label,
+    description: row.description,
+    hostGroupLabel: normalizeOptionalString(row.host_group_label),
+    policyPackKey: row.policy_pack_key,
+    policyPackLabel: policyPack?.label ?? null,
+    template: {
+      defaultThreadScope: template.defaultThreadScope ?? 'internal',
+      externalHandoffsEnabled: template.externalHandoffsEnabled ?? true,
+      description: template.description ?? null,
+    },
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
 }
 
 function computeNextRotationWindow(
@@ -1545,6 +1734,402 @@ function summarizeOpenClawFleetGroups(hosts: Array<ReturnType<typeof serializeHo
       environments: [...group.environments].sort((left, right) => left.localeCompare(right)),
     }))
     .sort((left, right) => left.label.localeCompare(right.label))
+}
+
+function sortUniqueStrings(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const value of values) {
+    const trimmed = normalizeOptionalString(value)
+    if (!trimmed || seen.has(trimmed)) {
+      continue
+    }
+    seen.add(trimmed)
+    normalized.push(trimmed)
+  }
+  return normalized.sort((left, right) => left.localeCompare(right))
+}
+
+function canonicalizeWorkspacePolicy(policy: WorkspacePolicy) {
+  return {
+    defaults: {
+      externalInitiation: policy.defaults.externalInitiation,
+      allowedPartners: sortUniqueStrings(policy.defaults.allowedPartners),
+    },
+    bindingRules: [...policy.bindingRules]
+      .map((rule) => ({
+        beamId: normalizeOptionalString(rule.beamId),
+        bindingType: rule.bindingType ?? null,
+        policyProfile: normalizeOptionalString(rule.policyProfile),
+        externalInitiation: rule.externalInitiation,
+        allowedPartners: sortUniqueStrings(rule.allowedPartners),
+      }))
+      .sort((left, right) =>
+        (left.beamId ?? '').localeCompare(right.beamId ?? '')
+        || (left.bindingType ?? '').localeCompare(right.bindingType ?? '')
+        || (left.policyProfile ?? '').localeCompare(right.policyProfile ?? '')
+        || left.externalInitiation.localeCompare(right.externalInitiation)),
+    workflowRules: [...policy.workflowRules]
+      .map((rule) => ({
+        workflowType: rule.workflowType,
+        requireApproval: rule.requireApproval === true,
+        allowedPartners: sortUniqueStrings(rule.allowedPartners),
+        approvers: sortUniqueStrings(rule.approvers),
+      }))
+      .sort((left, right) => left.workflowType.localeCompare(right.workflowType)),
+  }
+}
+
+function workspacePoliciesMatch(left: WorkspacePolicy, right: WorkspacePolicy): boolean {
+  return JSON.stringify(canonicalizeWorkspacePolicy(left)) === JSON.stringify(canonicalizeWorkspacePolicy(right))
+}
+
+function collectWorkspaceHostGroups(
+  db: Database,
+  workspaceSlug: string,
+  workspaceId: number,
+  hostsById: Map<number, ReturnType<typeof serializeHost>>,
+): string[] {
+  const groups: string[] = []
+
+  for (const host of hostsById.values()) {
+    if (host.workspaceSlug === workspaceSlug) {
+      groups.push(...host.placement.groupLabels)
+    }
+  }
+
+  for (const binding of listWorkspaceIdentityBindings(db, workspaceId)) {
+    for (const route of listOpenClawResolvedRoutesByBeamId(db, binding.beam_id)) {
+      if (!route.host_id) {
+        continue
+      }
+      const host = hostsById.get(route.host_id)
+      if (!host) {
+        continue
+      }
+      groups.push(...host.placement.groupLabels)
+    }
+  }
+
+  return sortUniqueStrings(groups)
+}
+
+function selectExpectedWorkspaceTemplate(
+  currentTemplate: SerializedOpenClawWorkspaceTemplate | null,
+  matchingTemplates: SerializedOpenClawWorkspaceTemplate[],
+): SerializedOpenClawWorkspaceTemplate | null {
+  if (currentTemplate && matchingTemplates.some((template) => template.key === currentTemplate.key)) {
+    return currentTemplate
+  }
+  return matchingTemplates.length === 1 ? matchingTemplates[0] ?? null : null
+}
+
+function applyOpenClawWorkspaceTemplate(
+  db: Database,
+  input: {
+    workspaceSlug: string
+    template: SerializedOpenClawWorkspaceTemplate
+    actor: string
+    note?: string | null
+  },
+): {
+  workspace: ReturnType<typeof getWorkspaceBySlug>
+  policy: WorkspacePolicy
+  updatedAt: string | null
+  updatedBy: string | null
+} | null {
+  const workspace = getWorkspaceBySlug(db, input.workspaceSlug)
+  if (!workspace) {
+    return null
+  }
+
+  const currentPolicyDocument = getWorkspacePolicyDocument(db, workspace.id)
+  const policyPack = input.template.policyPackKey
+    ? getOpenClawPolicyPackByKey(db, input.template.policyPackKey)
+    : null
+  const packPolicy = policyPack ? parseOpenClawPolicyPack(policyPack.policy_json) : currentPolicyDocument.policy
+  const templateAppliedAt = new Date().toISOString()
+
+  const updatedWorkspace = updateWorkspace(db, {
+    id: workspace.id,
+    description: input.template.template.description,
+    defaultThreadScope: input.template.template.defaultThreadScope,
+    externalHandoffsEnabled: input.template.template.externalHandoffsEnabled,
+  })
+
+  const policyResult = updateWorkspacePolicyDocument(db, workspace.id, {
+    defaults: packPolicy.defaults,
+    bindingRules: packPolicy.bindingRules,
+    workflowRules: packPolicy.workflowRules,
+    metadata: {
+      notes: packPolicy.metadata.notes ?? currentPolicyDocument.policy.metadata.notes,
+      template: {
+        templateKey: input.template.key,
+        templateLabel: input.template.label,
+        policyPackKey: input.template.policyPackKey,
+        policyPackLabel: input.template.policyPackLabel,
+        hostGroupLabel: input.template.hostGroupLabel,
+        appliedAt: templateAppliedAt,
+        appliedBy: input.actor,
+      },
+    },
+  }, input.actor)
+
+  logAuditEvent(db, {
+    action: 'admin.openclaw_workspace_template.applied',
+    actor: input.actor,
+    target: `openclaw-workspace:${workspace.slug}`,
+    details: {
+      templateKey: input.template.key,
+      templateLabel: input.template.label,
+      policyPackKey: input.template.policyPackKey,
+      policyPackLabel: input.template.policyPackLabel,
+      hostGroupLabel: input.template.hostGroupLabel,
+      note: input.note ?? null,
+    },
+  })
+
+  return {
+    workspace: updatedWorkspace,
+    policy: policyResult.policy,
+    updatedAt: policyResult.updatedAt,
+    updatedBy: policyResult.updatedBy,
+  }
+}
+
+function buildOpenClawFleetTemplateSummary(
+  db: Database,
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): SerializedOpenClawFleetTemplateSummary {
+  const serializedPolicyPacks = listOpenClawPolicyPacks(db).map((row) => serializeOpenClawPolicyPack(row))
+  const policyPackByKey = new Map(serializedPolicyPacks.map((pack) => [pack.key, pack]))
+  const serializedWorkspaceTemplates = listOpenClawWorkspaceTemplates(db)
+    .map((row) => serializeOpenClawWorkspaceTemplate(row, policyPackByKey))
+  const workspaceTemplateByKey = new Map(serializedWorkspaceTemplates.map((template) => [template.key, template]))
+  const hostsById = new Map(hosts.map((host) => [host.id, host]))
+  const attentionWorkspaces: SerializedOpenClawFleetTemplateAttentionWorkspace[] = []
+  let templatedWorkspaces = 0
+
+  for (const workspace of listWorkspaces(db)) {
+    const hostGroups = collectWorkspaceHostGroups(db, workspace.slug, workspace.id, hostsById)
+    const currentPolicy = getWorkspacePolicyDocument(db, workspace.id).policy
+    const templateMetadata = currentPolicy.metadata.template ?? null
+    const currentTemplate = templateMetadata?.templateKey
+      ? workspaceTemplateByKey.get(templateMetadata.templateKey) ?? null
+      : null
+    const matchingTemplates = serializedWorkspaceTemplates.filter((template) =>
+      template.hostGroupLabel ? hostGroups.includes(template.hostGroupLabel) : false)
+    const expectedTemplate = selectExpectedWorkspaceTemplate(currentTemplate, matchingTemplates)
+
+    if (currentTemplate) {
+      templatedWorkspaces += 1
+    }
+
+    let driftReason: string | null = null
+    if (templateMetadata?.templateKey && !currentTemplate) {
+      driftReason = `Applied template ${templateMetadata.templateKey} is no longer defined.`
+    } else if (matchingTemplates.length > 1 && !currentTemplate) {
+      driftReason = `Multiple workspace templates match host groups ${hostGroups.join(', ')}.`
+    } else if (expectedTemplate && !currentTemplate) {
+      driftReason = `Expected workspace template ${expectedTemplate.key} for host group ${expectedTemplate.hostGroupLabel}.`
+    } else if (expectedTemplate && currentTemplate && currentTemplate.key !== expectedTemplate.key) {
+      driftReason = `Workspace should use template ${expectedTemplate.key} for host group ${expectedTemplate.hostGroupLabel}.`
+    } else if (currentTemplate) {
+      const descriptionMatches = normalizeOptionalString(workspace.description) === currentTemplate.template.description
+      const threadScopeMatches = workspace.default_thread_scope === currentTemplate.template.defaultThreadScope
+      const handoffMatches = (workspace.external_handoffs_enabled === 1) === currentTemplate.template.externalHandoffsEnabled
+      if (!descriptionMatches || !threadScopeMatches || !handoffMatches) {
+        driftReason = 'Workspace settings drifted from the applied template.'
+      } else if (currentTemplate.policyPackKey) {
+        const policyPack = policyPackByKey.get(currentTemplate.policyPackKey) ?? null
+        if (!policyPack) {
+          driftReason = `Template ${currentTemplate.key} references missing policy pack ${currentTemplate.policyPackKey}.`
+        } else if (!workspacePoliciesMatch(currentPolicy, policyPack.policy)) {
+          driftReason = `Workspace policy drifted from policy pack ${currentTemplate.policyPackKey}.`
+        }
+      }
+    }
+
+    if (!driftReason) {
+      continue
+    }
+
+    attentionWorkspaces.push({
+      workspaceId: workspace.id,
+      workspaceSlug: workspace.slug,
+      workspaceName: workspace.name,
+      hostGroups,
+      templateKey: currentTemplate?.key ?? templateMetadata?.templateKey ?? null,
+      expectedTemplateKey: expectedTemplate?.key ?? null,
+      policyPackKey: currentTemplate?.policyPackKey ?? expectedTemplate?.policyPackKey ?? templateMetadata?.policyPackKey ?? null,
+      drifted: true,
+      reason: driftReason,
+      href: buildWorkspaceHref(workspace.slug) ?? `/workspaces?workspace=${encodeURIComponent(workspace.slug)}`,
+    })
+  }
+
+  attentionWorkspaces.sort((left, right) =>
+    left.workspaceSlug.localeCompare(right.workspaceSlug) || left.workspaceId - right.workspaceId)
+
+  return {
+    summary: {
+      policyPacks: serializedPolicyPacks.length,
+      workspaceTemplates: serializedWorkspaceTemplates.length,
+      templatedWorkspaces,
+      driftedWorkspaces: attentionWorkspaces.length,
+    },
+    policyPacks: serializedPolicyPacks,
+    workspaceTemplates: serializedWorkspaceTemplates,
+    attentionWorkspaces,
+  }
+}
+
+function buildOpenClawFleetRemediationSummary(
+  db: Database,
+  hosts: Array<ReturnType<typeof serializeHost>>,
+  rollout: OpenClawFleetRolloutSummary,
+  routeHealth: OpenClawFleetRouteHealthSummary,
+  templates: SerializedOpenClawFleetTemplateSummary,
+): SerializedOpenClawFleetRemediationSummary {
+  const suggested: SerializedOpenClawFleetRemediationItem[] = []
+
+  for (const host of hosts) {
+    if (host.rollout.versionState === 'drifted' && host.connectorVersion) {
+      suggested.push({
+        id: `align-rollout:${host.id}`,
+        kind: 'align_rollout',
+        severity: host.healthStatus === 'stale' ? 'critical' : 'warning',
+        title: `${hostTitleForDigest(host)} is off the desired connector target`,
+        detail: `${host.connectorVersion} is currently installed while the rollout target is ${host.rollout.desiredConnectorVersion ?? 'unset'}.`,
+        nextAction: 'Adopt the live connector version as the desired target if this host reflects the intended rollout state.',
+        safe: true,
+        requiresConfirmation: false,
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        templateKey: null,
+        href: buildOpenClawFleetHref(host.id),
+      })
+    }
+
+    if (host.summary.stale > 0) {
+      suggested.push({
+        id: `end-stale-routes:${host.id}`,
+        kind: 'end_stale_routes',
+        severity: host.healthStatus === 'stale' ? 'critical' : 'warning',
+        title: `${hostTitleForDigest(host)} still advertises stale routes`,
+        detail: `${host.summary.stale} stale route(s) remain visible and should be ended before they linger as deliverable history.`,
+        nextAction: 'End only the stale routes on this host and wait for the next inventory sync to republish live routes.',
+        safe: true,
+        requiresConfirmation: false,
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        templateKey: null,
+        href: buildOpenClawFleetHref(host.id),
+      })
+    }
+  }
+
+  for (const attentionHost of routeHealth.attentionHosts) {
+    if (attentionHost.failedReceipts === 0 && attentionHost.missingReceipts === 0) {
+      continue
+    }
+    const host = hosts.find((candidate) => candidate.id === attentionHost.hostId) ?? null
+    if (!host || host.maintenance.state !== 'serving') {
+      continue
+    }
+    suggested.push({
+      id: `drain-missing-receipts:${attentionHost.hostId}`,
+      kind: 'drain_missing_receipts',
+      severity: attentionHost.failedReceipts > 0 ? 'critical' : 'warning',
+      title: `${attentionHost.hostLabel || `Host ${attentionHost.hostId}`} is missing receipts or failing delivery`,
+      detail: `${attentionHost.failedReceipts} failed receipt(s) and ${attentionHost.missingReceipts} missing receipt(s) are currently open.`,
+      nextAction: 'Drain the host before debugging or replacing it so Beam stops sending new work to a route that is already degrading.',
+      safe: false,
+      requiresConfirmation: true,
+      hostId: attentionHost.hostId,
+      hostLabel: attentionHost.hostLabel,
+      workspaceSlug: attentionHost.workspaceSlug,
+      templateKey: null,
+      href: buildOpenClawFleetHref(attentionHost.hostId),
+    })
+  }
+
+  for (const workspace of templates.attentionWorkspaces) {
+    const templateKey = workspace.expectedTemplateKey ?? workspace.templateKey
+    if (!templateKey) {
+      continue
+    }
+    suggested.push({
+      id: `reapply-template:${workspace.workspaceSlug}:${templateKey}`,
+      kind: 'reapply_template',
+      severity: 'warning',
+      title: `${workspace.workspaceSlug} drifted from its fleet template`,
+      detail: workspace.reason,
+      nextAction: 'Reapply the expected template to restore policy and workspace defaults from the fleet-backed source of truth.',
+      safe: false,
+      requiresConfirmation: true,
+      hostId: null,
+      hostLabel: null,
+      workspaceSlug: workspace.workspaceSlug,
+      templateKey,
+      href: workspace.href,
+    })
+  }
+
+  const history = listAuditLog(db, { limit: 250 })
+    .filter((entry) =>
+      entry.action === 'admin.openclaw_fleet_remediation.applied'
+      || entry.action === 'admin.openclaw_workspace_template.applied')
+    .map((entry): SerializedOpenClawFleetRemediationHistoryItem => {
+      const details = parseJson<Record<string, unknown>>(entry.details, {})
+      const target = entry.target
+      const hostId = target.startsWith('openclaw-host:') ? normalizePositiveInteger(target.slice('openclaw-host:'.length)) : null
+      const workspaceSlug = target.startsWith('openclaw-workspace:') ? normalizeOptionalString(target.slice('openclaw-workspace:'.length)) : null
+      const kindRaw = normalizeOptionalString(details.kind)
+      const kind: OpenClawFleetRemediationKind | null =
+        kindRaw === 'align_rollout'
+        || kindRaw === 'end_stale_routes'
+        || kindRaw === 'drain_missing_receipts'
+        || kindRaw === 'reapply_template'
+          ? kindRaw
+          : (entry.action === 'admin.openclaw_workspace_template.applied' ? 'reapply_template' : null)
+
+      return {
+        id: `remediation-history:${entry.id}`,
+        action: entry.action,
+        actor: entry.actor,
+        timestamp: entry.timestamp,
+        target,
+        kind,
+        note: normalizeOptionalString(details.note),
+        href: hostId
+          ? buildOpenClawFleetHref(hostId)
+          : (workspaceSlug ? (buildWorkspaceHref(workspaceSlug) ?? null) : null),
+      }
+    })
+    .slice(0, 25)
+
+  suggested.sort((left, right) =>
+    severityWeight(left.severity) - severityWeight(right.severity)
+      || Number(left.requiresConfirmation) - Number(right.requiresConfirmation)
+      || (left.hostLabel ?? left.workspaceSlug ?? '').localeCompare(right.hostLabel ?? right.workspaceSlug ?? '')
+      || left.id.localeCompare(right.id))
+
+  const now = Date.now()
+  const appliedRecently = history.filter((entry) => Number.isFinite(Date.parse(entry.timestamp)) && (now - Date.parse(entry.timestamp)) <= (7 * 24 * 60 * 60 * 1000)).length
+
+  return {
+    summary: {
+      suggested: suggested.length,
+      critical: suggested.filter((item) => item.severity === 'critical').length,
+      requiresConfirmation: suggested.filter((item) => item.requiresConfirmation).length,
+      appliedRecently,
+    },
+    suggested,
+    history,
+  }
 }
 
 function buildOpenClawFleetMaintenanceSummary(
@@ -2691,6 +3276,8 @@ export function openClawAdminRouter(db: Database) {
     const rollout = buildOpenClawFleetRolloutSummary(hosts)
     const credentialPolicy = buildOpenClawFleetCredentialPolicySummary(hosts)
     const routeHealth = buildOpenClawFleetRouteHealthSummary(db, hosts)
+    const templates = buildOpenClawFleetTemplateSummary(db, hosts)
+    const remediation = buildOpenClawFleetRemediationSummary(db, hosts, rollout, routeHealth, templates)
     const summary = hosts.reduce((acc, host) => {
       acc.totalHosts += 1
       if (host.status === 'pending') acc.pendingHosts += 1
@@ -2742,6 +3329,9 @@ export function openClawAdminRouter(db: Database) {
         pendingCredentialActions: digest.summary.pendingCredentialActions,
         actionItems: digest.summary.actionItems,
         criticalItems: digest.summary.criticalItems,
+        templateDriftedWorkspaces: templates.summary.driftedWorkspaces,
+        suggestedRemediations: remediation.summary.suggested,
+        criticalRemediations: remediation.summary.critical,
       },
       hosts,
       conflicts,
@@ -2749,8 +3339,412 @@ export function openClawAdminRouter(db: Database) {
       rollout,
       credentialPolicy,
       routeHealth,
+      templates,
+      remediation,
       environments,
       hostGroups,
+    })
+  })
+
+  router.get('/fleet/policy-packs', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const policyPacks = listOpenClawPolicyPacks(db).map((row) => serializeOpenClawPolicyPack(row))
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      total: policyPacks.length,
+      policyPacks,
+    })
+  })
+
+  router.put('/fleet/policy-packs/:key', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const packKey = normalizeOptionalString(c.req.param('key'))
+    if (!packKey) {
+      return c.json({ error: 'Invalid policy pack key', errorCode: 'INVALID_POLICY_PACK_KEY' }, 400)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const policy = parseOpenClawPolicyPack(
+      typeof body.policy === 'string'
+        ? body.policy
+        : JSON.stringify(body.policy ?? {}),
+    )
+    const saved = upsertOpenClawPolicyPack(db, {
+      packKey,
+      label: normalizeOptionalString(body.label) ?? packKey,
+      description: normalizeOptionalString(body.description),
+      hostGroupLabel: normalizeOptionalString(body.hostGroupLabel),
+      policyJson: JSON.stringify(policy),
+    })
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_policy_pack.upserted',
+      actor: auth.session.email,
+      target: `openclaw-policy-pack:${saved.pack_key}`,
+      details: {
+        role: auth.session.role,
+        label: saved.label,
+        hostGroupLabel: saved.host_group_label,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      policyPack: serializeOpenClawPolicyPack(saved),
+    })
+  })
+
+  router.get('/fleet/workspace-templates', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const policyPackByKey = new Map(listOpenClawPolicyPacks(db).map((row) => {
+      const serialized = serializeOpenClawPolicyPack(row)
+      return [serialized.key, serialized] as const
+    }))
+    const workspaceTemplates = listOpenClawWorkspaceTemplates(db)
+      .map((row) => serializeOpenClawWorkspaceTemplate(row, policyPackByKey))
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      total: workspaceTemplates.length,
+      workspaceTemplates,
+    })
+  })
+
+  router.put('/fleet/workspace-templates/:key', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const templateKey = normalizeOptionalString(c.req.param('key'))
+    if (!templateKey) {
+      return c.json({ error: 'Invalid workspace template key', errorCode: 'INVALID_WORKSPACE_TEMPLATE_KEY' }, 400)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const policyPackKey = normalizeOptionalString(body.policyPackKey)
+    if (policyPackKey && !getOpenClawPolicyPackByKey(db, policyPackKey)) {
+      return c.json({ error: 'Unknown policy pack', errorCode: 'POLICY_PACK_NOT_FOUND' }, 404)
+    }
+
+    const template = parseOpenClawWorkspaceTemplate(
+      typeof body.template === 'string'
+        ? body.template
+        : JSON.stringify(body.template ?? {}),
+    )
+    const saved = upsertOpenClawWorkspaceTemplate(db, {
+      templateKey,
+      label: normalizeOptionalString(body.label) ?? templateKey,
+      description: normalizeOptionalString(body.description) ?? template.description ?? null,
+      hostGroupLabel: normalizeOptionalString(body.hostGroupLabel),
+      policyPackKey,
+      templateJson: JSON.stringify(template),
+    })
+    const policyPackByKey = new Map(listOpenClawPolicyPacks(db).map((row) => {
+      const serialized = serializeOpenClawPolicyPack(row)
+      return [serialized.key, serialized] as const
+    }))
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_workspace_template.upserted',
+      actor: auth.session.email,
+      target: `openclaw-workspace-template:${saved.template_key}`,
+      details: {
+        role: auth.session.role,
+        label: saved.label,
+        hostGroupLabel: saved.host_group_label,
+        policyPackKey: saved.policy_pack_key,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspaceTemplate: serializeOpenClawWorkspaceTemplate(saved, policyPackByKey),
+    })
+  })
+
+  router.post('/fleet/workspace-templates/:key/apply', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    const templateKey = normalizeOptionalString(c.req.param('key'))
+    if (!templateKey) {
+      return c.json({ error: 'Invalid workspace template key', errorCode: 'INVALID_WORKSPACE_TEMPLATE_KEY' }, 400)
+    }
+
+    const templateRow = getOpenClawWorkspaceTemplateByKey(db, templateKey)
+    if (!templateRow) {
+      return c.json({ error: 'Workspace template not found', errorCode: 'WORKSPACE_TEMPLATE_NOT_FOUND' }, 404)
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const workspaceSlug = normalizeOptionalString(body.workspaceSlug)
+    if (!workspaceSlug) {
+      return c.json({ error: 'workspaceSlug is required', errorCode: 'WORKSPACE_SLUG_REQUIRED' }, 400)
+    }
+
+    const policyPackByKey = new Map(listOpenClawPolicyPacks(db).map((row) => {
+      const serialized = serializeOpenClawPolicyPack(row)
+      return [serialized.key, serialized] as const
+    }))
+    const template = serializeOpenClawWorkspaceTemplate(templateRow, policyPackByKey)
+    const applied = applyOpenClawWorkspaceTemplate(db, {
+      workspaceSlug,
+      template,
+      actor: auth.session.email,
+      note: normalizeOptionalString(body.note),
+    })
+
+    if (!applied || !applied.workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'WORKSPACE_NOT_FOUND' }, 404)
+    }
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      workspace: serializeWorkspace(db, applied.workspace),
+      policy: applied.policy,
+      updatedAt: applied.updatedAt,
+      updatedBy: applied.updatedBy,
+    })
+  })
+
+  router.post('/fleet/remediations/apply', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const kindRaw = normalizeOptionalString(body.kind)
+    if (
+      kindRaw !== 'align_rollout'
+      && kindRaw !== 'end_stale_routes'
+      && kindRaw !== 'drain_missing_receipts'
+      && kindRaw !== 'reapply_template'
+    ) {
+      return c.json({ error: 'Unknown remediation kind', errorCode: 'INVALID_REMEDIATION_KIND' }, 400)
+    }
+
+    const note = normalizeOptionalString(body.note)
+
+    if (kindRaw === 'align_rollout') {
+      const hostId = normalizePositiveInteger(body.hostId)
+      if (!hostId) {
+        return c.json({ error: 'hostId is required', errorCode: 'HOST_ID_REQUIRED' }, 400)
+      }
+
+      const host = getOpenClawHostById(db, hostId)
+      if (!host) {
+        return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      const patch = buildOpenClawHostRolloutPatch(host, {
+        desiredConnectorVersion: host.connector_version,
+        notes: note ?? serializeOpenClawHostRollout(host).notes,
+      })
+      const updated = updateOpenClawHost(db, {
+        id: hostId,
+        metadataJson: patch.metadataJson,
+      })
+      if (!updated) {
+        return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      logAuditEvent(db, {
+        action: 'admin.openclaw_fleet_remediation.applied',
+        actor: auth.session.email,
+        target: `openclaw-host:${hostId}`,
+        details: {
+          role: auth.session.role,
+          kind: kindRaw,
+          note: note ?? null,
+          desiredConnectorVersion: updated.connector_version,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        kind: kindRaw,
+        host: serializeHost(db, updated),
+      })
+    }
+
+    if (kindRaw === 'end_stale_routes') {
+      const hostId = normalizePositiveInteger(body.hostId)
+      if (!hostId) {
+        return c.json({ error: 'hostId is required', errorCode: 'HOST_ID_REQUIRED' }, 400)
+      }
+
+      const host = getOpenClawHostById(db, hostId)
+      if (!host) {
+        return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      const routes = markOpenClawHostRoutesEnded(db, {
+        hostId,
+        runtimeSessionState: 'stale',
+      })
+
+      logAuditEvent(db, {
+        action: 'admin.openclaw_fleet_remediation.applied',
+        actor: auth.session.email,
+        target: `openclaw-host:${hostId}`,
+        details: {
+          role: auth.session.role,
+          kind: kindRaw,
+          note: note ?? null,
+          routeCount: routes.filter((route) => route.runtime_session_state === 'ended').length,
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        kind: kindRaw,
+        host: serializeHost(db, getOpenClawHostById(db, hostId) as OpenClawHostRow),
+        routes: listOpenClawResolvedRoutesForHost(db, hostId).map((route) => serializeRoute(db, route)),
+      })
+    }
+
+    if (kindRaw === 'drain_missing_receipts') {
+      const hostId = normalizePositiveInteger(body.hostId)
+      if (!hostId) {
+        return c.json({ error: 'hostId is required', errorCode: 'HOST_ID_REQUIRED' }, 400)
+      }
+      if (normalizeOptionalString(body.confirmPhrase) !== 'DRAIN_HOST') {
+        return c.json({ error: 'confirmPhrase DRAIN_HOST is required', errorCode: 'CONFIRMATION_REQUIRED' }, 400)
+      }
+
+      const host = getOpenClawHostById(db, hostId)
+      if (!host) {
+        return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      const patch = buildOpenClawHostMaintenancePatch(host, {
+        state: 'draining',
+        owner: auth.session.email,
+        reason: note ?? 'Guided remediation drain for missing or failed receipts',
+      })
+      const updated = updateOpenClawHost(db, {
+        id: hostId,
+        metadataJson: patch.metadataJson,
+      })
+      if (!updated) {
+        return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
+      }
+
+      logAuditEvent(db, {
+        action: 'admin.openclaw_fleet_remediation.applied',
+        actor: auth.session.email,
+        target: `openclaw-host:${hostId}`,
+        details: {
+          role: auth.session.role,
+          kind: kindRaw,
+          note: note ?? null,
+          confirmPhrase: 'DRAIN_HOST',
+        },
+      })
+
+      c.header('Cache-Control', 'no-store')
+      return c.json({
+        ok: true,
+        kind: kindRaw,
+        host: serializeHost(db, updated),
+      })
+    }
+
+    const workspaceSlug = normalizeOptionalString(body.workspaceSlug)
+    const templateKey = normalizeOptionalString(body.templateKey)
+    if (!workspaceSlug) {
+      return c.json({ error: 'workspaceSlug is required', errorCode: 'WORKSPACE_SLUG_REQUIRED' }, 400)
+    }
+    if (!templateKey) {
+      return c.json({ error: 'templateKey is required', errorCode: 'TEMPLATE_KEY_REQUIRED' }, 400)
+    }
+    if (normalizeOptionalString(body.confirmPhrase) !== 'REAPPLY_TEMPLATE') {
+      return c.json({ error: 'confirmPhrase REAPPLY_TEMPLATE is required', errorCode: 'CONFIRMATION_REQUIRED' }, 400)
+    }
+
+    const templateRow = getOpenClawWorkspaceTemplateByKey(db, templateKey)
+    if (!templateRow) {
+      return c.json({ error: 'Workspace template not found', errorCode: 'WORKSPACE_TEMPLATE_NOT_FOUND' }, 404)
+    }
+
+    const policyPackByKey = new Map(listOpenClawPolicyPacks(db).map((row) => {
+      const serialized = serializeOpenClawPolicyPack(row)
+      return [serialized.key, serialized] as const
+    }))
+    const template = serializeOpenClawWorkspaceTemplate(templateRow, policyPackByKey)
+    const applied = applyOpenClawWorkspaceTemplate(db, {
+      workspaceSlug,
+      template,
+      actor: auth.session.email,
+      note,
+    })
+    if (!applied || !applied.workspace) {
+      return c.json({ error: 'Workspace not found', errorCode: 'WORKSPACE_NOT_FOUND' }, 404)
+    }
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_fleet_remediation.applied',
+      actor: auth.session.email,
+      target: `openclaw-workspace:${workspaceSlug}`,
+      details: {
+        role: auth.session.role,
+        kind: kindRaw,
+        note: note ?? null,
+        templateKey,
+        confirmPhrase: 'REAPPLY_TEMPLATE',
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ok: true,
+      kind: kindRaw,
+      workspace: serializeWorkspace(db, applied.workspace),
+      policy: applied.policy,
+      updatedAt: applied.updatedAt,
+      updatedBy: applied.updatedBy,
     })
   })
 

--- a/packages/directory/src/routes/workspaces.ts
+++ b/packages/directory/src/routes/workspaces.ts
@@ -910,7 +910,7 @@ function summarizeWorkspaceAuditAction(action: string, details: Record<string, u
     }
 }
 
-function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspace {
+export function serializeWorkspace(db: Database, row: WorkspaceRow): SerializedWorkspace {
   const summary = getWorkspaceSummary(db, row.id)
   const { policy } = getWorkspacePolicyDocument(db, row.id)
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -406,6 +406,29 @@ export interface OpenClawFleetDigestDeliveryRow {
   details_json: string | null
 }
 
+export interface OpenClawPolicyPackRow {
+  id: number
+  pack_key: string
+  label: string
+  description: string | null
+  host_group_label: string | null
+  policy_json: string
+  created_at: string
+  updated_at: string
+}
+
+export interface OpenClawWorkspaceTemplateRow {
+  id: number
+  template_key: string
+  label: string
+  description: string | null
+  host_group_label: string | null
+  policy_pack_key: string | null
+  template_json: string
+  created_at: string
+  updated_at: string
+}
+
 export interface WorkspacePolicyRow {
   workspace_id: number
   policy_json: string
@@ -430,6 +453,15 @@ export interface WorkspacePolicyWorkflowRule {
 
 export interface WorkspacePolicyMetadata {
   notes: string | null
+  template?: {
+    templateKey: string | null
+    templateLabel: string | null
+    policyPackKey: string | null
+    policyPackLabel: string | null
+    hostGroupLabel: string | null
+    appliedAt: string | null
+    appliedBy: string | null
+  } | null
 }
 
 export interface WorkspacePolicy {

--- a/packages/directory/src/workspace-policy.ts
+++ b/packages/directory/src/workspace-policy.ts
@@ -18,6 +18,7 @@ export const DEFAULT_WORKSPACE_POLICY: WorkspacePolicy = {
   workflowRules: [],
   metadata: {
     notes: null,
+    template: null,
   },
 }
 
@@ -48,6 +49,37 @@ function sanitizeRuleExternalInitiation(value: unknown): WorkspacePolicyRuleExte
   }
 
   return 'inherit'
+}
+
+function parseTemplateMetadata(
+  raw: unknown,
+): WorkspacePolicy['metadata']['template'] {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+
+  const input = raw as Record<string, unknown>
+  const templateKey = sanitizeNullableString(input.templateKey)
+  const templateLabel = sanitizeNullableString(input.templateLabel)
+  const policyPackKey = sanitizeNullableString(input.policyPackKey)
+  const policyPackLabel = sanitizeNullableString(input.policyPackLabel)
+  const hostGroupLabel = sanitizeNullableString(input.hostGroupLabel)
+  const appliedAt = sanitizeNullableString(input.appliedAt)
+  const appliedBy = sanitizeNullableString(input.appliedBy)
+
+  if (!templateKey && !policyPackKey && !templateLabel && !policyPackLabel && !hostGroupLabel && !appliedAt && !appliedBy) {
+    return null
+  }
+
+  return {
+    templateKey,
+    templateLabel,
+    policyPackKey,
+    policyPackLabel,
+    hostGroupLabel,
+    appliedAt,
+    appliedBy,
+  }
 }
 
 function parseBindingRule(raw: unknown): WorkspacePolicyBindingRule | null {
@@ -115,6 +147,7 @@ export function parseWorkspacePolicy(raw: string | null | undefined): WorkspaceP
         : [],
       metadata: {
         notes: sanitizeNullableString(parsed.metadata?.notes),
+        template: parseTemplateMetadata(parsed.metadata?.template),
       },
     }
   } catch {
@@ -133,6 +166,7 @@ export function mergeWorkspacePolicy(current: WorkspacePolicy, patch: Partial<Wo
     metadata: {
       ...current.metadata,
       ...patch.metadata,
+      template: patch.metadata?.template === undefined ? current.metadata.template ?? null : patch.metadata.template ?? null,
     },
     bindingRules: patch.bindingRules ?? current.bindingRules,
     workflowRules: patch.workflowRules ?? current.workflowRules,

--- a/packages/directory/src/workspace-surface.test.ts
+++ b/packages/directory/src/workspace-surface.test.ts
@@ -1696,7 +1696,18 @@ test('workspace policy routes expose normalized policy and enforcement-ready bin
         defaults: { externalInitiation: string; allowedPartners: string[] }
         bindingRules: Array<{ policyProfile: string | null; externalInitiation: string; allowedPartners: string[] }>
         workflowRules: Array<{ workflowType: string; requireApproval: boolean; approvers: string[] }>
-        metadata: { notes: string | null }
+        metadata: {
+          notes: string | null
+          template: {
+            templateKey: string | null
+            templateLabel: string | null
+            policyPackKey: string | null
+            policyPackLabel: string | null
+            hostGroupLabel: string | null
+            appliedAt: string | null
+            appliedBy: string | null
+          } | null
+        }
       }
       previews: {
         bindings: Array<{ beamId: string; externalInitiation: string; allowedPartners: string[] }>
@@ -1717,6 +1728,7 @@ test('workspace policy routes expose normalized policy and enforcement-ready bin
     assert.equal(patchBody.policy.workflowRules[0]?.requireApproval, true)
     assert.deepEqual(patchBody.policy.workflowRules[0]?.approvers, ['ops@example.com', 'approvals@example.com'])
     assert.match(patchBody.policy.metadata.notes ?? '', /named approvers/i)
+    assert.equal(patchBody.policy.metadata.template, null)
     assert.equal(patchBody.previews.bindings[0]?.beamId, 'ops-bot@beam.directory')
     assert.equal(patchBody.previews.bindings[0]?.externalInitiation, 'allow')
     assert.deepEqual(patchBody.previews.bindings[0]?.allowedPartners, ['*@northwind.beam.directory', 'finance@northwind.beam.directory'])


### PR DESCRIPTION
## Summary
- add fleet policy pack and workspace template APIs plus template drift/remediation summaries
- add dashboard surfaces for policy packs, workspace templates, and guided remediation actions
- cover the new fleet remediation and template flows with directory tests and workspace docs

## Testing
- npm test --workspace=packages/directory
- npm run build
- npm test
- npm run test:e2e
- cd docs && npm run build

Closes #170
Closes #171