### PR TITLE
Add 1.5.0 fleet reconciliation and release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.5.0 (2026-04-02)
+
+### OpenClaw Fleet Autonomy
+- add host maintenance mode, drain, and resume controls that block delivery with a clear operator-visible reason
+- add connector version inventory, rollout rings, and canary visibility so rollout lag is visible at fleet scope
+- add fleet policy packs and workspace templates with drift detection and remediation paths
+- add desired-state reconciliation and stale route garbage collection for ended or orphaned subagent routes
+- add recurring rollout and maintenance digests with persisted schedule, run, and delivery history
+- commit buyer, operator, and fleet autonomy reports before cutting the release
+
+### Compatibility Note
+- No protocol-family change in this release train. Beam `1.5.0` remains on `beam/1`.
+
 ## v1.4.0 (2026-04-02)
 
 ### OpenClaw Fleet Automation

--- a/docs/guide/beam-workspaces.md
+++ b/docs/guide/beam-workspaces.md
@@ -210,6 +210,8 @@ The fleet surface also gives operators explicit day-2 actions:
 - drain a host with missing or failed receipts through a guided remediation flow before deeper repair work begins
 - stage guarded bulk actions across multiple hosts before a real revoke, with an explicit confirm phrase
 - clear staged revoke reviews again when a maintenance plan changes
+- run one fleet-wide reconciliation pass that classifies routes as `live`, `stale`, `orphaned`, or `conflict`
+- garbage-collect stale subagent routes and orphaned route history after the configured grace window
 
 The host detail and fleet summary now also expose the operational thresholds behind those actions:
 
@@ -249,6 +251,37 @@ The guarded remediation actions require explicit confirmation phrases:
 - `REAPPLY_TEMPLATE` before Beam reapplies the expected workspace template
 
 That keeps destructive or policy-resetting actions explicit while still letting one operator complete the full repair flow from the fleet surface instead of jumping into raw database or host state.
+
+For reconciliation and stale route cleanup, the normal operator loop is:
+
+1. open `Reconciliation and garbage collection` in the fleet page
+2. inspect `Hosts needing reconciliation` for stale, orphaned, or conflict-heavy hosts
+3. inspect `Attention routes` for the exact route Beam wants to classify or prune
+4. run `Run fleet reconciliation` fleet-wide or `Reconcile selected host` for one host
+5. confirm that:
+   - stale route counts drop
+   - garbage-collectable routes disappear
+   - the host returns to a `steady` or lower-noise `attention` state
+
+The reconciliation model is intentionally explicit:
+
+- `live`
+  - the route still matches the latest healthy host inventory and Beam can deliver to it
+- `stale`
+  - the host or credential state demotes the route temporarily; Beam will not treat it as fully deliverable
+- `orphaned`
+  - the route is historical only and should no longer win delivery
+- `conflict`
+  - duplicate ownership still blocks one canonical route
+
+Routes marked as `gc candidate` are safe to remove only because Beam has already classified them as historical state.
+
+If you want the same pass from the CLI, use:
+
+```bash
+npm run workspace:fleet-smoke
+npm run workspace:operator-dry-run
+```
 
 If you have just pulled new Beam code and want the local containers rebuilt before importing again, run:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beam-protocol",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beam-protocol",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -5765,10 +5765,10 @@
     },
     "packages/cli": {
       "name": "beam-protocol-cli",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.3.0",
+        "beam-protocol-sdk": "^1.5.0",
         "chalk": "^5.3.0",
         "commander": "^12.0.0",
         "inquirer": "^9.2.15",
@@ -5786,7 +5786,7 @@
       }
     },
     "packages/create-beam-agent": {
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "prompts": "^2.4.2"
@@ -5805,7 +5805,7 @@
     },
     "packages/dashboard": {
       "name": "@beam-protocol/dashboard",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -6367,7 +6367,7 @@
     },
     "packages/directory": {
       "name": "@beam-protocol/directory",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6391,10 +6391,10 @@
     },
     "packages/echo-agent": {
       "name": "@beam-protocol/echo-agent",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "beam-protocol-sdk": "^1.3.0"
+        "beam-protocol-sdk": "^1.5.0"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -6406,7 +6406,7 @@
     },
     "packages/message-bus": {
       "name": "@beam-protocol/message-bus",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.19.11",
@@ -6427,7 +6427,7 @@
     },
     "packages/sdk-typescript": {
       "name": "beam-protocol-sdk",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Verified B2B handoffs for AI agents",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Beam Protocol CLI for verified B2B handoffs",
   "type": "module",
   "bin": {
@@ -15,7 +15,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.3.0",
+    "beam-protocol-sdk": "^1.5.0",
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "inquirer": "^9.2.15",

--- a/packages/create-beam-agent/package.json
+++ b/packages/create-beam-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-beam-agent",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Scaffold a Beam-connected agent project",
   "type": "module",
   "bin": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/dashboard",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/lib/api.ts
+++ b/packages/dashboard/src/lib/api.ts
@@ -36,6 +36,7 @@ export type OpenClawRouteSource = 'agent-folder' | 'workspace-agent' | 'gateway-
 export type OpenClawRouteReportedState = 'live' | 'idle' | 'ended'
 export type OpenClawRouteRuntimeState = 'live' | 'idle' | 'stale' | 'ended' | 'conflict' | 'revoked'
 export type OpenClawRouteOwnerResolutionState = 'implicit' | 'preferred' | 'disabled'
+export type OpenClawRouteReconciliationClassification = 'live' | 'stale' | 'orphaned' | 'conflict'
 export type OpenClawHostRotationReviewState = 'scheduled' | 'due_soon' | 'overdue'
 export type OpenClawHostRecoveryRunbookState = 'idle' | 'prepared' | 'cutover_pending' | 'completed'
 export type OpenClawFleetBulkAction = 'apply_labels' | 'stage_revoke_review' | 'clear_revoke_review'
@@ -297,6 +298,16 @@ export interface OpenClawHostRoute {
   hostLabel: string | null
   hostHealth: OpenClawHostHealth
   hostCredentialState: OpenClawHostCredentialState
+  reconciliation: {
+    classification: OpenClawRouteReconciliationClassification
+    desiredState: 'deliverable' | 'historical'
+    reason: string
+    garbageCollectable: boolean
+    hostLastHeartbeatAt: string | null
+    hostLastInventoryAt: string | null
+    lastSeenAgeHours: number | null
+    endedAgeHours: number | null
+  }
   metadata: Record<string, unknown> | null
   lastSeenAt: string | null
   endedAt: string | null
@@ -387,6 +398,19 @@ export interface OpenClawHostSummary {
     updatedAt: string | null
     versionState: OpenClawHostRolloutVersionState
     canary: boolean
+  }
+  reconciliation: {
+    state: 'steady' | 'attention' | 'cleanup_required'
+    deliverableRoutes: number
+    liveRoutes: number
+    staleRoutes: number
+    orphanedRoutes: number
+    conflictRoutes: number
+    garbageCollectableRoutes: number
+    reason: string | null
+    nextAction: string | null
+    lastHeartbeatAt: string | null
+    lastInventoryAt: string | null
   }
   enrollment: OpenClawEnrollmentRequest | null
   summary: {
@@ -615,6 +639,10 @@ export interface OpenClawFleetOverviewResponse {
     templateDriftedWorkspaces: number
     suggestedRemediations: number
     criticalRemediations: number
+    driftedHosts: number
+    reconciliationCleanupRequiredHosts: number
+    orphanedRoutes: number
+    garbageCollectableRoutes: number
   }
   credentialPolicy: {
     counts: {
@@ -753,6 +781,52 @@ export interface OpenClawFleetOverviewResponse {
       workspaceHref: string | null
     }>
   }
+  reconciliation: {
+    summary: {
+      driftedHosts: number
+      cleanupRequiredHosts: number
+      liveRoutes: number
+      staleRoutes: number
+      orphanedRoutes: number
+      conflictRoutes: number
+      garbageCollectableRoutes: number
+      lastRunAt: string | null
+    }
+    attentionHosts: Array<{
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      healthStatus: OpenClawHostHealth
+      state: 'steady' | 'attention' | 'cleanup_required'
+      deliverableRoutes: number
+      staleRoutes: number
+      orphanedRoutes: number
+      conflictRoutes: number
+      garbageCollectableRoutes: number
+      reason: string | null
+      nextAction: string | null
+      href: string
+      workspaceHref: string | null
+    }>
+    attentionRoutes: Array<{
+      routeId: number
+      beamId: string
+      hostId: number
+      hostLabel: string | null
+      workspaceSlug: string | null
+      classification: OpenClawRouteReconciliationClassification
+      desiredState: 'deliverable' | 'historical'
+      garbageCollectable: boolean
+      routeSource: OpenClawRouteSource
+      connectionMode: 'websocket' | 'http' | 'hybrid' | 'unavailable' | null
+      reason: string
+      lastSeenAt: string | null
+      endedAt: string | null
+      href: string
+      workspaceHref: string | null
+      traceHref: string | null
+    }>
+  }
   hosts: OpenClawHostSummary[]
   conflicts: OpenClawConflictGroup[]
   templates: OpenClawFleetTemplateSummary
@@ -760,6 +834,8 @@ export interface OpenClawFleetOverviewResponse {
   environments: OpenClawFleetEnvironmentSummary[]
   hostGroups: OpenClawFleetHostGroupSummary[]
 }
+
+export type OpenClawFleetReconciliationResponse = OpenClawFleetOverviewResponse['reconciliation']
 
 export interface OpenClawFleetDigestItem {
   id: string
@@ -883,6 +959,18 @@ export interface OpenClawHostRoutesResponse {
   host: OpenClawHostSummary
   routes: OpenClawHostRoute[]
   total: number
+}
+
+export interface OpenClawFleetReconciliationRunResponse {
+  ok: true
+  hostId: number | null
+  staleGraceMinutes: number
+  orphanedGraceMinutes: number
+  endedRouteIds: number[]
+  deletedRouteIds: number[]
+  deletedCount: number
+  reconciliation: OpenClawFleetReconciliationResponse
+  hosts: OpenClawHostSummary[]
 }
 
 export interface OpenClawHostIdentitiesResponse {
@@ -2816,6 +2904,7 @@ export const directoryApi = {
   },
   getAgent: (beamId: string) => request<DirectoryAgentDetail>(`/agents/${encodeURIComponent(beamId)}`),
   getOpenClawFleetOverview: () => request<OpenClawFleetOverviewResponse>('/admin/openclaw/fleet/overview', undefined, { admin: true }),
+  getOpenClawFleetReconciliation: () => request<OpenClawFleetReconciliationResponse>('/admin/openclaw/fleet/reconciliation', undefined, { admin: true }),
   listOpenClawPolicyPacks: () => request<{ total: number; policyPacks: OpenClawPolicyPack[] }>('/admin/openclaw/fleet/policy-packs', undefined, { admin: true }),
   upsertOpenClawPolicyPack: (key: string, input: OpenClawPolicyPackUpsertInput) => request<{ policyPack: OpenClawPolicyPack }>(`/admin/openclaw/fleet/policy-packs/${encodeURIComponent(key)}`, {
     method: 'PUT',
@@ -2844,9 +2933,19 @@ export const directoryApi = {
     updatedAt?: string | null
     updatedBy?: string | null
     routes?: OpenClawHostRoute[]
+    reconciliation?: OpenClawFleetReconciliationResponse
   }>('/admin/openclaw/fleet/remediations/apply', {
     method: 'POST',
     body: JSON.stringify(input),
+  }, { admin: true }),
+  runOpenClawFleetReconciliation: (input?: {
+    hostId?: number | null
+    staleGraceMinutes?: number | null
+    orphanedGraceMinutes?: number | null
+    note?: string | null
+  }) => request<OpenClawFleetReconciliationRunResponse>('/admin/openclaw/fleet/reconciliation/run', {
+    method: 'POST',
+    body: JSON.stringify(input ?? {}),
   }, { admin: true }),
   getOpenClawFleetDigest: (params?: { format?: 'json' | 'markdown' }) => request<OpenClawFleetDigestResponse>(`/admin/openclaw/fleet/digest${buildQuery({ format: params?.format })}`, undefined, { admin: true }),
   updateOpenClawFleetDigestSchedule: (input: OpenClawFleetDigestSchedulePatchInput) => request<OpenClawFleetDigestSchedulePatchResponse>('/admin/openclaw/fleet/digest/schedule', {

--- a/packages/dashboard/src/pages/OpenClawFleetPage.tsx
+++ b/packages/dashboard/src/pages/OpenClawFleetPage.tsx
@@ -26,6 +26,7 @@ import {
   type OpenClawHostPolicyPatchInput,
   type OpenClawHostRecoveryRunbookState,
   type OpenClawHostRolloutRing,
+  type OpenClawRouteReconciliationClassification,
   type OpenClawRouteRuntimeState,
   type OpenClawRouteOwnerResolutionState,
   type OpenClawRouteSource,
@@ -71,6 +72,20 @@ function routeStateTone(status: OpenClawRouteRuntimeState): 'default' | 'success
     case 'ended':
     case 'conflict':
     case 'revoked':
+      return 'critical'
+    default:
+      return 'default'
+  }
+}
+
+function reconciliationTone(status: OpenClawRouteReconciliationClassification): 'default' | 'success' | 'warning' | 'critical' {
+  switch (status) {
+    case 'live':
+      return 'success'
+    case 'stale':
+      return 'warning'
+    case 'orphaned':
+    case 'conflict':
       return 'critical'
     default:
       return 'default'
@@ -847,6 +862,17 @@ export default function OpenClawFleetPage() {
     }, `${item.title} remediated.`)
   }
 
+  async function handleRunReconciliation(host?: Pick<OpenClawHostSummary, 'id' | 'label' | 'hostname'> | null) {
+    const hostLabel = host ? hostTitle(host as OpenClawHostSummary) : 'fleet'
+    await runAction(`reconciliation-${host?.id ?? 'all'}`, async () => {
+      await directoryApi.runOpenClawFleetReconciliation({
+        hostId: host?.id ?? null,
+        note: host ? `Manual reconciliation for ${hostLabel}` : 'Manual fleet-wide reconciliation',
+      })
+      await refreshAll(host?.id ?? selectedHostId, selectedConflictBeamId)
+    }, host ? `Reconciliation completed for ${hostLabel}.` : 'Fleet reconciliation completed.')
+  }
+
   async function handleSaveDigestSchedule() {
     await runAction('digest-schedule', async () => {
       await directoryApi.updateOpenClawFleetDigestSchedule({
@@ -1123,6 +1149,162 @@ export default function OpenClawFleetPage() {
             ) : (
               <EmptyPanel label="No hosts are currently breaching route-health review thresholds." />
             )}
+          </div>
+        </div>
+      </section>
+
+      <section className="panel">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="panel-title">Reconciliation and garbage collection</div>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Reconcile desired fleet state against observed host routes, classify stale or orphaned state, and clean up ended route drift before it silently degrades delivery.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+              disabled={actionBusy === 'reconciliation-all'}
+              onClick={() => { void handleRunReconciliation(null) }}
+            >
+              {actionBusy === 'reconciliation-all' ? 'Reconciling…' : 'Run fleet reconciliation'}
+            </button>
+            {selectedHost ? (
+              <button
+                type="button"
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                disabled={actionBusy === `reconciliation-${selectedHost.id}`}
+                onClick={() => { void handleRunReconciliation(selectedHost) }}
+              >
+                {actionBusy === `reconciliation-${selectedHost.id}` ? 'Reconciling host…' : 'Reconcile selected host'}
+              </button>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-6">
+          <MetricCard label="Drifted hosts" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.driftedHosts)} tone={(overview?.reconciliation.summary.driftedHosts ?? 0) > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Cleanup required" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.cleanupRequiredHosts)} tone={(overview?.reconciliation.summary.cleanupRequiredHosts ?? 0) > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Stale routes" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.staleRoutes)} tone={(overview?.reconciliation.summary.staleRoutes ?? 0) > 0 ? 'warning' : 'default'} />
+          <MetricCard label="Orphaned routes" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.orphanedRoutes)} tone={(overview?.reconciliation.summary.orphanedRoutes ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="Conflicts" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.conflictRoutes)} tone={(overview?.reconciliation.summary.conflictRoutes ?? 0) > 0 ? 'critical' : 'default'} />
+          <MetricCard label="GC candidates" value={!overview ? '—' : formatNumber(overview.reconciliation.summary.garbageCollectableRoutes)} tone={(overview?.reconciliation.summary.garbageCollectableRoutes ?? 0) > 0 ? 'warning' : 'default'} />
+        </div>
+
+        <div className="mt-4 grid gap-4 xl:grid-cols-[1.05fr,0.95fr]">
+          <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Hosts needing reconciliation</div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                {overview ? `${formatNumber(overview.reconciliation.attentionHosts.length)} hosts` : '—'}
+              </div>
+            </div>
+            <div className="mt-3 space-y-3">
+              {overview && overview.reconciliation.attentionHosts.length > 0 ? (
+                overview.reconciliation.attentionHosts.map((item) => (
+                  <div key={`reconciliation-host-${item.hostId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.hostLabel || `Host ${item.hostId}`}</div>
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.reason ?? 'No reconciliation drift detected.'}</div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <StatusPill label={item.state.replace(/_/g, ' ')} tone={item.state === 'cleanup_required' ? 'critical' : item.state === 'attention' ? 'warning' : 'success'} />
+                        <StatusPill label={item.healthStatus} tone={hostHealthTone(item.healthStatus)} />
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                      <div>{`${formatNumber(item.deliverableRoutes)} deliverable routes`}</div>
+                      <div>{`${formatNumber(item.staleRoutes)} stale · ${formatNumber(item.orphanedRoutes)} orphaned · ${formatNumber(item.conflictRoutes)} conflicts`}</div>
+                      <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace default'}</div>
+                      <div>{item.nextAction ?? 'No next action recorded'}</div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        onClick={() => focusHost(item.hostId)}
+                      >
+                        Open host
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 disabled:opacity-60 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        disabled={actionBusy === `reconciliation-${item.hostId}`}
+                        onClick={() => { void handleRunReconciliation({ id: item.hostId, label: item.hostLabel, hostname: item.hostLabel ?? `Host ${item.hostId}` }) }}
+                      >
+                        {actionBusy === `reconciliation-${item.hostId}` ? 'Reconciling…' : 'Reconcile host'}
+                      </button>
+                      {item.workspaceHref ? (
+                        <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.workspaceHref}>
+                          Open workspace
+                        </Link>
+                      ) : null}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <EmptyPanel label="No hosts currently need reconciliation review." />
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+            <div className="flex items-center justify-between gap-3">
+              <div className="text-sm font-medium text-slate-900 dark:text-slate-100">Attention routes</div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                {overview?.reconciliation.summary.lastRunAt ? `Last run ${formatRelativeTime(overview.reconciliation.summary.lastRunAt)}` : 'No reconciliation run recorded yet'}
+              </div>
+            </div>
+            <div className="mt-3 space-y-3">
+              {overview && overview.reconciliation.attentionRoutes.length > 0 ? (
+                overview.reconciliation.attentionRoutes.map((item) => (
+                  <div key={`reconciliation-route-${item.routeId}`} className="rounded-2xl border border-slate-200 p-4 dark:border-slate-800">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">{item.beamId}</div>
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.reason}</div>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <StatusPill label={item.classification} tone={reconciliationTone(item.classification)} />
+                        <StatusPill label={item.desiredState} tone={item.desiredState === 'deliverable' ? 'success' : 'default'} />
+                        {item.garbageCollectable ? <StatusPill label="gc candidate" tone="warning" /> : null}
+                      </div>
+                    </div>
+                    <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
+                      <div>{item.hostLabel ? `Host ${item.hostLabel}` : `Host ${item.hostId}`}</div>
+                      <div>{item.workspaceSlug ? `Workspace ${item.workspaceSlug}` : 'No workspace attached'}</div>
+                      <div>{`Source ${routeSourceLabel(item.routeSource)}`}</div>
+                      <div>{item.connectionMode ? `Transport ${item.connectionMode}` : 'No transport mode'}</div>
+                      <div>{item.lastSeenAt ? `Last seen ${formatRelativeTime(item.lastSeenAt)}` : 'No last-seen timestamp'}</div>
+                      <div>{item.endedAt ? `Ended ${formatRelativeTime(item.endedAt)}` : 'No ended timestamp'}</div>
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800"
+                        onClick={() => focusHost(item.hostId)}
+                      >
+                        Open host
+                      </button>
+                      {item.workspaceHref ? (
+                        <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.workspaceHref}>
+                          Open workspace
+                        </Link>
+                      ) : null}
+                      {item.traceHref ? (
+                        <Link className="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-100 dark:border-slate-800 dark:text-slate-200 dark:hover:bg-slate-800" to={item.traceHref}>
+                          Open trace
+                        </Link>
+                      ) : null}
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <EmptyPanel label="No route-level reconciliation attention items are open." />
+              )}
+            </div>
           </div>
         </div>
       </section>
@@ -3113,7 +3295,9 @@ export default function OpenClawFleetPage() {
                           <div className="flex flex-wrap gap-2">
                             <StatusPill label={routeSourceLabel(route.routeSource)} />
                             <StatusPill label={route.runtimeSessionState} tone={routeStateTone(route.runtimeSessionState)} />
+                            <StatusPill label={`recon:${route.reconciliation.classification}`} tone={reconciliationTone(route.reconciliation.classification)} />
                             <StatusPill label={route.ownerResolutionState} tone={ownerResolutionTone(route.ownerResolutionState)} />
+                            {route.reconciliation.garbageCollectable ? <StatusPill label="gc candidate" tone="warning" /> : null}
                           </div>
                         </div>
                         <div className="mt-3 grid gap-2 text-xs text-slate-500 dark:text-slate-400 md:grid-cols-2">
@@ -3121,6 +3305,8 @@ export default function OpenClawFleetPage() {
                           <div>{route.connectionMode ? `Transport ${route.connectionMode}` : 'No transport mode'}</div>
                           <div>{route.lastSeenAt ? `Last seen ${formatRelativeTime(route.lastSeenAt)}` : 'No last-seen timestamp'}</div>
                           <div>{route.endedAt ? `Ended ${formatRelativeTime(route.endedAt)}` : 'Still active in inventory'}</div>
+                          <div>{route.reconciliation.reason}</div>
+                          <div>{route.reconciliation.hostLastInventoryAt ? `Host inventory ${formatRelativeTime(route.reconciliation.hostLastInventoryAt)}` : 'No host inventory timestamp'}</div>
                           <div>{route.ownerResolutionAt ? `Owner action ${formatRelativeTime(route.ownerResolutionAt)}${route.ownerResolutionActor ? ` · ${route.ownerResolutionActor}` : ''}` : 'No explicit owner action'}</div>
                           <div>{route.hostCredentialState ? `Host credential ${route.hostCredentialState}` : 'No host credential state'}</div>
                           <div>{route.lastDelivery ? `Last delivery ${formatRelativeTime(route.lastDelivery.requestedAt)} · ${route.lastDelivery.status}` : 'No delivery receipt yet'}</div>

--- a/packages/directory/package.json
+++ b/packages/directory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/directory",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Beam Protocol Directory Server — agent registration, discovery, and intent routing",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/directory/src/db.ts
+++ b/packages/directory/src/db.ts
@@ -4353,7 +4353,8 @@ export function listOpenClawResolvedRoutesByBeamId(db: DB, beamId: string): Open
       h.health_status AS host_health_status,
       h.credential_state AS host_credential_state,
       h.workspace_slug AS host_workspace_slug,
-      h.last_heartbeat_at AS host_last_heartbeat_at
+      h.last_heartbeat_at AS host_last_heartbeat_at,
+      h.last_inventory_at AS host_last_inventory_at
     FROM openclaw_host_routes r
     JOIN openclaw_hosts h ON h.id = r.host_id
     WHERE r.beam_id = ?
@@ -4384,7 +4385,8 @@ export function listOpenClawResolvedRoutesForHost(db: DB, hostId: number): OpenC
       h.health_status AS host_health_status,
       h.credential_state AS host_credential_state,
       h.workspace_slug AS host_workspace_slug,
-      h.last_heartbeat_at AS host_last_heartbeat_at
+      h.last_heartbeat_at AS host_last_heartbeat_at,
+      h.last_inventory_at AS host_last_inventory_at
     FROM openclaw_host_routes r
     JOIN openclaw_hosts h ON h.id = r.host_id
     WHERE r.host_id = ?
@@ -5125,6 +5127,106 @@ export function markOpenClawHostRoutesEnded(
   updateOpenClawHostRouteCount(db, input.hostId)
   recalculateOpenClawRouteStates(db)
   return listOpenClawHostRoutes(db, input.hostId)
+}
+
+export function markOpenClawRoutesEndedByIds(
+  db: DB,
+  input: {
+    routeIds: number[]
+  },
+): OpenClawHostRouteRow[] {
+  const routeIds = [...new Set(input.routeIds.filter((value) => Number.isFinite(value) && value > 0))]
+  if (routeIds.length === 0) {
+    return []
+  }
+
+  const existing = routeIds
+    .map((routeId) => getOpenClawHostRouteById(db, routeId))
+    .filter((route): route is OpenClawHostRouteRow => Boolean(route))
+  if (existing.length === 0) {
+    return []
+  }
+
+  const endedAt = nowIso()
+  const placeholders = existing.map(() => '?').join(', ')
+  db.prepare(`
+    UPDATE openclaw_host_routes
+    SET reported_state = 'ended',
+        runtime_session_state = 'ended',
+        ended_at = ?,
+        updated_at = ?
+    WHERE id IN (${placeholders})
+  `).run(endedAt, endedAt, ...existing.map((route) => route.id))
+
+  const affectedHostIds = [...new Set(existing.map((route) => route.host_id))]
+  const affectedBeamIds = [...new Set(existing.map((route) => route.beam_id))]
+  for (const hostId of affectedHostIds) {
+    updateOpenClawHost(db, {
+      id: hostId,
+      lastRouteEventAt: endedAt,
+    })
+    updateOpenClawHostRouteCount(db, hostId)
+  }
+  recalculateOpenClawRouteStates(db, affectedBeamIds)
+
+  return existing
+    .map((route) => getOpenClawHostRouteById(db, route.id))
+    .filter((route): route is OpenClawHostRouteRow => Boolean(route))
+}
+
+export function deleteOpenClawHostRoutesByIds(
+  db: DB,
+  input: {
+    routeIds: number[]
+  },
+): {
+  deletedCount: number
+  affectedHostIds: number[]
+  affectedBeamIds: string[]
+} {
+  const routeIds = [...new Set(input.routeIds.filter((value) => Number.isFinite(value) && value > 0))]
+  if (routeIds.length === 0) {
+    return {
+      deletedCount: 0,
+      affectedHostIds: [],
+      affectedBeamIds: [],
+    }
+  }
+
+  const existing = routeIds
+    .map((routeId) => getOpenClawHostRouteById(db, routeId))
+    .filter((route): route is OpenClawHostRouteRow => Boolean(route))
+  if (existing.length === 0) {
+    return {
+      deletedCount: 0,
+      affectedHostIds: [],
+      affectedBeamIds: [],
+    }
+  }
+
+  const updatedAt = nowIso()
+  const placeholders = existing.map(() => '?').join(', ')
+  db.prepare(`
+    DELETE FROM openclaw_host_routes
+    WHERE id IN (${placeholders})
+  `).run(...existing.map((route) => route.id))
+
+  const affectedHostIds = [...new Set(existing.map((route) => route.host_id))]
+  const affectedBeamIds = [...new Set(existing.map((route) => route.beam_id))]
+  for (const hostId of affectedHostIds) {
+    updateOpenClawHost(db, {
+      id: hostId,
+      lastRouteEventAt: updatedAt,
+    })
+    updateOpenClawHostRouteCount(db, hostId)
+  }
+  recalculateOpenClawRouteStates(db, affectedBeamIds)
+
+  return {
+    deletedCount: existing.length,
+    affectedHostIds,
+    affectedBeamIds,
+  }
 }
 
 export function approveOpenClawHost(

--- a/packages/directory/src/openclaw-hosts.test.ts
+++ b/packages/directory/src/openclaw-hosts.test.ts
@@ -326,14 +326,18 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
         latencySloBreaches: number
         rotationDueHosts: number
         recoveryRunbooksOpen: number
-        duplicateIdentityConflicts: number
-        pendingCredentialActions: number
-        actionItems: number
-        criticalItems: number
-        templateDriftedWorkspaces: number
-        suggestedRemediations: number
-        criticalRemediations: number
-      }
+      duplicateIdentityConflicts: number
+      pendingCredentialActions: number
+      actionItems: number
+      criticalItems: number
+      templateDriftedWorkspaces: number
+      suggestedRemediations: number
+      criticalRemediations: number
+      driftedHosts: number
+      reconciliationCleanupRequiredHosts: number
+      orphanedRoutes: number
+      garbageCollectableRoutes: number
+    }
       hosts: Array<{
         id: number
         healthStatus: string
@@ -366,6 +370,10 @@ test('openclaw hosts enroll, approve, heartbeat, and inventory surface in fleet 
       templateDriftedWorkspaces: 0,
       suggestedRemediations: 1,
       criticalRemediations: 0,
+      driftedHosts: 0,
+      reconciliationCleanupRequiredHosts: 0,
+      orphanedRoutes: 0,
+      garbageCollectableRoutes: 0,
     })
     assert.equal(overviewBody.hosts[0]?.workspaceSlug, 'openclaw-local')
     assert.equal(overviewBody.hosts[0]?.healthStatus, 'healthy')
@@ -2109,8 +2117,9 @@ test('guided fleet remediations align rollout, drain missing receipts, and end s
       hostname: 'bravo-remediation.local',
       beamId: bravo.beamId,
       routeKey: 'bravo-remediation-route',
+      routeSource: 'subagent-run',
       workspaceSlug: 'openclaw-local',
-      heartbeatAt: new Date(Date.now() - (20 * 60 * 1000)).toISOString(),
+      heartbeatAt: new Date(Date.now() - (45 * 60 * 1000)).toISOString(),
     })
 
     const rolloutResponse = await app.request(new Request(`http://localhost/admin/openclaw/hosts/${alphaHost.host.id}/rollout`, {
@@ -2237,6 +2246,101 @@ test('guided fleet remediations align rollout, drain missing receipts, and end s
     assert.ok(!overviewAfterBody.remediation.suggested.some((item) =>
       item.kind === 'end_stale_routes' && item.hostId === bravoHost.host.id,
     ))
+  } finally {
+    db.close()
+  }
+})
+
+test('fleet reconciliation summarizes stale route drift and garbage-collects eligible stale subagent routes', async () => {
+  const db = createDatabase(':memory:')
+
+  try {
+    const agent = createFixtureAgent('reconcile@openclaw.beam.directory')
+    registerFixtureAgent(db, agent, 'Reconcile Agent')
+
+    const host = createApprovedHostWithRoute(db, {
+      label: 'Reconciliation Host',
+      hostname: 'reconciliation.local',
+      beamId: agent.beamId,
+      routeKey: 'reconciliation-route',
+      routeSource: 'subagent-run',
+      workspaceSlug: 'openclaw-local',
+      heartbeatAt: new Date(Date.now() - (45 * 60 * 1000)).toISOString(),
+    })
+
+    const app = createApp(db)
+    const viewerHeaders = createAdminHeaders(db, 'viewer@example.com', 'viewer')
+    const adminHeaders = {
+      ...createAdminHeaders(db, 'admin@example.com', 'admin'),
+      'content-type': 'application/json',
+    }
+
+    const reconciliationBeforeResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/reconciliation', {
+      headers: viewerHeaders,
+    }))
+    assert.equal(reconciliationBeforeResponse.status, 200)
+    const reconciliationBeforeBody = await reconciliationBeforeResponse.json() as {
+      summary: {
+        driftedHosts: number
+        staleRoutes: number
+        garbageCollectableRoutes: number
+      }
+      attentionHosts: Array<{
+        hostId: number
+        state: string
+      }>
+      attentionRoutes: Array<{
+        routeId: number
+        classification: string
+        garbageCollectable: boolean
+      }>
+    }
+    assert.equal(reconciliationBeforeBody.summary.driftedHosts, 1)
+    assert.equal(reconciliationBeforeBody.summary.staleRoutes, 1)
+    assert.equal(reconciliationBeforeBody.summary.garbageCollectableRoutes, 1)
+    assert.equal(reconciliationBeforeBody.attentionHosts[0]?.hostId, host.host.id)
+    assert.equal(reconciliationBeforeBody.attentionHosts[0]?.state, 'cleanup_required')
+
+    const routeBefore = listOpenClawResolvedRoutesByBeamId(db, agent.beamId)[0]
+    assert.ok(routeBefore)
+    assert.equal(reconciliationBeforeBody.attentionRoutes[0]?.routeId, routeBefore.id)
+    assert.equal(reconciliationBeforeBody.attentionRoutes[0]?.classification, 'stale')
+    assert.equal(reconciliationBeforeBody.attentionRoutes[0]?.garbageCollectable, true)
+
+    const runResponse = await app.request(new Request('http://localhost/admin/openclaw/fleet/reconciliation/run', {
+      method: 'POST',
+      headers: adminHeaders,
+      body: JSON.stringify({
+        hostId: host.host.id,
+        staleGraceMinutes: 0,
+        orphanedGraceMinutes: 0,
+        note: 'Force reconciliation cleanup during test',
+      }),
+    }))
+    assert.equal(runResponse.status, 200)
+    const runBody = await runResponse.json() as {
+      ok: boolean
+      hostId: number | null
+      endedRouteIds: number[]
+      deletedRouteIds: number[]
+      deletedCount: number
+      reconciliation: {
+        summary: {
+          staleRoutes: number
+          garbageCollectableRoutes: number
+        }
+      }
+    }
+    assert.equal(runBody.ok, true)
+    assert.equal(runBody.hostId, host.host.id)
+    assert.deepEqual(runBody.endedRouteIds, [routeBefore.id])
+    assert.deepEqual(runBody.deletedRouteIds, [routeBefore.id])
+    assert.equal(runBody.deletedCount, 1)
+    assert.equal(runBody.reconciliation.summary.staleRoutes, 0)
+    assert.equal(runBody.reconciliation.summary.garbageCollectableRoutes, 0)
+
+    const routeAfter = listOpenClawResolvedRoutesByBeamId(db, agent.beamId)[0]
+    assert.equal(routeAfter, undefined)
   } finally {
     db.close()
   }

--- a/packages/directory/src/routes/openclaw-hosts.ts
+++ b/packages/directory/src/routes/openclaw-hosts.ts
@@ -37,7 +37,7 @@ import {
   listWorkspaceIdentityBindings,
   listWorkspaceIdentityBindingsByBeamId,
   logAuditEvent,
-  markOpenClawHostRoutesEnded,
+  markOpenClawRoutesEndedByIds,
   recordOpenClawHostHeartbeat,
   recalculateOpenClawRouteStates,
   recoverOpenClawHost,
@@ -48,6 +48,7 @@ import {
   recordOpenClawFleetDigestDelivery,
   setOpenClawRouteOwnerResolution,
   syncOpenClawHostRoutes,
+  deleteOpenClawHostRoutesByIds,
   updateWorkspace,
   updateWorkspacePolicyDocument,
   updateOpenClawEnrollmentRequest,
@@ -483,6 +484,84 @@ type OpenClawFleetRolloutSummary = {
   attentionHosts: OpenClawFleetRolloutAttentionHost[]
 }
 
+type OpenClawRouteReconciliationClassification = 'live' | 'stale' | 'orphaned' | 'conflict'
+
+type SerializedOpenClawRouteReconciliation = {
+  classification: OpenClawRouteReconciliationClassification
+  desiredState: 'deliverable' | 'historical'
+  reason: string
+  garbageCollectable: boolean
+  hostLastHeartbeatAt: string | null
+  hostLastInventoryAt: string | null
+  lastSeenAgeHours: number | null
+  endedAgeHours: number | null
+}
+
+type SerializedOpenClawHostReconciliation = {
+  state: 'steady' | 'attention' | 'cleanup_required'
+  deliverableRoutes: number
+  liveRoutes: number
+  staleRoutes: number
+  orphanedRoutes: number
+  conflictRoutes: number
+  garbageCollectableRoutes: number
+  reason: string | null
+  nextAction: string | null
+  lastHeartbeatAt: string | null
+  lastInventoryAt: string | null
+}
+
+type OpenClawFleetReconciliationAttentionHost = {
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  healthStatus: OpenClawHostHealth
+  state: SerializedOpenClawHostReconciliation['state']
+  deliverableRoutes: number
+  staleRoutes: number
+  orphanedRoutes: number
+  conflictRoutes: number
+  garbageCollectableRoutes: number
+  reason: string | null
+  nextAction: string | null
+  href: string
+  workspaceHref: string | null
+}
+
+type OpenClawFleetReconciliationAttentionRoute = {
+  routeId: number
+  beamId: string
+  hostId: number
+  hostLabel: string | null
+  workspaceSlug: string | null
+  classification: OpenClawRouteReconciliationClassification
+  desiredState: 'deliverable' | 'historical'
+  garbageCollectable: boolean
+  routeSource: OpenClawRouteSource
+  connectionMode: OpenClawHostRouteRow['connection_mode']
+  reason: string
+  lastSeenAt: string | null
+  endedAt: string | null
+  href: string
+  workspaceHref: string | null
+  traceHref: string | null
+}
+
+type OpenClawFleetReconciliationSummary = {
+  summary: {
+    driftedHosts: number
+    cleanupRequiredHosts: number
+    liveRoutes: number
+    staleRoutes: number
+    orphanedRoutes: number
+    conflictRoutes: number
+    garbageCollectableRoutes: number
+    lastRunAt: string | null
+  }
+  attentionHosts: OpenClawFleetReconciliationAttentionHost[]
+  attentionRoutes: OpenClawFleetReconciliationAttentionRoute[]
+}
+
 type OpenClawFleetBulkAction =
   | 'apply_labels'
   | 'stage_revoke_review'
@@ -533,6 +612,8 @@ const OPENCLAW_ROTATION_DUE_SOON_HOURS = 72
 const OPENCLAW_ROUTE_LATENCY_SLO_MS = 5_000
 const OPENCLAW_ROUTE_LATENCY_LOOKBACK_HOURS = 24 * 7
 const OPENCLAW_ROUTE_LATENCY_LOG_LIMIT = 500
+const OPENCLAW_ROUTE_RECONCILIATION_STALE_GRACE_MINUTES = 30
+const OPENCLAW_ROUTE_RECONCILIATION_ORPHANED_GRACE_MINUTES = 30
 
 function normalizeOptionalString(value: unknown): string | null {
   if (typeof value !== 'string') {
@@ -1202,11 +1283,125 @@ function serializeLatestRouteDelivery(log: IntentLogRow | null) {
   }
 }
 
+function evaluateOpenClawRouteReconciliation(
+  row: OpenClawResolvedRouteRow,
+  input?: {
+    staleGraceMinutes?: number
+    orphanedGraceMinutes?: number
+  },
+): SerializedOpenClawRouteReconciliation {
+  const staleGraceMinutes = Math.max(0, Math.trunc(input?.staleGraceMinutes ?? OPENCLAW_ROUTE_RECONCILIATION_STALE_GRACE_MINUTES))
+  const orphanedGraceMinutes = Math.max(0, Math.trunc(input?.orphanedGraceMinutes ?? OPENCLAW_ROUTE_RECONCILIATION_ORPHANED_GRACE_MINUTES))
+  const nowMs = Date.now()
+  const lastSeenMs = row.last_seen_at ? Date.parse(row.last_seen_at) : Number.NaN
+  const endedMs = row.ended_at ? Date.parse(row.ended_at) : Number.NaN
+  const hostInventoryMs = row.host_last_inventory_at ? Date.parse(row.host_last_inventory_at) : Number.NaN
+  const inventoryPastRoute = Number.isFinite(hostInventoryMs)
+    && Number.isFinite(lastSeenMs)
+    && (hostInventoryMs - lastSeenMs) >= 60_000
+    && (row.reported_state !== 'live' || row.runtime_session_state !== 'live')
+  const staleTooOld = Number.isFinite(lastSeenMs)
+    && (nowMs - lastSeenMs) >= (staleGraceMinutes * 60_000)
+  const orphanedAgeReferenceMs = Number.isFinite(endedMs)
+    ? endedMs
+    : (Number.isFinite(hostInventoryMs) ? hostInventoryMs : lastSeenMs)
+  const orphanedTooOld = Number.isFinite(orphanedAgeReferenceMs)
+    && (nowMs - orphanedAgeReferenceMs) >= (orphanedGraceMinutes * 60_000)
+
+  let classification: OpenClawRouteReconciliationClassification = 'live'
+  let reason = 'Route matches the latest healthy host inventory.'
+  let garbageCollectable = false
+
+  if (row.runtime_session_state === 'conflict') {
+    classification = 'conflict'
+    reason = 'Duplicate route ownership blocks delivery until one host is selected.'
+  } else if (row.runtime_session_state === 'stale') {
+    classification = 'stale'
+    reason = row.host_health_status === 'stale'
+      ? 'Host heartbeat is stale, so Beam no longer treats the route as deliverable.'
+      : row.host_credential_state === 'rotation_pending' || row.host_credential_state === 'recovery_pending'
+        ? 'Host credential work is pending, so Beam temporarily demotes the route.'
+        : 'Route has not refreshed recently and needs either a new heartbeat or reconciliation.'
+    garbageCollectable = row.route_source === 'subagent-run' && staleTooOld
+  } else if (
+    row.owner_resolution_state === 'disabled'
+    || row.reported_state === 'ended'
+    || row.runtime_session_state === 'ended'
+    || inventoryPastRoute
+  ) {
+    classification = 'orphaned'
+    reason = row.owner_resolution_state === 'disabled'
+      ? 'Route was explicitly disabled and remains only as historical state.'
+      : row.reported_state === 'ended' || row.runtime_session_state === 'ended'
+        ? 'Route already ended and can be pruned after the reconciliation grace window.'
+        : 'Host inventory moved past this route, so it should remain historical only.'
+    garbageCollectable = orphanedTooOld
+  }
+
+  return {
+    classification,
+    desiredState: classification === 'orphaned' ? 'historical' : 'deliverable',
+    reason,
+    garbageCollectable,
+    hostLastHeartbeatAt: row.host_last_heartbeat_at,
+    hostLastInventoryAt: row.host_last_inventory_at,
+    lastSeenAgeHours: hoursSince(row.last_seen_at),
+    endedAgeHours: hoursSince(row.ended_at),
+  }
+}
+
+function summarizeOpenClawHostReconciliation(routes: OpenClawResolvedRouteRow[]): SerializedOpenClawHostReconciliation {
+  const evaluated = routes.map((route) => evaluateOpenClawRouteReconciliation(route))
+  const deliverableRoutes = evaluated.filter((entry) => entry.desiredState === 'deliverable').length
+  const liveRoutes = evaluated.filter((entry) => entry.classification === 'live').length
+  const staleRoutes = evaluated.filter((entry) => entry.classification === 'stale').length
+  const orphanedRoutes = evaluated.filter((entry) => entry.classification === 'orphaned').length
+  const conflictRoutes = evaluated.filter((entry) => entry.classification === 'conflict').length
+  const garbageCollectableRoutes = evaluated.filter((entry) => entry.garbageCollectable).length
+
+  let state: SerializedOpenClawHostReconciliation['state'] = 'steady'
+  let reason: string | null = null
+  let nextAction: string | null = null
+
+  if (garbageCollectableRoutes > 0) {
+    state = 'cleanup_required'
+    reason = `${garbageCollectableRoutes} stale or orphaned route(s) are ready for garbage collection.`
+    nextAction = 'Run fleet reconciliation to end stale subagent routes and remove orphaned history.'
+  } else if (conflictRoutes > 0) {
+    state = 'attention'
+    reason = `${conflictRoutes} route conflict(s) still block delivery.`
+    nextAction = 'Resolve route ownership before Beam resumes one canonical path.'
+  } else if (staleRoutes > 0) {
+    state = 'attention'
+    reason = `${staleRoutes} route(s) are stale and need either a new heartbeat or an inventory refresh.`
+    nextAction = 'Wait for a healthy host refresh or re-run reconciliation if the route should become historical.'
+  } else if (orphanedRoutes > 0) {
+    state = 'attention'
+    reason = `${orphanedRoutes} orphaned historical route(s) remain visible inside the grace window.`
+    nextAction = 'Allow the grace window to expire or run reconciliation later to prune them.'
+  }
+
+  return {
+    state,
+    deliverableRoutes,
+    liveRoutes,
+    staleRoutes,
+    orphanedRoutes,
+    conflictRoutes,
+    garbageCollectableRoutes,
+    reason,
+    nextAction,
+    lastHeartbeatAt: routes[0]?.host_last_heartbeat_at ?? null,
+    lastInventoryAt: routes[0]?.host_last_inventory_at ?? null,
+  }
+}
+
 function serializeRoute(db: Database, row: OpenClawResolvedRouteRow) {
   const workspace = row.workspace_slug ? getWorkspaceBySlug(db, row.workspace_slug) : null
   const bindings = listWorkspaceIdentityBindingsByBeamId(db, row.beam_id)
   const displayName = getAgent(db, row.beam_id)?.display_name ?? null
   const latestDelivery = serializeLatestRouteDelivery(getLatestIntentLogByTarget(db, row.beam_id))
+  const reconciliation = evaluateOpenClawRouteReconciliation(row)
 
   return {
     id: row.id,
@@ -1235,6 +1430,7 @@ function serializeRoute(db: Database, row: OpenClawResolvedRouteRow) {
     hostLabel: row.host_label,
     hostHealth: row.host_health_status,
     hostCredentialState: row.host_credential_state,
+    reconciliation,
     metadata: row.metadata_json ? JSON.parse(row.metadata_json) as Record<string, unknown> : null,
     lastSeenAt: row.last_seen_at,
     endedAt: row.ended_at,
@@ -1638,6 +1834,7 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
   const placement = serializeOpenClawHostPlacement(host)
   const maintenance = serializeOpenClawHostMaintenance(host)
   const rollout = serializeOpenClawHostRollout(host)
+  const reconciliation = summarizeOpenClawHostReconciliation(routes)
 
   return {
     id: host.id,
@@ -1670,8 +1867,189 @@ function serializeHost(db: Database, host: OpenClawHostRow) {
     placement,
     maintenance,
     rollout,
+    reconciliation,
     enrollment: serializeEnrollment(enrollment),
     summary,
+  }
+}
+
+function buildOpenClawFleetReconciliationSummary(
+  db: Database,
+  hosts: Array<ReturnType<typeof serializeHost>>,
+): OpenClawFleetReconciliationSummary {
+  const attentionHosts: OpenClawFleetReconciliationAttentionHost[] = []
+  const attentionRoutes: OpenClawFleetReconciliationAttentionRoute[] = []
+  const latestRun = listAuditLog(db, {
+    limit: 1,
+    target: 'openclaw-fleet:reconciliation',
+  })[0] ?? null
+
+  let driftedHosts = 0
+  let cleanupRequiredHosts = 0
+  let liveRoutes = 0
+  let staleRoutes = 0
+  let orphanedRoutes = 0
+  let conflictRoutes = 0
+  let garbageCollectableRoutes = 0
+
+  for (const host of hosts) {
+    liveRoutes += host.reconciliation.liveRoutes
+    staleRoutes += host.reconciliation.staleRoutes
+    orphanedRoutes += host.reconciliation.orphanedRoutes
+    conflictRoutes += host.reconciliation.conflictRoutes
+    garbageCollectableRoutes += host.reconciliation.garbageCollectableRoutes
+
+    if (host.reconciliation.state !== 'steady') {
+      driftedHosts += 1
+      if (host.reconciliation.state === 'cleanup_required') {
+        cleanupRequiredHosts += 1
+      }
+      attentionHosts.push({
+        hostId: host.id,
+        hostLabel: host.label,
+        workspaceSlug: host.workspaceSlug,
+        healthStatus: host.healthStatus,
+        state: host.reconciliation.state,
+        deliverableRoutes: host.reconciliation.deliverableRoutes,
+        staleRoutes: host.reconciliation.staleRoutes,
+        orphanedRoutes: host.reconciliation.orphanedRoutes,
+        conflictRoutes: host.reconciliation.conflictRoutes,
+        garbageCollectableRoutes: host.reconciliation.garbageCollectableRoutes,
+        reason: host.reconciliation.reason,
+        nextAction: host.reconciliation.nextAction,
+        href: buildOpenClawFleetHref(host.id),
+        workspaceHref: buildWorkspaceHref(host.workspaceSlug),
+      })
+    }
+
+    const routes = listOpenClawResolvedRoutesForHost(db, host.id)
+    for (const row of routes) {
+      const serialized = serializeRoute(db, row)
+      if (serialized.reconciliation.classification === 'live') {
+        continue
+      }
+      attentionRoutes.push({
+        routeId: serialized.id,
+        beamId: serialized.beamId,
+        hostId: serialized.hostId,
+        hostLabel: serialized.hostLabel,
+        workspaceSlug: serialized.workspaceSlug,
+        classification: serialized.reconciliation.classification,
+        desiredState: serialized.reconciliation.desiredState,
+        garbageCollectable: serialized.reconciliation.garbageCollectable,
+        routeSource: serialized.routeSource,
+        connectionMode: serialized.connectionMode,
+        reason: serialized.reconciliation.reason,
+        lastSeenAt: serialized.lastSeenAt,
+        endedAt: serialized.endedAt,
+        href: buildOpenClawFleetHref(serialized.hostId),
+        workspaceHref: serialized.workspace ? buildWorkspaceHref(serialized.workspace.slug) : buildWorkspaceHref(serialized.workspaceSlug),
+        traceHref: serialized.lastDelivery?.href ?? null,
+      })
+    }
+  }
+
+  attentionRoutes.sort((left, right) => {
+    const leftRank = left.garbageCollectable ? 0 : (left.classification === 'conflict' ? 1 : left.classification === 'stale' ? 2 : 3)
+    const rightRank = right.garbageCollectable ? 0 : (right.classification === 'conflict' ? 1 : right.classification === 'stale' ? 2 : 3)
+    if (leftRank !== rightRank) {
+      return leftRank - rightRank
+    }
+    return (Date.parse(right.lastSeenAt ?? '') || 0) - (Date.parse(left.lastSeenAt ?? '') || 0)
+  })
+
+  return {
+    summary: {
+      driftedHosts,
+      cleanupRequiredHosts,
+      liveRoutes,
+      staleRoutes,
+      orphanedRoutes,
+      conflictRoutes,
+      garbageCollectableRoutes,
+      lastRunAt: latestRun?.timestamp ?? null,
+    },
+    attentionHosts,
+    attentionRoutes: attentionRoutes.slice(0, 24),
+  }
+}
+
+function runOpenClawFleetReconciliation(
+  db: Database,
+  input?: {
+    hostId?: number | null
+    staleGraceMinutes?: number
+    orphanedGraceMinutes?: number
+  },
+) {
+  const staleGraceMinutes = Math.max(0, Math.trunc(input?.staleGraceMinutes ?? OPENCLAW_ROUTE_RECONCILIATION_STALE_GRACE_MINUTES))
+  const orphanedGraceMinutes = Math.max(0, Math.trunc(input?.orphanedGraceMinutes ?? OPENCLAW_ROUTE_RECONCILIATION_ORPHANED_GRACE_MINUTES))
+  refreshOpenClawHostHealth(db)
+  recalculateOpenClawRouteStates(db)
+
+  const targetHosts = input?.hostId
+    ? listOpenClawHosts(db).filter((host) => host.id === input.hostId)
+    : listOpenClawHosts(db)
+  const staleRouteIdsToEnd = new Set<number>()
+
+  for (const host of targetHosts) {
+    const routes = listOpenClawResolvedRoutesForHost(db, host.id)
+    for (const route of routes) {
+      const reconciliation = evaluateOpenClawRouteReconciliation(route, {
+        staleGraceMinutes,
+        orphanedGraceMinutes,
+      })
+      if (
+        reconciliation.garbageCollectable
+        && reconciliation.classification === 'stale'
+        && route.route_source === 'subagent-run'
+      ) {
+        staleRouteIdsToEnd.add(route.id)
+      }
+    }
+  }
+
+  const endedRoutes = markOpenClawRoutesEndedByIds(db, {
+    routeIds: [...staleRouteIdsToEnd],
+  })
+
+  refreshOpenClawHostHealth(db)
+  recalculateOpenClawRouteStates(db)
+
+  const orphanedRouteIdsToDelete = new Set<number>()
+  for (const host of targetHosts) {
+    const routes = listOpenClawResolvedRoutesForHost(db, host.id)
+    for (const route of routes) {
+      const reconciliation = evaluateOpenClawRouteReconciliation(route, {
+        staleGraceMinutes,
+        orphanedGraceMinutes,
+      })
+      if (reconciliation.garbageCollectable && reconciliation.classification === 'orphaned') {
+        orphanedRouteIdsToDelete.add(route.id)
+      }
+    }
+  }
+
+  const deleted = deleteOpenClawHostRoutesByIds(db, {
+    routeIds: [...orphanedRouteIdsToDelete],
+  })
+
+  refreshOpenClawHostHealth(db)
+  recalculateOpenClawRouteStates(db)
+
+  const serializedHosts = listOpenClawHosts(db)
+    .filter((host) => (input?.hostId ? host.id === input.hostId : true))
+    .map((host) => serializeHost(db, host))
+  const reconciliation = buildOpenClawFleetReconciliationSummary(db, serializedHosts)
+
+  return {
+    staleGraceMinutes,
+    orphanedGraceMinutes,
+    endedRouteIds: endedRoutes.map((route) => route.id),
+    deletedRouteIds: [...orphanedRouteIdsToDelete],
+    deletedCount: deleted.deletedCount,
+    hosts: serializedHosts,
+    reconciliation,
   }
 }
 
@@ -2012,14 +2390,14 @@ function buildOpenClawFleetRemediationSummary(
       })
     }
 
-    if (host.summary.stale > 0) {
+    if (host.reconciliation.garbageCollectableRoutes > 0) {
       suggested.push({
         id: `end-stale-routes:${host.id}`,
         kind: 'end_stale_routes',
         severity: host.healthStatus === 'stale' ? 'critical' : 'warning',
-        title: `${hostTitleForDigest(host)} still advertises stale routes`,
-        detail: `${host.summary.stale} stale route(s) remain visible and should be ended before they linger as deliverable history.`,
-        nextAction: 'End only the stale routes on this host and wait for the next inventory sync to republish live routes.',
+        title: `${hostTitleForDigest(host)} needs reconciliation cleanup`,
+        detail: `${host.reconciliation.garbageCollectableRoutes} stale or orphaned route(s) are now safe to garbage collect.`,
+        nextAction: 'Run reconciliation cleanup for this host and let the next inventory sync republish only the desired live routes.',
         safe: true,
         requiresConfirmation: false,
         hostId: host.id,
@@ -3278,6 +3656,7 @@ export function openClawAdminRouter(db: Database) {
     const routeHealth = buildOpenClawFleetRouteHealthSummary(db, hosts)
     const templates = buildOpenClawFleetTemplateSummary(db, hosts)
     const remediation = buildOpenClawFleetRemediationSummary(db, hosts, rollout, routeHealth, templates)
+    const reconciliation = buildOpenClawFleetReconciliationSummary(db, hosts)
     const summary = hosts.reduce((acc, host) => {
       acc.totalHosts += 1
       if (host.status === 'pending') acc.pendingHosts += 1
@@ -3332,6 +3711,10 @@ export function openClawAdminRouter(db: Database) {
         templateDriftedWorkspaces: templates.summary.driftedWorkspaces,
         suggestedRemediations: remediation.summary.suggested,
         criticalRemediations: remediation.summary.critical,
+        driftedHosts: reconciliation.summary.driftedHosts,
+        reconciliationCleanupRequiredHosts: reconciliation.summary.cleanupRequiredHosts,
+        orphanedRoutes: reconciliation.summary.orphanedRoutes,
+        garbageCollectableRoutes: reconciliation.summary.garbageCollectableRoutes,
       },
       hosts,
       conflicts,
@@ -3339,11 +3722,26 @@ export function openClawAdminRouter(db: Database) {
       rollout,
       credentialPolicy,
       routeHealth,
+      reconciliation,
       templates,
       remediation,
       environments,
       hostGroups,
     })
+  })
+
+  router.get('/fleet/reconciliation', (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'viewer')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    refreshOpenClawHostHealth(db)
+    recalculateOpenClawRouteStates(db)
+    const hosts = listOpenClawHosts(db).map((host) => serializeHost(db, host))
+
+    c.header('Cache-Control', 'no-store')
+    return c.json(buildOpenClawFleetReconciliationSummary(db, hosts))
   })
 
   router.get('/fleet/policy-packs', (c) => {
@@ -3619,9 +4017,8 @@ export function openClawAdminRouter(db: Database) {
         return c.json({ error: 'Host not found', errorCode: 'NOT_FOUND' }, 404)
       }
 
-      const routes = markOpenClawHostRoutesEnded(db, {
+      const result = runOpenClawFleetReconciliation(db, {
         hostId,
-        runtimeSessionState: 'stale',
       })
 
       logAuditEvent(db, {
@@ -3632,7 +4029,9 @@ export function openClawAdminRouter(db: Database) {
           role: auth.session.role,
           kind: kindRaw,
           note: note ?? null,
-          routeCount: routes.filter((route) => route.runtime_session_state === 'ended').length,
+          endedRouteIds: result.endedRouteIds,
+          deletedRouteIds: result.deletedRouteIds,
+          deletedCount: result.deletedCount,
         },
       })
 
@@ -3642,6 +4041,7 @@ export function openClawAdminRouter(db: Database) {
         kind: kindRaw,
         host: serializeHost(db, getOpenClawHostById(db, hostId) as OpenClawHostRow),
         routes: listOpenClawResolvedRoutesForHost(db, hostId).map((route) => serializeRoute(db, route)),
+        reconciliation: result.reconciliation,
       })
     }
 
@@ -3745,6 +4145,61 @@ export function openClawAdminRouter(db: Database) {
       policy: applied.policy,
       updatedAt: applied.updatedAt,
       updatedBy: applied.updatedBy,
+    })
+  })
+
+  router.post('/fleet/reconciliation/run', async (c) => {
+    const auth = requireAdminRole(db, c.req.raw, 'admin')
+    if (auth instanceof Response) {
+      return auth
+    }
+
+    let body: Record<string, unknown> = {}
+    try {
+      body = await c.req.json() as Record<string, unknown>
+    } catch {
+      body = {}
+    }
+
+    const hostId = normalizePositiveInteger(body.hostId)
+    const staleGraceMinutes = normalizeBoundedInteger(body.staleGraceMinutes, 0, 24 * 60)
+      ?? OPENCLAW_ROUTE_RECONCILIATION_STALE_GRACE_MINUTES
+    const orphanedGraceMinutes = normalizeBoundedInteger(body.orphanedGraceMinutes, 0, 24 * 60)
+      ?? OPENCLAW_ROUTE_RECONCILIATION_ORPHANED_GRACE_MINUTES
+    const note = normalizeOptionalString(body.note)
+    const result = runOpenClawFleetReconciliation(db, {
+      hostId,
+      staleGraceMinutes,
+      orphanedGraceMinutes,
+    })
+
+    logAuditEvent(db, {
+      action: 'admin.openclaw_fleet_reconciliation.run',
+      actor: auth.session.email,
+      target: 'openclaw-fleet:reconciliation',
+      details: {
+        role: auth.session.role,
+        hostId: hostId ?? null,
+        staleGraceMinutes,
+        orphanedGraceMinutes,
+        endedRouteIds: result.endedRouteIds,
+        deletedRouteIds: result.deletedRouteIds,
+        deletedCount: result.deletedCount,
+        note: note ?? null,
+      },
+    })
+
+    c.header('Cache-Control', 'no-store')
+    return c.json({
+      ok: true,
+      hostId: hostId ?? null,
+      staleGraceMinutes,
+      orphanedGraceMinutes,
+      endedRouteIds: result.endedRouteIds,
+      deletedRouteIds: result.deletedRouteIds,
+      deletedCount: result.deletedCount,
+      reconciliation: result.reconciliation,
+      hosts: result.hosts,
     })
   })
 

--- a/packages/directory/src/types.ts
+++ b/packages/directory/src/types.ts
@@ -352,6 +352,7 @@ export interface OpenClawResolvedRouteRow extends OpenClawHostRouteRow {
   host_credential_state: OpenClawHostCredentialState
   host_workspace_slug: string | null
   host_last_heartbeat_at: string | null
+  host_last_inventory_at: string | null
 }
 
 export interface OpenClawHostHeartbeatRow {

--- a/packages/echo-agent/package.json
+++ b/packages/echo-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/echo-agent",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Standalone Beam Echo Agent for local testing and onboarding",
   "type": "module",
   "main": "./dist/index.js",
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "beam-protocol-sdk": "^1.3.0"
+    "beam-protocol-sdk": "^1.5.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/message-bus/package.json
+++ b/packages/message-bus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beam-protocol/message-bus",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Persistent message bus for Beam Protocol — reliable agent-to-agent communication with retry, audit trail, and guaranteed delivery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk-typescript/package.json
+++ b/packages/sdk-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beam-protocol-sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "TypeScript SDK for verified B2B handoffs over Beam",
   "type": "module",
   "main": "./dist/index.js",

--- a/reports/1.5.0-buyer-dry-run.md
+++ b/reports/1.5.0-buyer-dry-run.md
@@ -1,0 +1,44 @@
+# Beam 1.5.0 Buyer Dry Run
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T19:32:51.612Z`
+- surface: OpenClaw fleet docs and operator-facing control-plane copy
+
+## Result
+
+`PASS`
+
+## Path
+
+1. The docs home still points operators to Beam Workspaces as the identity and control-plane layer.
+2. The Beam Workspaces guide now explains the OpenClaw fleet model, host approval, credential rotation and recovery, Linux install parity, and fleet digest commands in plain operator language.
+3. The dashboard surface vocabulary matches the guide: host approval, host detail, duplicate identity conflicts, host badges, partner channels, timeline, digest, route-owner actions, reconciliation, and thread composer.
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "checks": {
+    "docsHome": true,
+    "workspaceGuide": true,
+    "dashboardSurface": true,
+    "openClawFleetSurface": true,
+    "manualHostApproval": true,
+    "credentialLifecycle": true,
+    "linuxInstallPath": true,
+    "hostStatusCommands": true,
+    "reconciliationGuide": true,
+    "partnerChannels": true,
+    "timeline": true,
+    "digest": true,
+    "threadComposer": true,
+    "hostBadges": true,
+    "reconciliationSurface": true,
+    "routeOwnerActions": true
+  }
+}
+```

--- a/reports/1.5.0-fleet-drill.md
+++ b/reports/1.5.0-fleet-drill.md
@@ -1,0 +1,134 @@
+# Beam 1.5.0 Fleet Drill
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T19:32:52.248Z`
+- environment: local three-host OpenClaw fleet harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Bootstrap three approved OpenClaw hosts into one central Beam directory.
+2. Connect one live Beam route per host over WebSocket.
+3. Send a real ring of host-to-host messages so every host sends and receives at least once.
+4. Mark one host stale, run fleet reconciliation, and confirm stale route history is cleaned before the host rejoins the fleet.
+5. Inject a duplicate Beam identity conflict and confirm delivery is blocked until one explicit route owner is preferred and the duplicate route is disabled.
+6. Rotate one host credential and confirm the host returns with the rotated secret.
+7. Revoke a host, confirm delivery is blocked, then recover the host and confirm delivery resumes on the same Beam trace model.
+
+## Verification
+
+- Approved hosts visible: `3`
+- Ring messages delivered: `3`
+- Canary hosts after rollout update: `1`
+- Garbage-collectable routes before reconciliation: `1`
+- Deleted routes during reconciliation: `1`
+- Duplicate conflict count: `1`
+- Duplicate conflicts after owner resolution: `0`
+- Revoked hosts after remediation: `1`
+- Conflict response status: `FORBIDDEN`
+- Revoked response status: `FORBIDDEN`
+- Recovery credential state: `recovery_pending`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "workspace": "openclaw-local",
+  "hosts": [
+    {
+      "id": 1,
+      "label": "OpenClaw Host Alpha",
+      "hostname": "alpha.local"
+    },
+    {
+      "id": 2,
+      "label": "OpenClaw Host Beta",
+      "hostname": "beta.local"
+    },
+    {
+      "id": 3,
+      "label": "OpenClaw Host Gamma",
+      "hostname": "gamma.local"
+    }
+  ],
+  "ring": [
+    {
+      "nonce": "94e68cde-0f2d-4d29-9fd0-c23ca843e15a",
+      "to": "beacon@openclaw.beam.directory",
+      "from": "atlas@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet alpha -> beta"
+    },
+    {
+      "nonce": "fc2f5940-0ab7-485f-911a-8073e21148cc",
+      "to": "cipher@openclaw.beam.directory",
+      "from": "beacon@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet beta -> gamma"
+    },
+    {
+      "nonce": "5974844f-de95-44cf-9f0c-cf0b6be2d349",
+      "to": "atlas@openclaw.beam.directory",
+      "from": "cipher@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "fleet gamma -> alpha"
+    }
+  ],
+  "rollout": {
+    "ring": "canary",
+    "desiredConnectorVersion": "1.5.0-test",
+    "canaryHosts": 1
+  },
+  "reconciliation": {
+    "driftedHosts": 1,
+    "garbageCollectableRoutes": 1,
+    "deletedCount": 1
+  },
+  "conflict": {
+    "duplicateIdentityConflicts": 1,
+    "response": {
+      "error": "Agent atlas@openclaw.beam.directory is claimed by multiple OpenClaw hosts",
+      "errorCode": "FORBIDDEN"
+    }
+  },
+  "resolved": {
+    "duplicateIdentityConflicts": 0,
+    "message": {
+      "nonce": "17728f54-5888-4db3-b9c1-b55f6d8e0fd2",
+      "to": "atlas@openclaw.beam.directory",
+      "from": "beacon@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "beta -> alpha after conflict resolution"
+    }
+  },
+  "rotated": {
+    "hostId": 2,
+    "credentialState": "rotation_pending"
+  },
+  "revoked": {
+    "revokedHosts": 1,
+    "response": {
+      "error": "Agent cipher@openclaw.beam.directory belongs to a revoked OpenClaw host",
+      "errorCode": "FORBIDDEN"
+    }
+  },
+  "recovered": {
+    "hostId": 3,
+    "credentialState": "recovery_pending",
+    "message": {
+      "nonce": "10ddc227-692b-412b-af67-9f63900f3999",
+      "to": "cipher@openclaw.beam.directory",
+      "from": "atlas@openclaw.beam.directory",
+      "traceStatus": "acked",
+      "deliveredMessage": "alpha -> gamma after recovery"
+    }
+  }
+}
+```

--- a/reports/1.5.0-operator-dry-run.md
+++ b/reports/1.5.0-operator-dry-run.md
@@ -1,0 +1,134 @@
+# Beam 1.5.0 Operator Dry Run
+
+## Context
+
+- run date: `2026-04-02`
+- generated at: `2026-04-02T19:32:52.192Z`
+- environment: local three-host OpenClaw fleet harness
+
+## Result
+
+`PASS`
+
+## Scenario
+
+1. Bootstrap three approved OpenClaw hosts into one central Beam control plane.
+2. Verify the fleet overview, selected host detail, and workspace host badges.
+3. Put one host into a canary rollout ring and another into maintenance mode, then resume it cleanly.
+4. Force reconciliation drift on a subagent route, run reconciliation, and confirm garbage collection removes the stale historical state.
+5. Force one stale host, rotate one host credential, and confirm the fleet digest surfaces both conditions with next actions.
+6. Introduce a duplicate Beam identity on a second host, then resolve it through explicit route-owner actions.
+7. Revoke and recover the affected host and confirm the fleet returns to an active, healthy state without rebuilding workspace bindings.
+
+## Verification
+
+- Approved active hosts: `3`
+- Live routes: `3`
+- Selected host identities: `1`
+- Canary hosts after rollout update: `1`
+- Maintenance-blocked hosts: `1`
+- Garbage-collectable routes before reconciliation: `1`
+- Deleted routes during reconciliation: `1`
+- Stale hosts before remediation: `1`
+- Pending credential actions in digest: `1`
+- Duplicate conflicts after injection: `1`
+- Duplicate conflicts after owner resolution: `0`
+- Revoked gamma status: `revoked`
+- Gamma route after recovery: `live`
+
+## Evidence
+
+```json
+{
+  "ok": true,
+  "date": "2026-04-02",
+  "workspace": "openclaw-local",
+  "summary": {
+    "totalHosts": 3,
+    "pendingHosts": 0,
+    "activeHosts": 3,
+    "revokedHosts": 0,
+    "staleHosts": 0,
+    "liveRoutes": 3,
+    "staleRoutes": 0,
+    "conflictRoutes": 0,
+    "endedRoutes": 0,
+    "failedReceipts": 0,
+    "routesMissingReceipts": 3,
+    "degradedHosts": 3,
+    "latencySloBreaches": 0,
+    "rotationDueHosts": 0,
+    "recoveryRunbooksOpen": 0,
+    "receiptCoverageRatio": 0,
+    "duplicateIdentityConflicts": 0,
+    "pendingCredentialActions": 0,
+    "actionItems": 3,
+    "criticalItems": 0,
+    "templateDriftedWorkspaces": 0,
+    "suggestedRemediations": 3,
+    "criticalRemediations": 0,
+    "driftedHosts": 0,
+    "reconciliationCleanupRequiredHosts": 0,
+    "orphanedRoutes": 0,
+    "garbageCollectableRoutes": 0
+  },
+  "selectedHost": {
+    "id": 2,
+    "label": "OpenClaw Host Beta",
+    "routeCount": 1,
+    "identityCount": 1,
+    "heartbeatCount": 1
+  },
+  "rollout": {
+    "hostId": 1,
+    "ring": "canary",
+    "desiredConnectorVersion": "1.5.0-test",
+    "canaryHosts": 1
+  },
+  "maintenance": {
+    "hostId": 1,
+    "state": "maintenance",
+    "blockedHosts": 1,
+    "resumedState": "serving"
+  },
+  "reconciliation": {
+    "driftedHosts": 1,
+    "garbageCollectableRoutes": 1,
+    "deletedCount": 1
+  },
+  "stale": {
+    "staleHosts": 1
+  },
+  "rotated": {
+    "hostId": 2,
+    "credentialState": "rotation_pending"
+  },
+  "digest": {
+    "actionItems": 5,
+    "criticalItems": 2,
+    "pendingCredentialActions": 1,
+    "duplicateIdentityConflicts": 1
+  },
+  "conflict": {
+    "total": 1,
+    "beamId": "atlas@openclaw.beam.directory",
+    "routeState": "conflict"
+  },
+  "resolved": {
+    "duplicateIdentityConflicts": 0,
+    "disabledRouteId": 5,
+    "ownerResolutionState": "disabled"
+  },
+  "revoked": {
+    "hostId": 3,
+    "status": "revoked",
+    "healthStatus": "revoked"
+  },
+  "recovered": {
+    "hostId": 3,
+    "status": "active",
+    "healthStatus": "healthy",
+    "credentialState": "ready"
+  }
+}
+```

--- a/reports/1.5.0-rc1-checklist.md
+++ b/reports/1.5.0-rc1-checklist.md
@@ -1,0 +1,51 @@
+# Beam 1.5.0 RC1 Checklist
+
+Status: `ready`
+
+Last updated: `2026-04-02`
+
+## Scope
+
+Beam `1.5.0` is the OpenClaw fleet autonomy release:
+
+- host maintenance mode, drain, and resume controls
+- connector version inventory, rollout rings, and canary visibility
+- fleet policy packs and workspace templates with drift detection
+- desired-state reconciliation and stale route garbage collection
+- recurring rollout and maintenance digests with persisted history
+- repo-visible buyer, operator, and fleet evidence before the final cut
+
+## Evidence
+
+- Buyer dry run: [1.5.0-buyer-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.5.0-buyer-dry-run.md)
+- Operator dry run: [1.5.0-operator-dry-run.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.5.0-operator-dry-run.md)
+- Fleet drill: [1.5.0-fleet-drill.md](/Users/tobik/Documents/BEAM/beam-protocol/reports/1.5.0-fleet-drill.md)
+
+## Gates
+
+- [x] Host maintenance, drain, and resume are executable from the fleet surface and block delivery with a clear reason.
+- [x] Connector version inventory, rollout rings, and canary visibility are surfaced in the fleet overview.
+- [x] Policy packs and workspace templates are visible, applicable, and drift-aware for fleet-backed workspaces.
+- [x] Desired-state reconciliation summarizes stale/orphaned/conflict state and garbage-collects stale subagent routes.
+- [x] Recurring rollout and maintenance digests persist schedules, runs, and delivery history.
+- [x] Buyer/operator/fleet evidence is committed under `reports/`.
+- [x] Monorepo build, tests, E2E, and docs build are green on the candidate.
+- [ ] Final release smoke proves `1.5.0` across API, public site, docs, npm, and fleet APIs.
+
+## Candidate Verification
+
+Verified locally on `2026-04-02`:
+
+- `npm run build`
+- `npm test`
+- `npm run test:e2e`
+- `npm -C docs run build`
+- `node scripts/workspace/buyer-dry-run.mjs --output reports/1.5.0-buyer-dry-run.md`
+- `node scripts/workspace/operator-dry-run.mjs --output reports/1.5.0-operator-dry-run.md`
+- `node scripts/workspace/fleet-smoke.mjs --output reports/1.5.0-fleet-drill.md`
+
+## Notes
+
+- Local digest delivery remains intentionally `EMAIL_DELIVERY_UNAVAILABLE` when SMTP or Resend is not configured. The schedule, persistence, and escalation loop are still exercised end to end.
+- Beam `1.5.0` stays on the existing protocol family. No protocol-family change is part of this release.
+- Update this checklist to `released` after the tagged release smoke passes.

--- a/reports/1.5.0-release-notes-draft.md
+++ b/reports/1.5.0-release-notes-draft.md
@@ -1,0 +1,53 @@
+# Beam 1.5.0 Release Notes
+
+Release status: `draft`
+
+## Summary
+
+Beam `1.5.0` makes the OpenClaw fleet layer feel less like an operator console and more like a controlled autonomy system. The theme is not a new protocol primitive. The theme is safer day-2 fleet work: maintenance windows, rollout visibility, template-driven policy, reconciliation, and recurring review loops that operators can trust.
+
+## Highlights
+
+### Maintenance and drain control
+
+- add explicit host maintenance, drain, and resume controls to the fleet surface
+- block new delivery to draining or maintenance hosts while keeping routing state and audit visibility intact
+- keep the reason, owner, and recovery path visible in both fleet and workspace context
+
+### Connector rollout visibility
+
+- promote connector version inventory into a first-class fleet concern
+- show rollout rings, desired connector version, canary hosts, and drift directly in the fleet view
+- make version lag visible without host-by-host inspection
+
+### Policy packs and templates
+
+- add reusable policy packs and workspace templates for fleet-backed identities
+- expose drift between template intent and live workspace state
+- give operators one place to apply or restore the expected policy posture
+
+### Reconciliation and garbage collection
+
+- add explicit reconciliation summaries for `live`, `stale`, `orphaned`, and `conflict` route state
+- surface garbage-collectable stale subagent routes and let operators reconcile them safely
+- make stale route drift part of the normal fleet loop instead of a hidden cleanup task
+
+### Recurring rollout and maintenance digests
+
+- extend recurring fleet review to maintenance state, rollout lag, reconciliation drift, and unresolved follow-up
+- persist run history and delivery history so the daily fleet loop is inspectable and repeatable
+
+### Evidence-backed autonomy release
+
+- commit fresh buyer, operator, and fleet drill evidence under `reports/`
+- gate the release on explicit autonomy proof instead of operator memory
+
+## Compatibility Note
+
+No protocol-family change in this release train. Beam `1.5.0` remains on `beam/1`.
+
+## Publish Status
+
+- GitHub release: `pending`
+- npm packages: `pending`
+- Live API release truth: `pending`

--- a/scripts/workspace/buyer-dry-run.mjs
+++ b/scripts/workspace/buyer-dry-run.mjs
@@ -28,6 +28,9 @@ async function main() {
   assertIncludes(workspaceGuide, 'rotate host credentials without reinstalling the whole host', 'host credential lifecycle guidance')
   assertIncludes(workspaceGuide, 'managed Linux install command', 'linux install guidance')
   assertIncludes(workspaceGuide, 'fleet digest', 'fleet digest guidance')
+  assertIncludes(workspaceGuide, 'Reconciliation and garbage collection', 'reconciliation section')
+  assertIncludes(workspaceGuide, 'Run fleet reconciliation', 'reconciliation action guidance')
+  assertIncludes(workspaceGuide, 'gc candidate', 'garbage collection guidance')
   assertIncludes(workspaceGuide, 'npm run workspace:openclaw-setup', 'openclaw setup command')
   assertIncludes(workspaceGuide, 'npm run workspace:openclaw-status', 'openclaw status command')
   assertIncludes(workspaceUi, 'Partner channels', 'workspace UI partner channels section')
@@ -41,6 +44,8 @@ async function main() {
   assertIncludes(fleetUi, 'Rotate credential', 'fleet credential rotation action')
   assertIncludes(fleetUi, 'Recover host', 'fleet credential recovery action')
   assertIncludes(fleetUi, 'Fleet operator digest', 'fleet digest surface')
+  assertIncludes(fleetUi, 'Reconciliation and garbage collection', 'fleet reconciliation surface')
+  assertIncludes(fleetUi, 'Run fleet reconciliation', 'fleet reconciliation action')
   assertIncludes(fleetUi, 'Disable route', 'fleet route disable action')
   assertIncludes(fleetUi, 'Reset owner', 'fleet route owner reset action')
 
@@ -56,11 +61,13 @@ async function main() {
       credentialLifecycle: true,
       linuxInstallPath: true,
       hostStatusCommands: true,
+      reconciliationGuide: true,
       partnerChannels: true,
       timeline: true,
       digest: true,
       threadComposer: true,
       hostBadges: true,
+      reconciliationSurface: true,
       routeOwnerActions: true,
     },
   }
@@ -81,7 +88,7 @@ async function main() {
 
 1. The docs home still points operators to Beam Workspaces as the identity and control-plane layer.
 2. The Beam Workspaces guide now explains the OpenClaw fleet model, host approval, credential rotation and recovery, Linux install parity, and fleet digest commands in plain operator language.
-3. The dashboard surface vocabulary matches the guide: host approval, host detail, duplicate identity conflicts, host badges, partner channels, timeline, digest, route-owner actions, and thread composer.
+3. The dashboard surface vocabulary matches the guide: host approval, host detail, duplicate identity conflicts, host badges, partner channels, timeline, digest, route-owner actions, reconciliation, and thread composer.
 
 ## Evidence
 

--- a/scripts/workspace/fleet-shared.mjs
+++ b/scripts/workspace/fleet-shared.mjs
@@ -337,6 +337,11 @@ export async function startOpenClawFleetHarness() {
         headers: { Authorization: `Bearer ${token}` },
       })
     },
+    async fetchFleetReconciliation() {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/reconciliation`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+    },
     async fetchFleetDigest(params = {}) {
       const query = new URLSearchParams()
       if (params.format) {
@@ -372,6 +377,13 @@ export async function startOpenClawFleetHarness() {
     },
     async deliverFleetDigest(input = {}) {
       return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/digest/deliver`, {
+        method: 'POST',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
+    async runFleetReconciliation(input = {}) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/fleet/reconciliation/run`, {
         method: 'POST',
         headers: createAdminHeaders(token),
         body: JSON.stringify(input),
@@ -433,6 +445,33 @@ export async function startOpenClawFleetHarness() {
         body: JSON.stringify({ reason }),
       })
     },
+    async enableMaintenance(hostKey, input = {}) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/hosts/${hosts[hostKey].id}/maintenance`, {
+        method: 'POST',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
+    async drainHost(hostKey, input = {}) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/hosts/${hosts[hostKey].id}/drain`, {
+        method: 'POST',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
+    async resumeHost(hostKey) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/hosts/${hosts[hostKey].id}/resume`, {
+        method: 'POST',
+        headers: createAdminHeaders(token),
+      })
+    },
+    async updateRollout(hostKey, input) {
+      return requestJson(`${harness.directoryUrl}/admin/openclaw/hosts/${hosts[hostKey].id}/rollout`, {
+        method: 'PATCH',
+        headers: createAdminHeaders(token),
+        body: JSON.stringify(input),
+      })
+    },
     async syncHost(hostKey, routes = null, details = {}) {
       const host = hosts[hostKey]
       const inventoryRoutes = routes ?? [buildRoute(host, host.agent, host.routeSource)]
@@ -476,7 +515,7 @@ export async function startOpenClawFleetHarness() {
         body: JSON.stringify({ note }),
       })
     },
-    async markHostStale(hostKey, minutesAgo = 10) {
+    async markHostStale(hostKey, minutesAgo = 10, options = {}) {
       const dbApi = await loadDirectoryDbModule()
       const db = dbApi.createDatabase(harness.directoryDbPath)
       try {
@@ -486,6 +525,13 @@ export async function startOpenClawFleetHarness() {
           SET last_heartbeat_at = ?, health_status = 'watch'
           WHERE id = ?
         `).run(staleAt, hosts[hostKey].id)
+        if (options.ageRoutes) {
+          db.prepare(`
+            UPDATE openclaw_host_routes
+            SET last_seen_at = ?, updated_at = ?
+            WHERE host_id = ? AND reported_state != 'ended'
+          `).run(staleAt, staleAt, hosts[hostKey].id)
+        }
         return staleAt
       } finally {
         db.close()

--- a/scripts/workspace/fleet-smoke.mjs
+++ b/scripts/workspace/fleet-smoke.mjs
@@ -90,6 +90,33 @@ async function main() {
     ring.push(await sendAndExpect(fleet, fleet.agents.beta, fleet.agents.gamma, 'fleet beta -> gamma', fleet.clients.gamma))
     ring.push(await sendAndExpect(fleet, fleet.agents.gamma, fleet.agents.alpha, 'fleet gamma -> alpha', fleet.clients.alpha))
 
+    const rollout = await fleet.updateRollout('alpha', {
+      ring: 'canary',
+      desiredConnectorVersion: '1.5.0-test',
+      notes: 'Fleet drill canary visibility',
+    })
+    const rolloutOverview = await fleet.fetchFleetOverview()
+    if (rollout.host.rollout.ring !== 'canary' || rolloutOverview.rollout.summary.canaryHosts < 1) {
+      throw new Error('Expected the fleet drill to surface at least one canary rollout host.')
+    }
+
+    await fleet.markHostStale('gamma', 45, { ageRoutes: true })
+    const reconciliationBefore = await fleet.fetchFleetReconciliation()
+    if (reconciliationBefore.summary.garbageCollectableRoutes < 1) {
+      throw new Error('Expected the fleet drill to surface at least one garbage-collectable route.')
+    }
+    const reconciliationRun = await fleet.runFleetReconciliation({
+      hostId: fleet.hosts.gamma.id,
+      staleGraceMinutes: 0,
+      orphanedGraceMinutes: 0,
+      note: 'Fleet drill reconciliation',
+    })
+    if (reconciliationRun.deletedCount < 1) {
+      throw new Error('Expected the fleet drill reconciliation to delete at least one stale route.')
+    }
+    await fleet.syncHost('gamma', null, { stage: 'fleet-reconciliation-remediation' })
+    await fleet.reconnectHostClient('gamma')
+
     await fleet.createConflict()
     const conflictOverview = await fleet.fetchFleetOverview()
     if (conflictOverview.summary.duplicateIdentityConflicts !== 1) {
@@ -174,6 +201,16 @@ async function main() {
         hostname: host.hostname,
       })),
       ring,
+      rollout: {
+        ring: rollout.host.rollout.ring,
+        desiredConnectorVersion: rollout.host.rollout.desiredConnectorVersion,
+        canaryHosts: rolloutOverview.rollout.summary.canaryHosts,
+      },
+      reconciliation: {
+        driftedHosts: reconciliationBefore.summary.driftedHosts,
+        garbageCollectableRoutes: reconciliationBefore.summary.garbageCollectableRoutes,
+        deletedCount: reconciliationRun.deletedCount,
+      },
       conflict: {
         duplicateIdentityConflicts: conflictOverview.summary.duplicateIdentityConflicts,
         response: conflictFailure,
@@ -214,14 +251,18 @@ async function main() {
 1. Bootstrap three approved OpenClaw hosts into one central Beam directory.
 2. Connect one live Beam route per host over WebSocket.
 3. Send a real ring of host-to-host messages so every host sends and receives at least once.
-4. Inject a duplicate Beam identity conflict and confirm delivery is blocked until one explicit route owner is preferred and the duplicate route is disabled.
-5. Rotate one host credential and confirm the host returns with the rotated secret.
-6. Revoke a host, confirm delivery is blocked, then recover the host and confirm delivery resumes on the same Beam trace model.
+4. Mark one host stale, run fleet reconciliation, and confirm stale route history is cleaned before the host rejoins the fleet.
+5. Inject a duplicate Beam identity conflict and confirm delivery is blocked until one explicit route owner is preferred and the duplicate route is disabled.
+6. Rotate one host credential and confirm the host returns with the rotated secret.
+7. Revoke a host, confirm delivery is blocked, then recover the host and confirm delivery resumes on the same Beam trace model.
 
 ## Verification
 
 - Approved hosts visible: \`${Object.keys(fleet.hosts).length}\`
 - Ring messages delivered: \`${ring.length}\`
+- Canary hosts after rollout update: \`${rolloutOverview.rollout.summary.canaryHosts}\`
+- Garbage-collectable routes before reconciliation: \`${reconciliationBefore.summary.garbageCollectableRoutes}\`
+- Deleted routes during reconciliation: \`${reconciliationRun.deletedCount}\`
 - Duplicate conflict count: \`${conflictOverview.summary.duplicateIdentityConflicts}\`
 - Duplicate conflicts after owner resolution: \`${resolvedOverview.summary.duplicateIdentityConflicts}\`
 - Revoked hosts after remediation: \`${postRevokeOverview.summary.revokedHosts}\`

--- a/scripts/workspace/operator-dry-run.mjs
+++ b/scripts/workspace/operator-dry-run.mjs
@@ -25,6 +25,53 @@ async function main() {
       throw new Error('Expected all workspace fleet bindings to expose a healthy host badge and live runtime session state.')
     }
 
+    const rolloutUpdate = await fleet.updateRollout('alpha', {
+      ring: 'canary',
+      desiredConnectorVersion: '1.5.0-test',
+      notes: 'Operator dry run canary ring',
+    })
+    if (rolloutUpdate.host.rollout.ring !== 'canary') {
+      throw new Error(`Expected alpha rollout ring canary, received ${rolloutUpdate.host.rollout.ring}`)
+    }
+    const rolloutOverview = await fleet.fetchFleetOverview()
+    if (rolloutOverview.rollout.summary.canaryHosts < 1) {
+      throw new Error('Expected at least one canary host after rollout update.')
+    }
+
+    const maintenanceUpdate = await fleet.enableMaintenance('alpha', {
+      owner: 'ops@example.com',
+      reason: 'maintenance drill',
+    })
+    if (maintenanceUpdate.host.maintenance.state !== 'maintenance') {
+      throw new Error(`Expected alpha host to enter maintenance, received ${maintenanceUpdate.host.maintenance.state}`)
+    }
+    const maintenanceOverview = await fleet.fetchFleetOverview()
+    if (maintenanceOverview.maintenance.counts.blocked < 1) {
+      throw new Error('Expected maintenance mode to block at least one host in the fleet overview.')
+    }
+    await fleet.resumeHost('alpha')
+    const resumedAlpha = await fleet.fetchHost(fleet.hosts.alpha.id)
+    if (resumedAlpha.host.maintenance.state !== 'serving') {
+      throw new Error(`Expected alpha host to resume serving, received ${resumedAlpha.host.maintenance.state}`)
+    }
+
+    await fleet.markHostStale('gamma', 45, { ageRoutes: true })
+    const reconciliationBefore = await fleet.fetchFleetReconciliation()
+    if (reconciliationBefore.summary.driftedHosts < 1 || reconciliationBefore.summary.garbageCollectableRoutes < 1) {
+      throw new Error('Expected reconciliation to surface at least one drifted host and garbage-collectable route.')
+    }
+    const reconciliationRun = await fleet.runFleetReconciliation({
+      hostId: fleet.hosts.gamma.id,
+      staleGraceMinutes: 0,
+      orphanedGraceMinutes: 0,
+      note: 'Operator dry run reconciliation',
+    })
+    if (reconciliationRun.deletedCount < 1) {
+      throw new Error('Expected reconciliation to delete at least one garbage-collectable route.')
+    }
+    await fleet.syncHost('gamma', null, { stage: 'reconciliation-remediation' })
+    await fleet.reconnectHostClient('gamma')
+
     const betaHost = await fleet.fetchHost(fleet.hosts.beta.id)
     if (betaHost.host.status !== 'active' || betaHost.host.healthStatus !== 'healthy') {
       throw new Error('Expected the selected fleet host to be active and healthy.')
@@ -130,6 +177,23 @@ async function main() {
         identityCount: betaHost.identities.length,
         heartbeatCount: betaHost.heartbeats.length,
       },
+      rollout: {
+        hostId: rolloutUpdate.host.id,
+        ring: rolloutUpdate.host.rollout.ring,
+        desiredConnectorVersion: rolloutUpdate.host.rollout.desiredConnectorVersion,
+        canaryHosts: rolloutOverview.rollout.summary.canaryHosts,
+      },
+      maintenance: {
+        hostId: maintenanceUpdate.host.id,
+        state: maintenanceUpdate.host.maintenance.state,
+        blockedHosts: maintenanceOverview.maintenance.counts.blocked,
+        resumedState: resumedAlpha.host.maintenance.state,
+      },
+      reconciliation: {
+        driftedHosts: reconciliationBefore.summary.driftedHosts,
+        garbageCollectableRoutes: reconciliationBefore.summary.garbageCollectableRoutes,
+        deletedCount: reconciliationRun.deletedCount,
+      },
       stale: {
         staleHosts: staleOverview.summary.staleHosts,
       },
@@ -182,15 +246,21 @@ async function main() {
 
 1. Bootstrap three approved OpenClaw hosts into one central Beam control plane.
 2. Verify the fleet overview, selected host detail, and workspace host badges.
-3. Force one stale host, rotate one host credential, and confirm the fleet digest surfaces both conditions with next actions.
-4. Introduce a duplicate Beam identity on a second host, then resolve it through explicit route-owner actions.
-5. Revoke and recover the affected host and confirm the fleet returns to an active, healthy state without rebuilding workspace bindings.
+3. Put one host into a canary rollout ring and another into maintenance mode, then resume it cleanly.
+4. Force reconciliation drift on a subagent route, run reconciliation, and confirm garbage collection removes the stale historical state.
+5. Force one stale host, rotate one host credential, and confirm the fleet digest surfaces both conditions with next actions.
+6. Introduce a duplicate Beam identity on a second host, then resolve it through explicit route-owner actions.
+7. Revoke and recover the affected host and confirm the fleet returns to an active, healthy state without rebuilding workspace bindings.
 
 ## Verification
 
 - Approved active hosts: \`${overview.summary.activeHosts}\`
 - Live routes: \`${overview.summary.liveRoutes}\`
 - Selected host identities: \`${betaHost.identities.length}\`
+- Canary hosts after rollout update: \`${rolloutOverview.rollout.summary.canaryHosts}\`
+- Maintenance-blocked hosts: \`${maintenanceOverview.maintenance.counts.blocked}\`
+- Garbage-collectable routes before reconciliation: \`${reconciliationBefore.summary.garbageCollectableRoutes}\`
+- Deleted routes during reconciliation: \`${reconciliationRun.deletedCount}\`
 - Stale hosts before remediation: \`${staleOverview.summary.staleHosts}\`
 - Pending credential actions in digest: \`${digest.summary.pendingCredentialActions}\`
 - Duplicate conflicts after injection: \`${conflictOverview.summary.duplicateIdentityConflicts}\`


### PR DESCRIPTION
## Summary\n- add desired-state reconciliation and stale route garbage collection for OpenClaw fleet routes\n- extend the fleet dashboard and dry-run harness with reconciliation visibility and cleanup proof\n- bump the repo to 1.5.0 and add buyer/operator/fleet evidence plus RC/release notes\n\n## Testing\n- npm run build\n- npm test\n- npm run test:e2e\n- npm -C docs run build\n- node scripts/workspace/buyer-dry-run.mjs --output reports/1.5.0-buyer-dry-run.md\n- node scripts/workspace/operator-dry-run.mjs --output reports/1.5.0-operator-dry-run.md\n- node scripts/workspace/fleet-smoke.mjs --output reports/1.5.0-fleet-drill.md